### PR TITLE
Feature/remove config from global state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: python
 python:
     - "3.5"
     - "3.6"
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements.txt pytest-mock"
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "3.5"
     - "3.6"
 install: "pip install -r requirements.txt pytest-mock"
 script: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,18 @@
 import os
-from vivarium import config
 
-# Remove user overrides but keep custom cache locations if any
-config.reset_layer('override', preserve_keys=['input_data.intermediary_data_cache_path', 'input_data.auxiliary_data_folder'])
-config.simulation_parameters.set_with_metadata('year_start', 1990, layer='override', source=os.path.realpath(__file__))
-config.simulation_parameters.set_with_metadata('year_end', 2010, layer='override', source=os.path.realpath(__file__))
-config.simulation_parameters.set_with_metadata('time_step', 30.5, layer='override', source=os.path.realpath(__file__))
-config.simulation_parameters.set_with_metadata('initial_age', '', layer='override', source=os.path.realpath(__file__))
+import pytest
+
+from vivarium.framework.engine import build_simulation_configuration
+
+
+@pytest.fixture(scope='module')
+def base_config():
+    config = build_simulation_configuration({})
+    metadata = {'layer': 'override', 'source': os.path.realpath(__file__)}
+    config.reset_layer('override', preserve_keys=['input_data.intermediary_data_cache_path',
+                                                   'input_data.auxiliary_data_folder'])
+    config.simulation_parameters.set_with_metadata('year_start', 1990, **metadata)
+    config.simulation_parameters.set_with_metadata('year_end', 2010, **metadata)
+    config.simulation_parameters.set_with_metadata('time_step', 30.5, **metadata)
+    config.simulation_parameters.set_with_metadata('initial_age', '', **metadata)
+    return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,5 +14,4 @@ def base_config():
     config.simulation_parameters.set_with_metadata('year_start', 1990, **metadata)
     config.simulation_parameters.set_with_metadata('year_end', 2010, **metadata)
     config.simulation_parameters.set_with_metadata('time_step', 30.5, **metadata)
-    config.simulation_parameters.set_with_metadata('initial_age', '', **metadata)
     return config

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import pandas as pd
 
-from vivarium.test_util import build_table, setup_simulation, generate_test_population
+from vivarium.test_util import build_table, setup_simulation, TestPopulation
 
 
 @pytest.fixture(scope='module')
@@ -25,7 +25,7 @@ def test_interpolated_tables(config):
     del one_d_age['year']
     one_d_age = one_d_age.drop_duplicates()
 
-    simulation = setup_simulation([generate_test_population], 10000)
+    simulation = setup_simulation([TestPopulation()], 10000, input_config=config)
     manager = simulation.tables
     years = manager.build_table(years)
     ages = manager.build_table(ages)
@@ -64,7 +64,7 @@ def test_interpolated_tables_without_uniterpolated_columns(config):
     del years['sex']
     years = years.drop_duplicates()
 
-    simulation = setup_simulation([generate_test_population], 10000)
+    simulation = setup_simulation([TestPopulation()], 10000, input_config=config)
     manager = simulation.tables
     years = manager.build_table(years, key_columns=(), parameter_columns=('year', 'age',))
 
@@ -91,7 +91,7 @@ def test_interpolated_tables__exact_values_at_input_points(config):
     years = build_table(lambda age, sex, year: year, year_start, year_end)
     input_years = years.year.unique()
 
-    simulation = setup_simulation([generate_test_population], 10000)
+    simulation = setup_simulation([TestPopulation()], 10000, input_config=config)
     manager = simulation.tables
     years = manager.build_table(years)
 

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -8,6 +8,7 @@ from vivarium.framework.randomness import choice
 
 from vivarium.framework.state_machine import Machine, State, Transition
 
+
 def _population_fixture(column, initial_value):
     @listens_for('initialize_simulants')
     @uses_columns([column])
@@ -15,12 +16,14 @@ def _population_fixture(column, initial_value):
         event.population_view.update(pd.Series(initial_value, index=event.index))
     return inner
 
+
 def _even_population_fixture(column, values):
     @listens_for('initialize_simulants')
     @uses_columns([column])
     def inner(event):
         event.population_view.update(choice('start', event.index, values))
     return inner
