### PR TITLE
Refactor lookup

### DIFF
--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -89,15 +89,15 @@ class LookupTable:
         if data is None or (isinstance(data, pd.DataFrame) and data.empty):
             raise ValueError("Must supply some data")
 
-        if set(key_columns).intersection(set(parameter_columns)):
-            raise ValueError(f'There should be no overlap between key columns: {key_columns} '
-                             f'and parameter columns: {parameter_columns}.')
-
         # Note datetime catches pandas timestamps
         if isinstance(data, (Number, datetime, timedelta, list, tuple)):
             self.table = ScalarTable(data, value_columns)
 
         elif isinstance(data, pd.DataFrame):
+            if set(key_columns).intersection(set(parameter_columns)):
+                raise ValueError(f'There should be no overlap between key columns: {key_columns} '
+                                 f'and parameter columns: {parameter_columns}.')
+
             view_columns = sorted((set(key_columns) | set(parameter_columns)) - {'year'})
             self.table = InterpolatedTable(data, population_view(view_columns), key_columns,
                                            parameter_columns, value_columns, interpolation_order, clock)

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -22,31 +22,21 @@ class InterpolatedTableView:
     """
     def __init__(self, data, population_view, key_columns, parameter_columns, value_columns, interpolation_order, clock):
         self._data = data
-        # TODO: figure out if we need interpolation to be lazily generated
         self.population_view = population_view
         self._key_columns = key_columns
         self._parameter_columns = parameter_columns
         self._interpolation_order = interpolation_order
         self._value_columns = value_columns
         self.clock = clock
-        self._interpolation = self.interpolation()
-
-    def interpolation(self):
-        data = self._data
-        # TODO: find out is data ever callable
-        if callable(data) and not isinstance(data, Interpolation):
-            import pdb
-            pdb.set_trace()
-            data = data()
 
         if isinstance(data, Interpolation):
             warnings.warn("Creating lookup tables from pre-initialized Interpolation objects is deprecated. "
                           "Use key_columns and parameter_columns to control interpolation. If that isn't possible "
                           "then please raise an issue with your use case.", DeprecationWarning)
-            return data
+            self._interpolation = self._data
         else:
-            return Interpolation(data, self._key_columns, self._parameter_columns,
-                                                order=self._interpolation_order)
+            self._interpolation =  Interpolation(data, self._key_columns, self._parameter_columns,
+                                                 order=self._interpolation_order)
 
     def __call__(self, index):
         pop = self.population_view.get(index)

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -2,6 +2,7 @@
 from numbers import Number
 from datetime import datetime, timedelta
 import warnings
+
 import pandas as pd
 
 from vivarium.interpolation import Interpolation
@@ -157,7 +158,8 @@ class LookupTableManager:
         functions which will estimate all remaining columns in the table.
 
         If data is a number, time, list, or tuple, a scalar table will be constructed with
-        the values in data the values in each column of the table.
+        the values in data as the values in each column of the table, named according to
+        value_columns.
 
 
         Parameters

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -10,12 +10,6 @@ from vivarium.interpolation import Interpolation
 class InterpolatedTableView:
     """A callable that returns the result of an interpolation function over input data.
 
-    Parameters
-    ----------
-    interpolation : callable
-    population_view : `vivarium.framework.population.PopulationView`
-    clock : callable
-
     Notes
     -----
     These cannot be created directly. Use the `lookup` method on the builder during setup.
@@ -35,8 +29,8 @@ class InterpolatedTableView:
                           "then please raise an issue with your use case.", DeprecationWarning)
             self._interpolation = self._data
         else:
-            self._interpolation =  Interpolation(data, self._key_columns, self._parameter_columns,
-                                                 order=self._interpolation_order)
+            self._interpolation = Interpolation(data, self._key_columns, self._parameter_columns,
+                                                order=self._interpolation_order)
 
     def __call__(self, index):
         pop = self.population_view.get(index)

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -152,7 +152,7 @@ class InterpolatedDataManager:
                                          self.clock)
         else:
             raise ValueError(f'The only allowable types for data are number, datetime, timedelta,'
-                             f'list, tuple, or pandas DataFrame. You passed {type(data)}.')
+                             f'list, tuple, or pandas.DataFrame. You passed {type(data)}.')
 
     def __repr__(self):
         return "InterpolatedDataManager()"

