### PR TITLE
Bugfix/population dependencies

### DIFF
--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -227,7 +227,7 @@ class PopulationManager:
 
         self._validate_no_missing_initializers(unordered_initializers)
 
-        # This is the brute force N^2 way because constructing a dependency graph is work
+        # This is the brute force N! way because constructing a dependency graph is work
         # and in practice this should run in about order N time due to the way dependencies are
         # typically specified.  N is also very small in all current applications.
         while len(unordered_initializers) != starting_length:

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -15,73 +15,51 @@ def test_create_PopulationView_with_all_columns():
     assert set(view.columns) == {'age', 'sex'}
 
 
-def test_circular_initializers():
-    """   [4]
-          /
-        [3]
-        / \
-      [2]-[5]
-      /
-    [1]
+def make_initializer_dag(num_nodes, edges):
+    """Helper to create a dag organized as a list of dictionaries from
+    a node count and edges defined as tuples of (node_index, column_name)
+
+    Always assigns created column as "Column{index}"
     """
+    dag = [{'name': f"initializer{i}",
+            'creates': [f"Column{i}"],
+            'requires': []} for i in range(num_nodes)]
+    for edge in edges:
+        node_index, column_name = edge
+        dag[node_index]['requires'].append(column_name)
+
+    return dag
+
+
+@pytest.mark.parametrize("num_nodes,edges", [
+    (5, [(0, "Column1"), (1, "Column2"), (2, "Column3"), (2, "Column4"), (4, "Column1")])
+    ])
+def test_cyclic_dependencies(num_nodes, edges):
     manager = PopulationManager()
-    manager.register_simulant_initializer(lambda: "initializer1",
-                                          ['Column1'], ['Column2'])
-    manager.register_simulant_initializer(lambda: "initializer2",
-                                          ['Column2'], ['Column3'])
-    manager.register_simulant_initializer(lambda: "initializer 3",
-                                          ['Column3'], ['Column4', 'Column5'])
-    manager.register_simulant_initializer(lambda: "initializer 4",
-                                          ['Column4'], [])
-    manager.register_simulant_initializer(lambda: "initializer 5",
-                                          ['Column5'], ['Column2'])
+
+    dag = make_initializer_dag(num_nodes, edges)
+    for node in dag:
+        manager.register_simulant_initializer(lambda: node['name'], 
+                                                      node['creates'],
+                                                      node['requires'])
+
     with pytest.raises(PopulationError, match="Check for cyclic dependencies"):
         manager._order_initializers()
 
 
-def test_missing_initializer():
-    """        /
-         [4] [5]
-          \  /   
-      [2] [3]
-       \  /
-       [1]
-    """
+@pytest.mark.parametrize("num_nodes,edges", [
+    (5, [(0, "Column1"), (0, "Column2"), (2, "Column3"), (2, "Column4"), (0, "NaNColumn")]),
+    (5, [(0, "Column2"), (1, "Column2"), (2, "NaNColumn"), (1, "Column3"), (3, "Column4"), (3, "Column1")])
+    ])
+def test_missing_dependencies(num_nodes, edges):
     manager = PopulationManager()
-    manager.register_simulant_initializer(lambda: "initializer1",
-                                          ['Column1'], ['Column2', 'Column3'])
-    manager.register_simulant_initializer(lambda: "initializer2",
-                                          ['Column2'], [])
-    manager.register_simulant_initializer(lambda: "initializer3",
-                                          ['Column3'], ['Column4', 'Column5'])
-    manager.register_simulant_initializer(lambda: "initializer4",
-                                          ['Column4'], [])
-    manager.register_simulant_initializer(lambda: "initializer5",
-                                          ['Column5'], ['NonExistantColumn'])
-    with pytest.raises(PopulationError, match="Check for missing dependencies"):
-        manager._order_initializers()
 
+    dag = make_initializer_dag(num_nodes, edges)
+    for node in dag:
+        manager.register_simulant_initializer(lambda: node['name'], 
+                                                      node['creates'],
+                                                      node['requires'])
 
-def test_circular_and_missing_initializer():
-    """ [3]--
-         |
-        [2]
-        / \
-      [1]-[4]
-           |
-          [5]
-    """
-    manager = PopulationManager()
-    manager.register_simulant_initializer(lambda: "initializer1",
-                                          ['Column1'], ['Column2'])
-    manager.register_simulant_initializer(lambda: "initializer2",
-                                          ['Column2'], ['Column3', 'Column4'])
-    manager.register_simulant_initializer(lambda: "initializer3",
-                                          ['Column3'], ['NonExistantColumn'])
-    manager.register_simulant_initializer(lambda: "initializer4",
-                                          ['Column4'], ['Column1', 'Column5'])
-    manager.register_simulant_initializer(lambda: "initializer5",
-                                          ['Column5'], [])
     with pytest.raises(PopulationError, match="Check for missing dependencies"):
         manager._order_initializers()
 


### PR DESCRIPTION
Made the initializer test graphs slightly more interesting and added a test for a graph containing both circular and missing dependencies. They all currently pass