+
 
 def test_transition():
     done_state = State('done')

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -28,10 +28,8 @@ def _even_population_fixture(column, values):
 def test_transition():
     done_state = State('done')
     start_state = State('start')
-    done_transition = Transition(done_state, lambda agents: np.full(len(agents), 1.0))
-    start_state.transition_set.append(done_transition)
-    machine = Machine('state')
-    machine.states.extend([start_state, done_state])
+    start_state.add_transition(done_state)
+    machine = Machine('state', states=[start_state, done_state])
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')])
     event_time = simulation.current_time + simulation.step_size
@@ -43,11 +41,9 @@ def test_choice():
     a_state = State('a')
     b_state = State('b')
     start_state = State('start')
-    a_transition = Transition(a_state, lambda agents: np.full(len(agents), 0.5))
-    b_transition = Transition(b_state, lambda agents: np.full(len(agents), 0.5))
-    start_state.transition_set.extend((a_transition, b_transition))
-    machine = Machine('state')
-    machine.states.extend([start_state, a_state, b_state])
+    start_state.add_transition(a_state, probability_func=lambda agents: np.full(len(agents), 0.5))
+    start_state.add_transition(b_state, probability_func=lambda agents: np.full(len(agents), 0.5))
+    machine = Machine('state', states=[start_state, a_state, b_state])
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], population_size=10000)
     event_time = simulation.current_time + simulation.step_size
@@ -75,8 +71,8 @@ def test_no_null_transition():
     a_state = State('a')
     b_state = State('b')
     start_state = State('start')
-    a_transition = Transition(a_state)
-    b_transition = Transition(b_state)
+    a_transition = Transition(start_state, a_state)
+    b_transition = Transition(start_state, b_state)
     start_state.transition_set.allow_null_transition = False
     start_state.transition_set.extend((a_transition, b_transition))
     machine = Machine('state')
@@ -97,7 +93,7 @@ def test_side_effects():
             population_view.update(pop['count'] + 1)
     done_state = DoneState('done')
     start_state = State('start')
-    done_transition = Transition(done_state, lambda agents: np.full(len(agents), 1.0))
+    done_transition = Transition(start_state, done_state, lambda agents: np.full(len(agents), 1.0))
     start_state.transition_set.append(done_transition)
     done_state.transition_set.append(done_transition)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,6 @@ envlist = py36
 xfail_strict = true
 [testenv]
 deps=pytest
+     pytest-mock
      -rrequirements.txt
 commands=py.test

--- a/vivarium/__init__.py
+++ b/vivarium/__init__.py
@@ -11,6 +11,4 @@ __all__ = ['config', 'VivariumError']
 class VivariumError(Exception):
     pass
 
-config = ConfigTree(layers=['base', 'component_configs', 'model_override', 'override'])
-if os.path.exists(os.path.expanduser('~/vivarium.yaml')):
-    config.load(os.path.expanduser('~/vivarium.yaml'), layer='override', source=os.path.expanduser('~/vivarium.yaml'))
+

--- a/vivarium/config_tree.py
+++ b/vivarium/config_tree.py
@@ -23,6 +23,7 @@ For example:
 >>> config.section_b.item1
 'value7'
 """
+from typing import Mapping, Union
 import yaml
 
 
@@ -307,17 +308,17 @@ class ConfigTree:
             child = self._children[name]
             child.set_value(value, layer, source)
 
-    def update(self, data, layer=None, source=None):
+    def update(self, data: Union[Mapping, str, bytes], layer: str=None, source: str=None):
         """Adds additional data into the ConfigTree.
 
 
         Parameters
         ----------
-        data : dict or None
+        data :
             source data
-        layer : str
+        layer :
             layer to load data into. If none is supplied the outermost one is used
-        source : str
+        source :
             Source to attribute the values to
 
         See Also

--- a/vivarium/config_tree.py
+++ b/vivarium/config_tree.py
@@ -200,7 +200,7 @@ class ConfigTree:
         """
         Parameters
         ----------
-        data : dict
+        data : dict, str, or ConfigTree, optional
             A dictionary containing initial values
         layers : list
             A list of layer names. The order in which layers defined determines
@@ -214,7 +214,7 @@ class ConfigTree:
         self.__dict__['_frozen'] = False
 
         if data:
-            self.read_dict(data, layer=self._layers[0], source='initial data')
+            self.update(data, layer=self._layers[0], source='initial data')
 
     def freeze(self):
         """Causes the ConfigTree to become read only.
