### PR TITLE
Bugfix/population dependencies

### DIFF
--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -1,5 +1,5 @@
 """System for managing population creation, updating and viewing."""
-from typing import Sequence, List, Callable, Union, Mapping, Any
+from typing import Sequence, List, Tuple, Callable, Union, Mapping, Any
 from collections import deque, namedtuple
 
 import pandas as pd
@@ -207,9 +207,8 @@ class PopulationManager:
         status = pd.Series(True, index=pop_data.index)
         self.get_view(['tracked']).update(status)
 
-
     @staticmethod
-    def _validate_no_missing_initializers(initializers):
+    def _validate_no_missing_initializers(initializers: Sequence[Tuple]) -> None:
         created_columns = []
         required_columns = []
         for _, created, required in initializers:
@@ -219,7 +218,6 @@ class PopulationManager:
         if not set(required_columns) <= set(created_columns):
             raise PopulationError(f"The initializers {initializers} could not be added.  "
                                   "Check for missing dependencies in your components.")
-
 
     def _order_initializers(self) -> None:
         unordered_initializers = deque(self._population_initializers)

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -15,7 +15,6 @@ def test_create_PopulationView_with_all_columns():
     assert set(view.columns) == {'age', 'sex'}
 
 
-# test dependencies
 def test_circular_initializers():
     manager = PopulationManager()
     manager.register_simulant_initializer(lambda: "initializer 1",
@@ -37,9 +36,9 @@ def test_missing_initializer():
 def test_conflicting_initializers():
     manager = PopulationManager()
     manager.register_simulant_initializer(lambda: "initializer 1",
-                                          ['dummy_column'], [])
+                                          ['result_column'], [])
     manager.register_simulant_initializer(lambda: "initializer 2",
-                                          ['dummy_column'], [])
+                                          ['result_column'], [])
     with pytest.raises(PopulationError, match="Multiple components are attempting "
                                               "to initialize the same columns"):
         manager._order_initializers()

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -1,6 +1,7 @@
 import pandas as pd
+import pytest
 
-from vivarium.framework.population import PopulationView
+from vivarium.framework.population import PopulationView, PopulationManager, PopulationError
 
 
 class DummyPopulationManager:
@@ -12,3 +13,33 @@ def test_create_PopulationView_with_all_columns():
     manager = DummyPopulationManager()
     view = PopulationView(manager)
     assert set(view.columns) == {'age', 'sex'}
+
+
+# test dependencies
+def test_circular_initializers():
+    manager = PopulationManager()
+    manager.register_simulant_initializer(lambda: "initializer 1",
+                                          ['init_1_column'], ['init_2_column'])
+    manager.register_simulant_initializer(lambda: "initializer 2",
+                                          ['init_2_column'], ['init_1_column'])
+    with pytest.raises(PopulationError, match="Check for cyclic dependencies"):
+        manager._order_initializers()
+
+
+def test_missing_initializer():
+    manager = PopulationManager()
+    manager.register_simulant_initializer(lambda: "initializer 1",
+                                          ["result_column"], ["input_column"])
+    with pytest.raises(PopulationError, match="Check for missing dependencies"):
+        manager._order_initializers()
+
+
+def test_conflicting_initializers():
+    manager = PopulationManager()
+    manager.register_simulant_initializer(lambda: "initializer 1",
+                                          ['dummy_column'], [])
+    manager.register_simulant_initializer(lambda: "initializer 2",
+                                          ['dummy_column'], [])
+    with pytest.raises(PopulationError, match="Multiple components are attempting "
+                                              "to initialize the same columns"):
+        manager._order_initializers()


### PR DESCRIPTION
This addresses the ambiguity of the PopulationError thrown when the pop initializers can't be ordered. It now distinguishes between cyclic dependencies and a missing component. I added unit tests for these, as well as a test for the other error case, which is multiple components trying to generate the same column.

I chose to piggy-back on the loop already being run to generate a list of columns that would be created/required, which results in potentially extra extensions to the lists. Alternative would be to make one pass at the beginning to populate those lists, or in the exception branch. 

Regarding the comment above the loop: isn't the algorithm listed n!, because worst case is full iteration of the list of initializers that decreases by one after each iteration (reverse order)? Rather than iterating the full list and then failing next time (n ** 2)