--- a/src/vivarium/framework/plugins.py
+++ b/src/vivarium/framework/plugins.py
@@ -5,7 +5,7 @@ from .utilities import import_by_path
 
 _MANAGERS = {
     'lookup': {
-        'controller': 'vivarium.framework.lookup.InterpolatedDataManager',
+        'controller': 'vivarium.framework.lookup.LookupTableManager',
         'builder_interface': 'vivarium.framework.lookup.LookupTableInterface',
     },
     'randomness': {

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -2,7 +2,7 @@ import pytest
 
 from vivarium.framework.engine import SimulationContext, Builder, setup_simulation, run, run_simulation
 from vivarium.framework.event import EventManager, EventInterface
-from vivarium.framework.lookup import InterpolatedDataManager, LookupTableInterface
+from vivarium.framework.lookup import LookupTableManager, LookupTableInterface
 from vivarium.framework.components import ComponentManager, ComponentInterface
 from vivarium.framework.metrics import Metrics
 from vivarium.framework.plugins import PluginManager
@@ -39,7 +39,7 @@ def test_SimulationContext_init_default(base_config, components):
     assert isinstance(sim.values, ValuesManager)
     assert isinstance(sim.events, EventManager)
     assert isinstance(sim.population, PopulationManager)
-    assert isinstance(sim.tables, InterpolatedDataManager)
+    assert isinstance(sim.tables, LookupTableManager)
     assert isinstance(sim.randomness, RandomnessManager)
 
     assert isinstance(sim.builder, Builder)
@@ -87,7 +87,7 @@ def test_SimulationContext_init_custom(base_config, components):
     assert isinstance(sim.values, ValuesManager)
     assert isinstance(sim.events, EventManager)
     assert isinstance(sim.population, PopulationManager)
-    assert isinstance(sim.tables, InterpolatedDataManager)
+    assert isinstance(sim.tables, LookupTableManager)
     assert isinstance(sim.randomness, RandomnessManager)
 
     assert isinstance(sim.builder, Builder)

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -17,9 +17,9 @@ def test_interpolated_tables(base_config):
 
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
-    years = manager.build_table(years, key_columns=('sex',), parameter_columns=('age', 'year',))
-    ages = manager.build_table(ages, key_columns=('sex',), parameter_columns=('age', 'year',))
-    one_d_age = manager.build_table(one_d_age, key_columns=('sex',), parameter_columns=('age',))
+    years = manager.build_table(years, key_columns=('sex',), parameter_columns=('age', 'year',), value_columns=None)
+    ages = manager.build_table(ages, key_columns=('sex',), parameter_columns=('age', 'year',), value_columns=None)
+    one_d_age = manager.build_table(one_d_age, key_columns=('sex',), parameter_columns=('age',), value_columns=None)
 
     result_years = years(simulation.population.population.index)
     result_ages = ages(simulation.population.population.index)
@@ -57,7 +57,7 @@ def test_interpolated_tables_without_uninterpolated_columns(base_config):
 
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
-    years = manager.build_table(years, key_columns=(), parameter_columns=('year', 'age',))
+    years = manager.build_table(years, key_columns=(), parameter_columns=('year', 'age',), value_columns=None)
 
     result_years = years(simulation.population.population.index)
 
@@ -85,7 +85,7 @@ def test_interpolated_tables__exact_values_at_input_points(base_config):
 
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
-    years = manager.build_table(years, key_columns=('sex',), parameter_columns=('age', 'year',))
+    years = manager.build_table(years, key_columns=('sex',), parameter_columns=('age', 'year',), value_columns=None)
 
     for year in input_years:
         simulation.clock._time = pd.Timestamp(year, 1, 1)

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -116,7 +116,7 @@ def test_scalar_tables_from_single_value(base_config):
 def test_invalid_data_type_build_table(base_config):
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         manager.build_table('break', key_columns=None, parameter_columns=None, value_columns=None)
 
 


### PR DESCRIPTION
Refactoring lookup. Changes as follows:

In lookup.py:
- address the ToDos from the design meeting, including removing the option for callable data and lazy generation of interpolation and verifying that return types are consistent
- refactor so that the manager always returns the same type (a LookupTable) rather than sometimes a ScalarView and sometimes an InterpolatedTableView
- allow for lists/tuples to be passed to build scalar tables
- naming changes for consistency & clarity
- more documentation

In test_lookup.py:
- updating tests that use the manager build_table function to include the added value_columns parameter
- adding tests for scalar table and additional tests for interpolated table

In plugins.py:
- changing controller name for lookup to reflect naming changes in lookup.py

In test_engine.py:
- updating tests that use the manager build_table function to include the added value_columns parameter

All smoke tests pass with these changes. All tests in vivarium_inputs and vivarium_public_health (once updated - see refactor/lookup pr in vivarium_public_health) also pass. 