@@ -243,6 +243,14 @@ class ConfigTree:
     def __getitem__(self, name):
         """Get a configuration value from the outermost layer in which it appears."""
         return self.get_from_layer(name)
+
+    def __delattr__(self, name):
+        if name in self._children:
+            del self._children[name]
+
+    def __delitem__(self, name):
+        if name in self._children:
+            del self._children[name]
 
     def __contains__(self, name):
         """Test if a configuration key exists in any layer."""
@@ -329,6 +337,7 @@ class ConfigTree:
         if isinstance(data, dict):
             self.read_dict(data, layer, source)
         elif isinstance(data, ConfigTree):
+            # TODO: set this to parse the other config tree including layer and source info.  Maybe.
             self.read_dict(data.to_dict(), layer, source)
         elif isinstance(data, str):
             if data.endswith('.yaml'):

--- a/vivarium/config_tree.py
+++ b/vivarium/config_tree.py
@@ -307,6 +307,34 @@ class ConfigTree:
             child = self._children[name]
             child.set_value(value, layer, source)
 
+    def update(self, data, layer=None, source=None):
+        """Adds additional data into the ConfigTree.
+
+
+        Parameters
+        ----------
+        data : dict or None
+            source data
+        layer : str
+            layer to load data into. If none is supplied the outermost one is used
+        source : str
+            Source to attribute the values to
+
+        See Also
+        --------
+        read_dict
+        """
+        if isinstance(data, dict):
+            self.read_dict(data, layer, source)
+        elif isinstance(data, str):
+            if data.endswith('.yaml'):
+                source = source if source else data
+                self.load(data, layer, source)
+            else:
+                self.loads(data, layer, source)
+        else:
+            raise ValueError(f"Update must be called with dictionary or string.  You passed in {type(data)}")
+
     def read_dict(self, data_dict, layer=None, source=None):
         """Load a dictionary into the ConfigTree. If the dict contains nested dicts
         then the values will be added recursively. See module docstring for example code.

--- a/vivarium/config_tree.py
+++ b/vivarium/config_tree.py
@@ -328,6 +328,8 @@ class ConfigTree:
         """
         if isinstance(data, dict):
             self.read_dict(data, layer, source)
+        elif isinstance(data, ConfigTree):
+            self.read_dict(data.to_dict(), layer, source)
         elif isinstance(data, str):
             if data.endswith('.yaml'):
                 source = source if source else data
@@ -337,7 +339,8 @@ class ConfigTree:
         elif data is None:
             pass
         else:
-            raise ValueError(f"Update must be called with dictionary or string.  You passed in {type(data)}")
+            raise ValueError(f"Update must be called with dictionary, string, or ConfigTree. "
+                             f"You passed in {type(data)}")
 
     def read_dict(self, data_dict, layer=None, source=None):
         """Load a dictionary into the ConfigTree. If the dict contains nested dicts

--- a/vivarium/config_tree.py
+++ b/vivarium/config_tree.py
@@ -295,6 +295,7 @@ class ConfigTree:
         TypeError
             if the ConfigTree is frozen
         """
+
         if self._frozen:
             raise TypeError('Frozen ConfigTree does not support assignment')
 
@@ -333,6 +334,8 @@ class ConfigTree:
                 self.load(data, layer, source)
             else:
                 self.loads(data, layer, source)
+        elif data is None:
+            pass
         else:
             raise ValueError(f"Update must be called with dictionary or string.  You passed in {type(data)}")
 

--- a/vivarium/framework/celery_tasks.py
+++ b/vivarium/framework/celery_tasks.py
@@ -14,8 +14,8 @@ app = Celery()
 
 @app.task(autoretry_for=(Exception,), max_retries=2)
 def worker(parameters, logging_directory):
-    input_draw = int(parameters['input_draw'])
-    model_draw = int(parameters['model_draw'])
+    input_draw = parameters['input_draw']
+    model_draw = parameters['model_draw']
     component_config = parameters['components']
     branch_config = parameters['config']
 
@@ -24,7 +24,7 @@ def worker(parameters, logging_directory):
     logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                         filename=os.path.join(logging_directory, str(worker_)+'.log'), level=logging.DEBUG)
     logging.info('Starting job: {}'.format((input_draw, model_draw, component_config, branch_config)))
-    
+
     try:
         from vivarium.framework.engine import build_simulation_configuration, run, setup_simulation
         from vivarium.framework.components import load_component_manager

--- a/vivarium/framework/celery_tasks.py
+++ b/vivarium/framework/celery_tasks.py
@@ -13,31 +13,34 @@ app = Celery()
 
 
 @app.task(autoretry_for=(Exception,), max_retries=2)
-def worker(input_draw_number, model_draw_number, component_config, branch_config, logging_directory):
-    np.random.seed([input_draw_number, model_draw_number])
+def worker(parameters, logging_directory):
+    input_draw = int(parameters['input_draw'])
+    model_draw = int(parameters['model_draw'])
+    component_config = parameters['components']
+    branch_config = parameters['config']
+
+    np.random.seed([input_draw, model_draw])
     worker_ = current_process().index
     logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                         filename=os.path.join(logging_directory, str(worker_)+'.log'), level=logging.DEBUG)
-    logging.info('Starting job: {}'.format((input_draw_number, model_draw_number, component_config, branch_config)))
-
-    run_configuration = component_config['configuration'].get('run_configuration', {})
-    run_configuration['run_id'] = str(worker_)+'_'+str(time())
-    if branch_config is not None:
-        run_configuration['run_key'] = dict(branch_config)
-        run_configuration['run_key']['input_draw'] = input_draw_number
-        run_configuration['run_key']['model_draw'] = model_draw_number
-    component_config['configuration']['run_configuration'] = run_configuration
-
+    logging.info('Starting job: {}'.format((input_draw, model_draw, component_config, branch_config)))
+    
     try:
-        from vivarium.framework.engine import configure, run
+        from vivarium.framework.engine import build_simulation_configuration, run, setup_simulation
         from vivarium.framework.components import load_component_manager
         from vivarium.framework.util import collapse_nested_dict
 
-        configure(input_draw_number=input_draw_number,
-                  model_draw_number=model_draw_number, simulation_config=branch_config)
-        component_manager = load_component_manager(component_config)
-        results = run(component_manager)
-        idx = pd.MultiIndex.from_tuples([(input_draw_number, model_draw_number)],
+        config = build_simulation_configuration(parameters)
+        config.run_configuration.run_id = str(worker_)+'_'+str(time())
+        if branch_config is not None:
+            config.run_configuration.update({'run_key': dict(branch_config)}, layer='override', source=str(worker_))
+            config.run_configuration.run_key.update({'input_draw': input_draw,
+                                                     'model_draw': model_draw})
+
+        component_manager = load_component_manager(config)
+        simulation = setup_simulation(component_manager, config)
+        results = run(simulation)
+        idx = pd.MultiIndex.from_tuples([(input_draw, model_draw)],
                                         names=['input_draw_number', 'model_draw_number'])
         results = pd.DataFrame(results, index=idx).to_json()
 
@@ -46,5 +49,5 @@ def worker(input_draw_number, model_draw_number, component_config, branch_config
         logging.exception('Unhandled exception in worker')
         raise
     finally:
-        logging.info('Exiting job: {}'.format((input_draw_number, model_draw_number, component_config, branch_config)))
+        logging.info('Exiting job: {}'.format((input_draw, model_draw, component_config, branch_config)))
 

--- a/vivarium/framework/components.py
+++ b/vivarium/framework/components.py
@@ -63,6 +63,20 @@ class ComponentManager:
 
     def __init__(self, config: ConfigTree, dataset_manager):
         self.tags = {}
+
+        if 'components' in config:
+            self.component_config = config.components
+            del config.components
+        else:
+            self.component_config = {}
+
+        if 'configuration' in config:
+            model_config = config.configuration
+            source = model_config.source if 'source' in model_config else None
+            del model_config.source
+            del config.configuration
+            config.update(model_config, layer='model_override', source=source)
+
         self.config = config
         self.components = []
         self.dataset_manager = dataset_manager
@@ -72,7 +86,7 @@ class ComponentManager:
         the ComponentManager.
         """
 
-        component_list = _extract_component_list(self.config.components)
+        component_list = _extract_component_list(self.component_config)
         component_list = _prep_components(self.config, component_list, self.dataset_manager.constructors)
         new_components = []
         for component in component_list:

--- a/vivarium/framework/engine.py
+++ b/vivarium/framework/engine.py
@@ -162,7 +162,6 @@ def build_simulation_configuration(parameters: Mapping) -> ConfigTree:
     -------
     A valid simulation configuration.
     """
-
     # Start with the base configuration in the user's home directory
     config = ConfigTree(layers=['base', 'component_configs', 'model_override', 'override'])
     if os.path.exists(os.path.expanduser('~/vivarium.yaml')):
@@ -231,7 +230,7 @@ def run(simulation):
 
 
 def do_command(args):
-    config = build_simulation_configuration(args)
+    config = build_simulation_configuration(vars(args))
     component_manager = load_component_manager(config)
     if args.command == 'run':
         simulation = setup_simulation(component_manager, config)

--- a/vivarium/framework/engine.py
+++ b/vivarium/framework/engine.py
@@ -160,7 +160,7 @@ def build_base_configuration(parameters: Mapping = None) -> ConfigTree:
     # Get an input and model draw
     for draw_type in ['input_draw', 'model_draw']:
         if parameters and draw_type in parameters and parameters[draw_type] is not None:
-            metadata = {'layer': 'override', 'source': 'command_line_argument'}
+            metadata = {'layer': 'override', 'source': 'command line or launching script'}
             draw = _get_draw_template(draw_type, parameters[draw_type])
         else:
             metadata = default_metadata

--- a/vivarium/framework/engine.py
+++ b/vivarium/framework/engine.py
@@ -35,7 +35,7 @@ class Builder:
         self.population_view = context.population.get_view
         self.clock = lambda: lambda: context.current_time
         self.step_size = lambda: lambda: context.step_size
-        self.configuration = lambda: lambda: context.configuration
+        self.configuration = context.configuration
         input_draw_number = context.configuration.run_configuration.draw_number
         model_draw_number = context.configuration.run_configuration.model_draw_number
         self.randomness = lambda key: RandomnessStream(key, self.clock(), (input_draw_number, model_draw_number))

--- a/vivarium/framework/engine.py
+++ b/vivarium/framework/engine.py
@@ -178,7 +178,7 @@ def build_simulation_configuration(parameters: Mapping) -> ConfigTree:
 
     # Get an input and model draw
     for draw_type in ['input_draw', 'model_draw']:
-        if parameters[draw_type] is not None:
+        if draw_type in parameters and parameters[draw_type] is not None:
             metadata = {'layer': 'override', 'source': 'command_line_argument'}
             draw = _get_draw_template(draw_type, parameters[draw_type])
         else:

--- a/vivarium/framework/engine.py
+++ b/vivarium/framework/engine.py
@@ -8,11 +8,9 @@ from pprint import pformat, pprint
 from time import time
 
 import yaml
-
 import pandas as pd
 
-from vivarium import config
-
+from vivarium.config_tree import ConfigTree
 from vivarium.framework.values import ValuesManager
 from vivarium.framework.event import EventManager, Event, emits
 from vivarium.framework.population import PopulationManager, creates_simulants
@@ -26,7 +24,8 @@ _log = logging.getLogger(__name__)
 
 
 class Builder:
-    def __init__(self, context):
+    """Useful tools for constructing and configuring simulation components."""
+    def __init__(self, context: SimulationContext):
         self.lookup = context.tables.build_table
         self.value = context.values.get_value
         self.rate = context.values.get_rate
@@ -35,8 +34,9 @@ class Builder:
         self.population_view = context.population.get_view
         self.clock = lambda: lambda: context.current_time
         self.step_size = lambda: lambda: context.step_size
-        input_draw_number = config.run_configuration.draw_number
-        model_draw_number = config.run_configuration.model_draw_number
+        self.configuration = lambda: lambda: context.configuration
+        input_draw_number = context.configuration.run_configuration.draw_number
+        model_draw_number = context.configuration.run_configuration.model_draw_number
         self.randomness = lambda key: RandomnessStream(key, self.clock(), (input_draw_number, model_draw_number))
 
     def __repr__(self):
@@ -45,8 +45,9 @@ class Builder:
 
 class SimulationContext:
     """context"""
-    def __init__(self, component_manager):
+    def __init__(self, component_manager, configuration):
         self.component_manager = component_manager
+        self.configuration = configuration
         self.values = ValuesManager()
         self.events = EventManager()
         self.population = PopulationManager()
@@ -70,9 +71,7 @@ class SimulationContext:
         self.events.get_emitter('post_setup')(None)
 
     def __repr__(self):
-        return "SimulationContext(components={}, current_time={}, step_size={})".format(self.components,
-                                                                                        self.current_time,
-                                                                                        self.step_size)
+        return "SimulationContext(current_time={}, step_size={})".format(self.current_time, self.step_size)
 
 
 @emits('time_step')
@@ -89,8 +88,7 @@ def _step(simulation, time_step_emitter, time_step__prepare_emitter,
     simulation.update_time()
 
 
-def _get_time(suffix):
-    params = config.simulation_parameters
+def _get_time(suffix, params):
     month, day = 'month' + suffix, 'day' + suffix
     if month in params or day in params:
         if not (month in params and day in params):
@@ -103,20 +101,20 @@ def _get_time(suffix):
 @creates_simulants
 @emits('simulation_end')
 def event_loop(simulation, simulant_creator, end_emitter):
-    start = _get_time('start')
-    stop = _get_time('end')
+    sim_params = simulation.configuration.simulation_parameters
+
+    start = _get_time('start', sim_params)
+    stop = _get_time('end', sim_params)
 
     simulation.current_time = start
+    population_size = sim_params.population_size
 
-    population_size = config.simulation_parameters.population_size
-
-    if config.simulation_parameters.initial_age is not None and config.simulation_parameters.pop_age_start is None:
-        simulant_creator(population_size, population_configuration={
-            'initial_age': config.simulation_parameters.initial_age})
+    if sim_params.initial_age is not None and sim_params.pop_age_start is None:
+        simulant_creator(population_size, population_configuration={'initial_age': sim_params.initial_age})
     else:
         simulant_creator(population_size)
 
-    simulation.step_size = pd.Timedelta(config.simulation_parameters.time_step, unit='D')
+    simulation.step_size = pd.Timedelta(sim_params.time_step, unit='D')
 
     while simulation.current_time < stop:
         gc.collect()  # TODO: Actually figure out where the memory leak is.
@@ -125,20 +123,18 @@ def event_loop(simulation, simulant_creator, end_emitter):
     end_emitter(Event(simulation.population.population.index))
 
 
-def setup_simulation(component_manager):
+def setup_simulation(component_manager, config):
+    config.set_with_metadata('run_configuration.run_id', str(time()), layer='base')
+    config.set_with_metadata('run_configuration.run_key', {'draw': config.run_configuration.draw_number}, layer='base')
     component_manager.add_components([_step, event_loop])
-    simulation = SimulationContext(component_manager)
-
+    simulation = SimulationContext(component_manager, config)
     simulation.setup()
-
     return simulation
 
 
 def run_simulation(simulation):
     start = time()
-
     event_loop(simulation)
-
     metrics = simulation.values.get_value('metrics')
     metrics.source = lambda index: {}
     metrics = metrics(simulation.population.population.index)
@@ -146,41 +142,48 @@ def run_simulation(simulation):
     return metrics
 
 
-def configure(input_draw_number=None, model_draw_number=None, simulation_config=None):
-    if simulation_config:
-        if isinstance(simulation_config, dict):
-            config.read_dict(simulation_config)
+def build_simulation_configuration(**parameters):
+    """Updates the base configuration with command line arguments or sets sensible defaults."""
+    config = ConfigTree(layers=['base', 'component_configs', 'model_override', 'override'])
+    if os.path.exists(os.path.expanduser('~/vivarium.yaml')):
+        config.load(os.path.expanduser('~/vivarium.yaml'), layer='override',
+                    source=os.path.expanduser('~/vivarium.yaml'))
+
+    def _get_draw_template(draw_type_, value_):
+        return {'run_configuration': {f'{draw_type_}_number': value_}}
+
+    default_component_manager = {'vivarium': {'component_manager': 'vivarium.framework.components.ComponentManager'}}
+    default_dataset_manager = {'vivarium': {'dataset_manager': 'vivarium.framework.components.DummyDatasetManager'}}
+    default_metadata = {'layer': 'override', 'source': 'default'}
+
+    for draw_type in ['input_draw', 'model_draw']:
+        if draw_type in parameters:
+            metadata = {'layer': 'override', 'source': 'command_line_argument'}
+            draw = _get_draw_template(draw_type, parameters[draw_type])
         else:
-            config.read(simulation_config)
+            metadata = default_metadata
+            draw = _get_draw_template(draw_type, 0)
+        config.update(draw, **metadata)
 
-    if input_draw_number is not None:
-        config.run_configuration.set_with_metadata('draw_number', input_draw_number,
-                                                   layer='override', source='command_line_argument')
-    else:
-        if 'draw_number' not in config.run_configuration:
-            config.run_configuration.set_with_metadata('draw_number', 0,
-                                                       layer='override', source='default')
+    config.update(parameters.get('config', None), layer='override')
+    config.update(parameters.get('components', None), layer='model_override')
 
-    if model_draw_number is not None:
-        config.run_configuration.set_with_metadata('model_draw_number', model_draw_number,
-                                                   layer='override', source='command_line_argument')
-    else:
-        if 'model_draw_number' not in config.run_configuration:
-            config.run_configuration.set_with_metadata('model_draw_number', 0,
-                                                       layer='override', source='default')
+    if 'component_manager' not in config['vivarium']:
+        config.update(default_component_manager, **default_metadata)
+    if 'dataset_manager' not in config['vivarium']:
+        config.update(default_dataset_manager, **default_metadata)
+
+    return config
 
 
-def run(component_manager):
-    config.set_with_metadata('run_configuration.run_id', str(time()), layer='base')
-    config.set_with_metadata('run_configuration.run_key', {'draw': config.run_configuration.draw_number}, layer='base')
-    simulation = setup_simulation(component_manager)
+def run(simulation):
     metrics = run_simulation(simulation)
-    for name, value in collapse_nested_dict(config.run_configuration.run_key.to_dict()):
-        metrics[name] = value
 
+    for name, value in collapse_nested_dict(simulation.configuration.run_configuration.run_key.to_dict()):
+        metrics[name] = value
     _log.debug(pformat(metrics))
 
-    unused_config_keys = config.unused_keys()
+    unused_config_keys = simulation.configuration.unused_keys()
     if unused_config_keys:
         _log.debug("Some configuration keys not used during run: %s", unused_config_keys)
 
@@ -188,18 +191,11 @@ def run(component_manager):
 
 
 def do_command(args):
-    configure(input_draw_number=args.input_draw, simulation_config=args.config)
-
-    if args.components.endswith('.yaml'):
-        with open(args.components) as f:
-            component_config = f.read()
-        component_config = yaml.load(component_config)
-    else:
-        raise VivariumError("Unknown components configuration type: {}".format(args.components))
-
-    component_manager = load_component_manager(component_config=component_config)
+    config = build_simulation_configuration(**args)
+    component_manager = load_component_manager(config)
     if args.command == 'run':
-        results = run(component_manager)
+        simulation = setup_simulation(component_manager, config)
+        results = run(simulation)
         if args.results_path:
             try:
                 os.makedirs(os.path.dirname(args.results_path))

--- a/vivarium/framework/event.py
+++ b/vivarium/framework/event.py
@@ -149,7 +149,7 @@ class EventManager:
                          for i, priority in enumerate(listens_for.finder(component))
                          for v in priority]
             listeners += [(v, getattr(component, att), i)
-                          for att in sorted(dir(component))
+                          for att in sorted(dir(component)) if callable(getattr(component, att))
                           for i, vs in enumerate(listens_for.finder(getattr(component, att)))
                           for v in vs]
 
@@ -158,7 +158,7 @@ class EventManager:
 
             emitters = [(v, component) for v in emits.finder(component)]
             emitters += [(v, getattr(component, att))
-                         for att in sorted(dir(component))
+                         for att in sorted(dir(component)) if callable(getattr(component, att))
                          for v in emits.finder(getattr(component, att))]
 
             # Pre-create the EventChannels for known emitters

--- a/vivarium/framework/state_machine.py
+++ b/vivarium/framework/state_machine.py
@@ -135,13 +135,8 @@ class Transition:
         """The name of this transition."""
         return ''
 
-    def __str__(self):
-        return 'Transition({})'.format(self.output)
-
     def __repr__(self):
-        return 'Transition(output= {}, _probability={}, _active={})'.format(self.output,
-                                                                            self._probability,
-                                                                            self._active_index)
+        return f'Transition(from={self.input_state.state_id}, to={self.output_state.state_id})'
 
 
 class State:
@@ -302,7 +297,7 @@ class TransitionSet:
         decisions: `pandas.Series`
             A series containing the name of the next state for each simulant in the index.
         """
-        outputs, probabilities = zip(*[(transition.output, np.array(transition.probability(index)))
+        outputs, probabilities = zip(*[(transition.output_state, np.array(transition.probability(index)))
                                        for transition in self.transitions])
         probabilities = np.transpose(probabilities)
         outputs, probabilities = self._normalize_probabilities(outputs, probabilities)

--- a/vivarium/framework/state_machine.py
+++ b/vivarium/framework/state_machine.py
@@ -91,14 +91,17 @@ class Transition:
 
     Parameters
     ----------
-    output : State
+    input_state: State
+        The start state of the entity that undergoes the transition.
+    output_state : State
         The end state of the entity that undergoes the transition.
     probability_func : callable
         A method or function that describing the probability of this transition occurring.
     """
-    def __init__(self, output, probability_func=lambda index: pd.Series(1, index=index),
+    def __init__(self, input_state, output_state, probability_func=lambda index: pd.Series(1, index=index),
                  triggered=Trigger.NOT_TRIGGERED):
-        self.output = output
+        self.input_state = input_state
+        self.output_state = output_state
         self._probability = probability_func
         self._active_index, self.start_active = _process_trigger(triggered)
 
@@ -219,7 +222,7 @@ class State:
         output : State
             The end state after the transition.
         """
-        t = Transition(output, probability_func=probability_func, triggered=triggered)
+        t = Transition(self, output, probability_func=probability_func, triggered=triggered)
         self.transition_set.append(t)
         return t
 


### PR DESCRIPTION
The primary motivation of this PR is to pull the config out of the global state and make it accessible through the builder.  There are a large number of minor changes and a handful of larger changes made to accomplish this.  The main highlights are:

- Removed support for python 3.5 (I've been using f-strings and Alec is using some of the new metaclass stuff defined in https://www.python.org/dev/peps/pep-0487/ for the incoming dataset manager).
- Moved off unittest.mock in favor of the pytest mock system.  Pulling the config from the global state allows us to make better use of many of the great pytest features, but unfortunately their syntax conflicts the the injection style of the mock.patch decorator we were using previously.
- Added an `update` method to the `ConfigTree`.  Since the `ConfigTree` has many mapping like features and `update` is the canonical way to add new values to a mapping in python.  Also, gives a data agnostic entry point (vs. the `load`, `loads`, and `read_dict` methods).
- Moved a bunch of the configuration handling at the beginning of the simulation into the engine as the `build_simulation_configuration` function.  There are some bits of data that don't yet have a good home that live there now as well, unfortunately, but we can address that later.
- Made the `EventManager` and `ValueManager` classes filter out non-callable object attributes when they're looking for marked attributes.  This lets us keep the default look-up behavior on the configuration,
but also allow classes to keep copies of the whole simulation configuration or some subsection of it after set up time without unfortunate side effects.
- Gave the `Pipeline` class a reference to its manager so that it can provide the current time step to its mutators/post-processors (e.g. the rate post processor that needs to scale to the current time step).
- Gave transitions a reference to their input state.  I had a functional reason for this that I can't remember.  But it also make Transitions more easily identifiable in debugging.
- Made `generate_test_population` a class so it can respect the locality of the simulation configuration.

This PR is essentially final.  I still need to get downstream tests passing (inputs, public-health, experiments) which might result in minor changes however.