### PR TITLE
Feature/order 0 interp

### DIFF
--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -272,4 +272,4 @@ class LookupTableInterface:
         -------
         LookupTable
         """
-        return self._lookup_table_manager.build_table(data, key_columns, parameter_columns, value_columns, extrapolate)
+        return self._lookup_table_manager.build_table(data, key_columns, parameter_columns, value_columns)

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -209,7 +209,7 @@ class LookupTableManager:
 
     configuration_defaults = {
         'interpolation': {
-            'order': 0,
+            'order': 1,
         }
     }
 

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -137,7 +137,7 @@ class LookupTableManager:
 
     configuration_defaults = {
         'interpolation': {
-            'order': 1,
+            'order': 0,
         }
     }
 
@@ -145,9 +145,7 @@ class LookupTableManager:
         self._pop_view_builder = builder.population.get_view
         self.clock = builder.time.clock()
         self._interpolation_order = builder.configuration.interpolation.order
-        if self._interpolation_order not in [0, 1]:
-            raise ValueError('Only order 0 and order 1 interpolations are supported. '
-                             f'You specified {self._interpolation_order}')
+
 
     def build_table(self, data, key_columns, parameter_columns, value_columns):
         """Construct a LookupTable from input data.

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -139,7 +139,7 @@ class LookupTable:
     """
     def __init__(self, data: Union[ScalarValue, pd.DataFrame, List[ScalarValue], Tuple[ScalarValue]],
                  population_view: Callable, key_columns: Union[List[str], Tuple[str]],
-                 parameter_columns: Union[List[str], Tuple[str]], value_columns: Union[List[str], Tuple[str]],
+                 parameter_columns: ParameterType, value_columns: Union[List[str], Tuple[str]],
                  interpolation_order: int, clock: Callable, extrapolate: bool):
 
         validate_parameters(data, key_columns, parameter_columns, value_columns)

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -139,7 +139,7 @@ def validate_parameters(data, categorical_parameters, continuous_parameters, ord
 
     out = []
     for p in continuous_parameters:
-        if not isinstance(p, (List, Tuple)) and len(p) != 3:
+        if not isinstance(p, (List, Tuple)) or len(p) != 3:
             raise ValueError(f'Interpolation is only supported for binned data. You must specify a list or tuple '
                              f'containing, in order, the column name used when interpolation is called, '
                              f'the column name for the left edge (inclusive), and the column name for '

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -137,6 +137,11 @@ def validate_parameters(data, categorical_parameters, continuous_parameters, ord
     out = []
     for p in continuous_parameters:
 
+        if isinstance(p, (List, Tuple)) and len(p) != 3:
+            raise ValueError(f'If you specify bin edges for a parameter, they must be in the form '
+                             f'(column name when called, column name of left bin edge, column name of right bin edge). '
+                             f'You specified {p}.')
+
         param_col = p[1] if isinstance(p, (List, Tuple)) else p
 
         if len(data[param_col].unique()) > order:

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -2,8 +2,6 @@ import warnings
 
 import pandas as pd
 from scipy import interpolate
-from typing import Sequence
-
 from typing import Union, List, Tuple
 
 

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -171,7 +171,7 @@ def check_data_complete(data, parameter_columns):
     param_edges = [p for p in parameter_columns if isinstance(p, (Tuple, List))]
     param_points = [p for p in parameter_columns if isinstance(p, str)]
 
-    # FIXME: There has to be a cleaner, faster way to do this
+    # FIXME: There has to be a cleaner, faster, less horrible way to do this
     # check no overlaps/gaps
     for p in param_edges:
         other_params = param_points + [p_ed[0] for p_ed in param_edges if p_ed != p]
@@ -180,10 +180,15 @@ def check_data_complete(data, parameter_columns):
         else:
             sub_tables = {None: data}.items()
 
+        n_p_total = len(set(data[p[0]]))
+
         for _, table in sub_tables:
 
             param_data = table[[p[0], p[1]]].copy().sort_values(by=p[0])
             start, end = param_data[p[0]].reset_index(drop=True), param_data[p[1]].reset_index(drop=True)
+
+            if len(set(start)) < n_p_total:
+                raise ValueError(f'You must provide a value for every combination of {parameter_columns}')
 
             if len(start) <= 1:
                 continue
@@ -199,11 +204,11 @@ def check_data_complete(data, parameter_columns):
                                               f'non-continuous bins.')
 
     # check all combos - because we know there are no overlaps/repeats, we can just check the numbers match
-    params = param_points + [p[0] for p in param_edges]
-    combos = list(product(*[set(data[p]) for p in params]))
+    #params = param_points + [p[0] for p in param_edges]
+    #combos = list(product(*[set(data[p]) for p in params]))
 
-    if len(combos) > data.shape[0]:
-       raise ValueError(f'You must provide a value for every combination of {parameter_columns}')
+    #if len(combos) > data.shape[0]:
+    #    raise ValueError(f'You must provide a value for every combination of {parameter_columns}')
 
 
 

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -1,8 +1,5 @@
-import warnings
-
 import pandas as pd
 import numpy as np
-from scipy import interpolate
 from typing import Union, List, Tuple, TypeVar
 
 ParameterType = TypeVar('ParameterType', List[List[str]], List[Tuple[str, str, str]])

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -117,9 +117,10 @@ def validate_parameters(data, categorical_parameters, continuous_parameters, ord
         raise ValueError('Only order 0 and order 1 interpolations are supported. '
                          f'You specified {order}')
 
-    # FIXME: allow for more than 2 parameter interpolation
-    if len(continuous_parameters) not in [1, 2]:
-        raise ValueError("Only interpolation over 1 or 2 variables is supported")
+    if len(continuous_parameters) not in [1, 2] and order != 0:
+        raise ValueError("Interpolation over more than two parameters is only supported"
+                         "for order 0. For all other orders, only interpolation over 1 or "
+                         "2 variables is supported")
 
     out = []
     for p in continuous_parameters:

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -32,6 +32,8 @@ class Interpolation:
         self.interpolations = {}
 
         for key, base_table in sub_tables:
+            if base_table.empty:    # if one of the key columns is a category and not all values are present in data
+                continue
             # For each permutation of the key columns build interpolations
             self.interpolations[key] = {}
             for value_column in value_columns:

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -8,9 +8,6 @@ class Interpolation:
     def __init__(self, data: pd.DataFrame, categorical_parameters: Sequence[str],
                  continuous_parameters: Sequence[str], order: int):
 
-        #if order != 0:
-        #    raise NotImplementedError(f'Only order 0 interpolations are supported.You specified {order}')
-
         self.key_columns = categorical_parameters
         self.parameter_columns, self._data = validate_parameters(data, continuous_parameters, order)
 
@@ -92,9 +89,6 @@ class Interpolation:
 
     def __repr__(self):
         return "Interpolation()"
-
-
-
 
 
 def validate_parameters(data, continuous_parameters, order):

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -62,7 +62,7 @@ class Interpolation:
 
     def __call__(self, population):
 
-        validate_call_data(population, self.key_columns, self.parameter_columns)
+        self. _validate_call_data(population)
 
         if self.key_columns:
             sub_tables = population.groupby(list(self.key_columns))
@@ -88,26 +88,28 @@ class Interpolation:
 
         return result
 
+    def _validate_call_data(self, data):
+        if not isinstance(data, pd.DataFrame):
+            raise TypeError(f'Interpolations can only be called on pandas.DataFrames. You'
+                            f'passed {type(data)}.')
+
+        if not set(self.parameter_columns) <= set(data.columns.values.tolist()):
+            raise ValueError(f'The continuous parameter columns with which you built the Interpolation must all'
+                             f'be present in the data you call it on. The Interpolation has key'
+                             f'columns: {self.parameter_columns} and your data has columns: '
+                             f'{data.columns.values.tolist()}')
+
+        if self.key_columns and not set(self.key_columns) <= set(data.columns.values.tolist()):
+            raise ValueError(f'The key (categorical) columns with which you built the Interpolation must all'
+                             f'be present in the data you call it on. The Interpolation has key'
+                             f'columns: {self.key_columns} and your data has columns: '
+                             f'{data.columns.values.tolist()}')
+
     def __repr__(self):
         return "Interpolation()"
 
 
-def validate_call_data(data, key_columns, parameter_columns):
-    if not isinstance(data, pd.DataFrame):
-        raise TypeError(f'Interpolations can only be called on pandas.DataFrames. You'
-                        f'passed {type(data)}.')
 
-    if not set(parameter_columns) <= set(data.columns.values.tolist()):
-        raise ValueError(f'The continuous parameter columns with which you built the Interpolation must all'
-                         f'be present in the data you call it on. The Interpolation has key'
-                         f'columns: {parameter_columns} and your data has columns: '
-                         f'{data.columns.values.tolist()}')
-
-    if key_columns and not set(key_columns) <= set(data.columns.values.tolist()):
-        raise ValueError(f'The key (categorical) columns with which you built the Interpolation must all'
-                         f'be present in the data you call it on. The Interpolation has key'
-                         f'columns: {key_columns} and your data has columns: '
-                         f'{data.columns.values.tolist()}')
 
 
 def validate_parameters(data, continuous_parameters, order):

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -235,7 +235,7 @@ class Order0Interp:
     ----------
     data :
         The data from which to build the interpolation. Contains
-        cateogrical_parameters and continuous_parameters.
+        categorical_parameters and continuous_parameters.
     parameter_columns :
         Column names to be used as parameters in Interpolation.
     """
@@ -250,7 +250,8 @@ class Order0Interp:
             Parameter columns. Should be of form (column name used in call,
             column name for left bin edge, column name for right bin edge)
             or column name. If given as single column name, assumed to be
-            midpoint of bin and continuous bins created
+            midpoint of bin and continuous bins created. Assumes left bin
+            edges are inclusive and right exclusive.
 
         """
         check_data_complete(data, parameter_columns)

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -255,7 +255,7 @@ class Order0Interp:
 
         """
         check_data_complete(data, parameter_columns)
-        self.data = data.copy()
+        self.data = data
         self.value_columns = value_columns
 
         # (column name used in call, column name for left edge): [ordered left edges of bins]

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -100,7 +100,7 @@ class Interpolation:
         for key, sub_table in sub_tables:
             if sub_table.empty:
                 continue
-            if self.order == 0: # we can interpolate all value columns at once
+            if self.order == 0:  # we can interpolate all value columns at once
                 df = self.interpolations[key](sub_table)
                 result.loc[sub_table.index, self.value_columns] = df.loc[sub_table.index, self.value_columns]
             else:
@@ -129,7 +129,7 @@ def validate_parameters(data, categorical_parameters, continuous_parameters, ord
     if len(continuous_parameters) not in [1, 2] and order != 0:
         raise ValueError("Interpolation over more than two parameters is only supported"
                          "for order 0. For all other orders, only interpolation over 1 or "
-                         "2 variables is supported")
+                         "2 variables is supported.")
 
     if len(continuous_parameters) < 1:
         raise ValueError("You must supply at least one continuous parameter over which to interpolate.")
@@ -193,7 +193,7 @@ def check_data_complete(data, parameter_columns):
     If multiple parameters, make sure all combinations of parameters
     are present in data."""
 
-    param_edges = [p[1:] for p in parameter_columns if isinstance(p, (Tuple, List))] # strip out call column name
+    param_edges = [p[1:] for p in parameter_columns if isinstance(p, (Tuple, List))]  # strip out call column name
     param_points = [p for p in parameter_columns if isinstance(p, str)]
 
     # check no overlaps/gaps
@@ -245,7 +245,7 @@ class Order0Interp:
         Parameters
         ----------
         data :
-            Dataframe used to build interpolation.
+            Data frame used to build interpolation.
         parameter_columns :
             Parameter columns. Should be of form (column name used in call,
             column name for left bin edge, column name for right bin edge)
@@ -263,7 +263,7 @@ class Order0Interp:
 
         for p in parameter_columns:
             if isinstance(p, (List, Tuple)):
-                param = (p[0], p[1]) # no need for right edge because already confirmed continuous
+                param = (p[0], p[1])  # no need for right edge because already confirmed continuous
                 left_edge = self.data[param[1]].drop_duplicates().sort_values()
             else:  # make left edge assuming p is the midpoint and bins are continuous
                 left_edge = make_left_edge(self.data, p)
@@ -294,7 +294,7 @@ class Order0Interp:
             merge_cols.append(cols[1])
             interpolant_col = interpolants[cols[0]]
             bin_indices = np.digitize(interpolant_col, bins)
-            # digitize uses 0 to indicate <min and len(bins) for >max so adjust to actual indices into bin_indices
+            # digitize uses 0 to indicate < min and len(bins) for > max so adjust to actual indices into bin_indices
             bin_indices = [x-1 if x > 0 else x for x in bin_indices]
 
             interpolant_bins[cols[1]] = [bins[i] for i in bin_indices]
@@ -325,7 +325,7 @@ def make_left_edge(data: pd.DataFrame, col: str) -> pd.Series:
     mid_pts['shift'] = mid_pts[col].shift()
 
     mid_pts['left'] = mid_pts.apply(lambda row: (row[col] if pd.isna(row['shift'])
-                                                   else 0.5 * (row[col] + row['shift'])), axis=1)
+                                                 else 0.5 * (row[col] + row['shift'])), axis=1)
 
     return mid_pts.set_index(col)['left']
 

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -94,14 +94,14 @@ class Interpolation:
             sub_tables = interpolants.groupby(list(self.key_columns))
         else:
             sub_tables = [(None, interpolants)]
+        # specify some numeric type for columns so they won't be objects but will updated with whatever
+        # column type actually is
         result = pd.DataFrame(index=interpolants.index, columns=self.value_columns, dtype=np.float64)
         for key, sub_table in sub_tables:
             if sub_table.empty:
                 continue
             if self.order == 0: # we can interpolate all value columns at once
                 df = self.interpolations[key](sub_table)
-                #for v in self.value_columns:
-                #    result.loc[sub_table.index, v] = df.loc[sub_table.index, v]
                 result.loc[sub_table.index, self.value_columns] = df.loc[sub_table.index, self.value_columns]
             else:
                 funcs = self.interpolations[key]

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -303,9 +303,10 @@ class Order0Interp:
             merge_cols.append(cols[1])
             interpolant_col = interpolants[cols[0]]
             if not self.extrapolate and (interpolant_col.min() < bins[0] or interpolant_col.max() >= max_right):
-                raise NotImplementedError(f'Extrapolation outside of bins used to set up interpolation '
-                                          f'is not supported. Parameter {cols[0]} includes data outside '
-                                          f'of original bins.')
+                raise ValueError(f'Extrapolation outside of bins used to set up interpolation is only allowed '
+                                 f'when explicitly set in creation of Interpolation. Extrapolation is currently '
+                                 f'off for this interpolation, and parameter {cols[0]} includes data outside of '
+                                 f'original bins.')
             bin_indices = np.digitize(interpolant_col, bins)
             # digitize uses 0 to indicate < min and len(bins) for > max so adjust to actual indices into bin_indices
             bin_indices = [x-1 if x > 0 else x for x in bin_indices]

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -255,7 +255,7 @@ class Order0Interp:
 
         """
         check_data_complete(data, parameter_columns)
-        self.data = data
+        self.data = data.copy()
         self.value_columns = value_columns
 
         # (column name used in call, column name for left edge): [ordered left edges of bins]

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -8,6 +8,9 @@ class Interpolation:
     def __init__(self, data: pd.DataFrame, categorical_parameters: Sequence[str],
                  continuous_parameters: Sequence[str], order: int):
 
+        if order != 0:
+            raise NotImplementedError(f'Only order 0 interpolations are supported.You specified {order}')
+
         self.key_columns = categorical_parameters
         self.parameter_columns, self._data = validate_parameters(data, continuous_parameters, order)
 

--- a/src/vivarium/interpolation.py
+++ b/src/vivarium/interpolation.py
@@ -155,3 +155,29 @@ def validate_call_data(data, key_columns, parameter_columns):
                          f'be present in the data you call it on. The Interpolation has key'
                          f'columns: {key_columns} and your data has columns: '
                          f'{data.columns.values.tolist()}')
+
+
+def check_data_complete(data, parameter_columns):
+    """ For any parameters specified with edges, make sure edges
+    don't overlap and don't have any gaps. Assumes that edges are
+    specified with ends and starts overlapping (but one exclusive and
+    the other inclusive) so can check that end of previous == start
+    of current.
+
+    """
+
+    param_edges = [p for p in parameter_columns if isinstance(p, (Tuple, List))]
+
+    for p in param_edges:
+        param_data = data[[p[0], p[1]]].copy().sort_values(by=p[0])
+        start, end = param_data[p[0]].reset_index(drop=True), param_data[p[1]].reset_index(drop=True)
+
+        for i in range(1, len(start)):
+            if end[i-1] != start[i]:
+                raise NotImplementedError(f'Interpolation only supported for parameter columns '
+                                          f'with continuous, non-overlapping bins. Parameter {p} '
+                                          f'has an overlap or gap between {start[i-1]}-'
+                                          f'{end[i-1]} and {start[i]}-{end[i]}')
+
+
+

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -120,8 +120,10 @@ def build_table(value, year_start, year_end, columns=('age', 'year', 'sex', 'val
                         r_values.append(v(age, sex, year))
                     else:
                         r_values.append(v)
-                rows.append([age, year, sex] + r_values)
-    return pd.DataFrame(rows, columns=['age', 'year', 'sex'] + list(value_columns))
+                rows.append([age, age, age+1, year, year, year+1, sex] + r_values)
+    return pd.DataFrame(rows, columns=['age', 'age_group_start', 'age_group_end',
+                                       'year', 'year_start', 'year_end', 'sex']
+                                      + list(value_columns))
 
 
 def make_dummy_column(name, initial_value):

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -13,7 +13,8 @@ def test_interpolated_tables(base_config):
     one_d_age = ages.copy()
     del one_d_age['year']
     one_d_age = one_d_age.drop_duplicates()
-    base_config.population.update({'population_size': 10000})
+    base_config.population.update({'population_size': 10000,})
+    base_config.interpolation.update({'order': 1})  # the results we're checking later assume interp order 1
 
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
@@ -54,6 +55,7 @@ def test_interpolated_tables_without_uninterpolated_columns(base_config):
     del years['sex']
     years = years.drop_duplicates()
     base_config.population.update({'population_size': 10000})
+    base_config.interpolation.update({'order': 1})  # the results we're checking later assume interp order 1
 
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -138,8 +138,8 @@ def test_lookup_table_interpolated_return_types(base_config):
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
     table = (manager.build_table(data, key_columns=('sex',),
-                                 parameter_columns=(['age', 'age_group_start', 'age_group_end'],
-                                                    ['year', 'year_start', 'year_end'],),
+                                 parameter_columns=[['age', 'age_group_start', 'age_group_end'],
+                                                    ['year', 'year_start', 'year_end']],
                                  value_columns=None)(simulation.population.population.index))
     # make sure a single value column is returned as a series
     assert isinstance(table, pd.Series)
@@ -147,8 +147,8 @@ def test_lookup_table_interpolated_return_types(base_config):
     # now add a second value column to make sure the result is a df
     data['value2'] = data.value
     table = (manager.build_table(data, key_columns=('sex',),
-                                 parameter_columns=(['age', 'age_group_start', 'age_group_end'],
-                                                    ['year', 'year_start', 'year_end'],),
+                                 parameter_columns=[['age', 'age_group_start', 'age_group_end'],
+                                                    ['year', 'year_start', 'year_end']],
                                  value_columns=None)(simulation.population.population.index))
 
     assert isinstance(table, pd.DataFrame)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -195,3 +195,20 @@ def test_order0interp():
     result = interp(interpolants)
     assert result.equals(pd.DataFrame({'value': [3, 4, 1, 7, 3]}))
 
+
+def test_order_zero_with_key_column():
+    data = pd.DataFrame({'year_start': [1990, 1990, 1995, 1995],
+                         'year_end': [1995, 1995, 2000, 2000],
+                         'sex': ['Male', 'Female', 'Male', 'Female'],
+                         'value_1': [10, 7, 2, 12],
+                         'value_2': [1200, 1350, 1476, 1046]})
+
+    i = Interpolation(data, ['sex',], [('year', 'year_start', 'year_end'),], 0)
+
+    query = pd.DataFrame({'year': [1992, 1993,],
+                          'sex': ['Male', 'Female']})
+
+    expected_result = pd.DataFrame({'value_1': [10, 7],
+                                    'value_2': [1200, 1350]})
+
+    assert i(query).equals(expected_result)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -244,3 +244,34 @@ def test_order_zero_no_bins_2d():
                                    index=[1, 2, 17, 5, -1])
 
     assert i(query).equals(expected_result)
+
+
+def test_order_zero_created_bins_equal_explicit_bins():
+    data_midpt = pd.DataFrame({'year': [1990]*4 + [1991]*4,
+                               'sex': ['Male', 'Female']*4,
+                               'age': [15, 24, 24, 15]*2,
+                               'value_1': [10, 7, 2, 12, 6, 15, 27, -1],
+                               'value_2': [1200, 1350, 1476, 1046, 1520, -602, 1528, 0]})
+
+    data_binned = pd.DataFrame({'year_start': [1980.5]*4 + [1990.5]*4,
+                                'year_end': [1990.5]*4 + [1991]*4,
+                                'sex': ['Male', 'Female']*4,
+                                'age_start': [11.5, 19.5, 19.5, 11.5]*2,
+                                'age_end': [19.5, 24, 24, 19.5]*2,
+                                'value_1': [10, 7, 2, 12, 6, 15, 27, -1],
+                                'value_2': [1200, 1350, 1476, 1046, 1520, -602, 1528, 0]})
+
+    i_midpt = Interpolation(data_midpt, ['sex'], ['year', 'age'], 0)
+
+    i_binned = Interpolation(data_binned, ['sex'], [('year', 'year_start', 'year_end'),
+                                                    ('age', 'age_start', 'age_end')], 0)
+
+    query = pd.DataFrame({'year': [1990.45, 1990.5001, 1991, 1990.7, 2007],
+                          'sex': ['Male', 'Female', 'Female', 'Male', 'Female'],
+                          'age': [15, 19.5, 19.45, 20, 16],},
+                         index=[1, 2, 17, 5, -1])
+
+    result_midpt = i_midpt(query)
+    result_binned = i_binned(query)
+
+    assert result_midpt.equals(result_binned)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -30,6 +30,7 @@ def make_bin_edges(data: pd.DataFrame, col: str) -> pd.DataFrame:
 
     return data.set_index(idx)
 
+
 @pytest.mark.skip(reason="only order 0 interpolation currently supported")
 def test_1d_interpolation():
     df = pd.DataFrame({'a': np.arange(100), 'b': np.arange(100), 'c': np.arange(100, 0, -1)})
@@ -181,8 +182,8 @@ def test_validate_parameters__empty_data():
         out, data, _ = validate_parameters(pd.DataFrame(columns=["age_group_left", "age_group_right",
                                                                  "sex", "year_left", "year_right",
                                                                  "value"]), ["sex"],
-                                        [("age", "age_group_left", "age_group_right"),
-                                         ["year", "year_left", "year_right"]], 1)
+                                           [("age", "age_group_left", "age_group_right"),
+                                            ["year", "year_left", "year_right"]], 1)
     assert len(record) == 2
     message = record[0].message.args[0] + " " + record[1].message.args[0]
     assert "age" in message and "year" in message

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -276,22 +276,19 @@ def test_order_zero_created_bins_equal_explicit_bins():
 
     assert result_midpt.equals(result_binned)
 
+
 def test_order_zero_non_numeric_values():
     data = pd.DataFrame({'year': [1990, 1990],
                          'age': [15, 24,],
                          'value_1': ['blue', 'red']})
 
-    i = Interpolation(data, ['year', 'age'], 0)
+    i = Interpolation(data, (), ['year', 'age'], 0)
 
     query = pd.DataFrame({'year': [1990, 1990],
                           'age': [15, 20,]},
-                         index=[1, 2])
+                         index=[1, 0])
 
-    import pdb
-    pdb.set_trace()
-
-    expected_result = pd.DataFrame({'value_1': [10.0, 15.0, -1.0, 27.0, -1.0],
-                                    'value_2': [1200.0, -602.0, 0.0, 1528.0, 0.0]},
-                                   index=[1, 2, 17, 5, -1])
+    expected_result = pd.DataFrame({'value_1': ['blue', 'red']},
+                                   index=[1, 0])
 
     assert i(query).equals(expected_result)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -2,6 +2,7 @@ import pytest
 
 import pandas as pd
 import numpy as np
+import itertools
 
 from vivarium.interpolation import Interpolation, validate_parameters
 
@@ -28,11 +29,34 @@ def test_age_year_interpolation():
             for sex in ['Male', 'Female']:
                 data.append({'age': age, 'sex': sex, 'year': year, 'pop': pop})
     df = pd.DataFrame(data)
+
     df = df.sample(frac=1)  # Shuffle table to assure interpolation works given unsorted input
 
     i = Interpolation(df, ('sex', 'age'), ('year',), 1)
+    query = pd.DataFrame({'year': [1990, 1990], 'age': [35, 35], 'sex': ['Male', 'Female']})
+    assert np.allclose(i(query), 388.5)
 
-    assert np.allclose(i(year=[1990, 1990], age=[35, 35], sex=['Male', 'Female']), 388.5)
+
+def test_interpolation_called_missing_key_col():
+    a = [range(1990, 1995), range(25, 30), ['Male', 'Female']]
+    df = pd.DataFrame(list(itertools.product(*a)), columns=['year', 'age', 'sex'])
+    df['pop'] = df.age * 11.1
+    df = df.sample(frac=1)  # Shuffle table to assure interpolation works given unsorted input
+    i = Interpolation(df, ['sex',], ['year','age'], 1)
+    query = pd.DataFrame({'year': [1990, 1990], 'age': [35, 35]})
+    with pytest.raises(ValueError):
+        i(query)
+
+
+def test_interpolation_called_missing_param_col():
+    a = [range(1990, 1995), range(25, 30), ['Male', 'Female']]
+    df = pd.DataFrame(list(itertools.product(*a)), columns=['year', 'age', 'sex'])
+    df['pop'] = df.age * 11.1
+    df = df.sample(frac=1)  # Shuffle table to assure interpolation works given unsorted input
+    i = Interpolation(df, ['sex',], ['year','age'], 1)
+    query = pd.DataFrame({'year': [1990, 1990], 'sex': ['Male', 'Female']})
+    with pytest.raises(ValueError):
+        i(query)
 
 
 def test_2d_interpolation():
@@ -66,17 +90,6 @@ def test_interpolation_with_categorical_parameters():
     assert np.allclose(np.arange(100, 0, step=-0.01), i(query_two))
 
 
-def test_interpolation_with_function():
-    df = pd.DataFrame({'a': np.arange(100), 'b': np.arange(100), 'c': np.arange(100, 0, -1)})
-    df = df.sample(frac=1)  # Shuffle table to assure interpolation works given unsorted input
-
-    i = Interpolation(df, (), ('a',), 1, func=lambda x: x * 2,)
-
-    query = pd.DataFrame({'a': np.arange(100, step=0.01)})
-
-    assert np.allclose(query.a * 2, i(query).b)
-
-
 def test_order_zero_2d():
     a = np.mgrid[0:5, 0:5][0].reshape(25)
     b = np.mgrid[0:5, 0:5][1].reshape(25)
@@ -95,10 +108,10 @@ def test_order_zero_1d():
     s = pd.Series({0: 0, 1: 1}).reset_index()
     f = Interpolation(s, tuple(), ('index', ), order=0)
 
-    assert f(index=[0])[0] == 0, 'should be precise at index values'
-    assert f(index=[1])[0] == 1
-    assert f(index=[2])[0] == 1, 'should be constant extrapolation outside of input range'
-    assert f(index=[-1])[0] == 0
+    assert f(pd.DataFrame({'index': [0]}))[0] == 0, 'should be precise at index values'
+    assert f(pd.DataFrame({'index': [1]}))[0] == 1
+    assert f(pd.DataFrame({'index': [2]}))[0] == 1, 'should be constant extrapolation outside of input range'
+    assert f(pd.DataFrame({'index': [-1]}))[0] == 0
 
 
 def test_validate_parameters__empty_data():

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import itertools
 
-from vivarium.interpolation import Interpolation, validate_parameters
+from vivarium.interpolation import Interpolation, validate_parameters, check_data_complete
 
 
 def test_1d_interpolation():
@@ -125,3 +125,15 @@ def test_validate_parameters__empty_data():
     assert set(data.columns) == {"sex", "value"}
 
 
+def test_check_data_complete():
+    data = pd.DataFrame({'year_start': [1995, 1990, 2000, 2005, 2010],
+                         'year_end': [2000, 1995, 2005, 2010, 2015],
+                         'age_start': [16, 10, 20, 25, 35],
+                         'age_end': [20, 15, 25, 35, 40],})
+
+    with pytest.raises(NotImplementedError) as error:
+        check_data_complete(data, [('year_start', 'year_end'), ['age_start', 'age_end']])
+
+    message = error.value.args[0]
+
+    assert "age_start" in message and "age_end" in message and "10-15" in message and "16-20" in message

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import itertools
 
-from vivarium.interpolation import Interpolation, validate_parameters, check_data_complete
+from vivarium.interpolation import Interpolation, validate_parameters, check_data_complete, make_left_edge
 
 
 def test_1d_interpolation():
@@ -162,3 +162,13 @@ def test_check_data_missing_combos():
     message = error.value.args[0]
 
     assert 'combination' in message
+
+
+def test_make_left_edge():
+    ages = [3, 7, 1]
+    data = pd.DataFrame({'age': ages, 'year': [1990, 1992, 1991]})
+    left_edge = make_left_edge(data, 'age')
+
+    expected_left = [2, 5, 1]
+    for i, a in enumerate(ages):
+        assert left_edge[a] == expected_left[i]

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -126,10 +126,10 @@ def test_validate_parameters__empty_data():
 
 
 def test_check_data_complete_gaps():
-    data = pd.DataFrame({'year_start': [1990, 1990, 1995, 2000, 2005],
-                         'year_end': [1995, 1995, 2000, 2005, 2010],
-                         'age_start': [16, 10, 20, 25, 35],
-                         'age_end': [20, 15, 25, 35, 40],})
+    data = pd.DataFrame({'year_start': [1990, 1990, 1995, 1995],
+                         'year_end': [1995, 1995, 2000, 2000],
+                         'age_start': [16, 10, 10, 16],
+                         'age_end': [20, 15, 15, 20],})
 
     with pytest.raises(NotImplementedError) as error:
         check_data_complete(data, [('year_start', 'year_end'), ['age_start', 'age_end']])

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -320,3 +320,17 @@ def test_order_zero_3d_with_key_col():
 
     result = interp(interpolants)
     assert result.equals(pd.DataFrame({'value': [3.0, 5.0, 2.0, 7.0, 3.0]}, index=[10, 4, 7, 0, 9]))
+
+
+def test_order_zero_diff_bin_sizes():
+    data = pd.DataFrame({'year_start': [1990, 1995, 1996, 2005, 2005.5,],
+                         'year_end': [1995, 1996, 2005, 2005.5, 2010],
+                         'value': [1, 5, 2.3, 6, 100]})
+
+    i = Interpolation(data, tuple(), [('year', 'year_start', 'year_end')], 0, False)
+
+    query = pd.DataFrame({'year': [2007, 1990, 2005.4, 1994, 2004, 1995, 2002, 1995.5, 1996]})
+
+    expected_result = pd.DataFrame({'value': [100, 1, 6, 1, 2.3, 5, 2.3, 5, 2.3]})
+
+    assert i(query).equals(expected_result)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -196,7 +196,7 @@ def test_order0interp():
     assert result.equals(pd.DataFrame({'value': [3, 4, 1, 7, 3]}))
 
 
-def test_order_zero_with_key_column():
+def test_order_zero_1d_with_key_column():
     data = pd.DataFrame({'year_start': [1990, 1990, 1995, 1995],
                          'year_end': [1995, 1995, 2000, 2000],
                          'sex': ['Male', 'Female', 'Male', 'Female'],
@@ -282,7 +282,7 @@ def test_order_zero_non_numeric_values():
                          'age': [15, 24,],
                          'value_1': ['blue', 'red']})
 
-    i = Interpolation(data, (), ['year', 'age'], 0)
+    i = Interpolation(data, tuple(), ['year', 'age'], 0)
 
     query = pd.DataFrame({'year': [1990, 1990],
                           'age': [15, 20,]},
@@ -292,3 +292,28 @@ def test_order_zero_non_numeric_values():
                                    index=[1, 0])
 
     assert i(query).equals(expected_result)
+
+
+def test_order_zero_3d_with_key_col():
+    data = pd.DataFrame({'year_start': [1990, 1990, 1990, 1990, 1995, 1995, 1995, 1995]*2,
+                         'year_end': [1995, 1995, 1995, 1995, 2000, 2000, 2000, 2000]*2,
+                         'age_start': [15, 10, 10, 15, 10, 10, 15, 15]*2,
+                         'age_end': [20, 15, 15, 20, 15, 15, 20, 20]*2,
+                         'height_start': [140, 160, 140, 160, 140, 160, 140, 160]*2,
+                         'height_end': [160, 180, 160, 180, 160, 180, 160, 180]*2,
+                         'sex': ['Male']*8+['Female']*8,
+                         'value': [5, 3, 1, 7, 8, 6, 4, 2, 6, 4, 2, 8, 9, 7, 5, 3]})
+
+    interp = Interpolation(data, ('sex',),
+                           [('age', 'age_start', 'age_end'),
+                            ('year', 'year_start', 'year_end'),
+                            ('height', 'height_start', 'height_end')], 0)
+
+    interpolants = pd.DataFrame({'age': [12, 17, 8, 25, 12],
+                                 'year': [1992, 1998, 1985, 1992, 1992],
+                                 'height': [160, 145, 110, 185, 160],
+                                 'sex': ['Male', 'Female', 'Female', 'Male', 'Male']},
+                                index=[10, 4, 7, 0, 9])
+
+    result = interp(interpolants)
+    assert result.equals(pd.DataFrame({'value': [3.0, 5.0, 2.0, 7.0, 3.0]}, index=[10, 4, 7, 0, 9]))

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -168,7 +168,7 @@ def test_order_zero_1d_no_extrapolation():
     assert f(pd.DataFrame({'index': [0.999]}))[0][0] == 1
 
     with pytest.raises(ValueError) as error:
-        f(pd.DataFrame({'index': [1]}))[0][0] == 1
+        f(pd.DataFrame({'index': [1]}))
 
     message = error.value.args[0]
     assert 'Extrapolation' in message and 'index' in message

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -125,9 +125,9 @@ def test_validate_parameters__empty_data():
     assert set(data.columns) == {"sex", "value"}
 
 
-def test_check_data_complete():
-    data = pd.DataFrame({'year_start': [1995, 1990, 2000, 2005, 2010],
-                         'year_end': [2000, 1995, 2005, 2010, 2015],
+def test_check_data_complete_gaps():
+    data = pd.DataFrame({'year_start': [1990, 1990, 1995, 2000, 2005],
+                         'year_end': [1995, 1995, 2000, 2005, 2010],
                          'age_start': [16, 10, 20, 25, 35],
                          'age_end': [20, 15, 25, 35, 40],})
 
@@ -136,4 +136,29 @@ def test_check_data_complete():
 
     message = error.value.args[0]
 
-    assert "age_start" in message and "age_end" in message and "10-15" in message and "16-20" in message
+    assert "age_start" in message and "age_end" in message
+
+
+def test_check_data_complete_overlap():
+    data = pd.DataFrame({'year_start': [1995, 1995, 2000, 2005, 2010],
+                         'year_end': [2000, 2000, 2005, 2010, 2015]})
+
+    with pytest.raises(ValueError) as error:
+        check_data_complete(data, [('year_start', 'year_end')])
+
+    message = error.value.args[0]
+
+    assert "year_start" in message and "year_end" in message
+
+
+def test_check_data_missing_combos():
+    data = pd.DataFrame({'year': [1990, 1990, 1995],
+                         'age_start': [10, 15, 10],
+                         'age_end': [15, 20, 15]})
+
+    with pytest.raises(ValueError) as error:
+        check_data_complete(data, ['year', ('age_start', 'age_end')])
+
+    message = error.value.args[0]
+
+    assert 'combination' in message

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -4,7 +4,7 @@ import pandas as pd
 import numpy as np
 import itertools
 
-from vivarium.interpolation import Interpolation, validate_parameters, check_data_complete, make_left_edge
+from vivarium.interpolation import Interpolation, validate_parameters, check_data_complete, make_left_edge, Order0Interp
 
 
 def test_1d_interpolation():
@@ -172,3 +172,26 @@ def test_make_left_edge():
     expected_left = [2, 5, 1]
     for i, a in enumerate(ages):
         assert left_edge[a] == expected_left[i]
+
+
+def test_order0interp():
+    data = pd.DataFrame({'year_start': [1990, 1990, 1990, 1990, 1995, 1995, 1995, 1995],
+                         'year_end': [1995, 1995, 1995, 1995, 2000, 2000, 2000, 2000],
+                         'age_start': [15, 10, 10, 15, 10, 10, 15, 15],
+                         'age_end': [20, 15, 15, 20, 15, 15, 20, 20],
+                         'height_start': [140, 160, 140, 160, 140, 160, 140, 160],
+                         'height_end': [160, 180, 160, 180, 160, 180, 160, 180],
+                         'value': [5, 3, 1, 7, 8, 6, 4, 2]})
+
+    interp = Order0Interp(data, [('age', 'age_start', 'age_end'),
+                                 ('year', 'year_start', 'year_end'),
+                                 ('height', 'height_start', 'height_end'),]
+                          , ['value'])
+
+    interpolants = pd.DataFrame({'age': [12, 17, 8, 25, 12],
+                                 'year': [1992, 1998, 1985, 1992, 1992],
+                                 'height': [160, 145, 110, 185, 160]})
+
+    result = interp(interpolants)
+    assert result.equals(pd.DataFrame({'value': [3, 4, 1, 7, 3]}))
+

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -108,6 +108,9 @@ def test_order_zero_1d():
     s = pd.Series({0: 0, 1: 1}).reset_index()
     f = Interpolation(s, tuple(), ('index', ), order=0)
 
+    df = pd.DataFrame({'index': [0, 1, 1]}, index=[3, 7, 2])
+    f(df)
+
     assert f(pd.DataFrame({'index': [0]}))[0][0] == 0, 'should be precise at index values'
     assert f(pd.DataFrame({'index': [1]}))[0][0] == 1
     assert f(pd.DataFrame({'index': [2]}))[0][0] == 1, 'should be constant extrapolation outside of input range'
@@ -208,7 +211,7 @@ def test_order_zero_with_key_column():
     query = pd.DataFrame({'year': [1992, 1993,],
                           'sex': ['Male', 'Female']})
 
-    expected_result = pd.DataFrame({'value_1': [10, 7],
-                                    'value_2': [1200, 1350]})
+    expected_result = pd.DataFrame({'value_1': [10.0, 7.0],
+                                    'value_2': [1200.0, 1350.0]})
 
     assert i(query).equals(expected_result)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -132,7 +132,7 @@ def test_check_data_complete_gaps():
                          'age_end': [20, 15, 15, 20],})
 
     with pytest.raises(NotImplementedError) as error:
-        check_data_complete(data, [('year_start', 'year_end'), ['age_start', 'age_end']])
+        check_data_complete(data, [('year', 'year_start', 'year_end'), ['age', 'age_start', 'age_end']])
 
     message = error.value.args[0]
 
@@ -144,7 +144,7 @@ def test_check_data_complete_overlap():
                          'year_end': [2000, 2000, 2005, 2010, 2015]})
 
     with pytest.raises(ValueError) as error:
-        check_data_complete(data, [('year_start', 'year_end')])
+        check_data_complete(data, [('year', 'year_start', 'year_end')])
 
     message = error.value.args[0]
 
@@ -157,7 +157,7 @@ def test_check_data_missing_combos():
                          'age_end': [15, 20, 15]})
 
     with pytest.raises(ValueError) as error:
-        check_data_complete(data, ['year', ('age_start', 'age_end')])
+        check_data_complete(data, ['year', ('age', 'age_start', 'age_end')])
 
     message = error.value.args[0]
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -275,3 +275,23 @@ def test_order_zero_created_bins_equal_explicit_bins():
     result_binned = i_binned(query)
 
     assert result_midpt.equals(result_binned)
+
+def test_order_zero_non_numeric_values():
+    data = pd.DataFrame({'year': [1990, 1990],
+                         'age': [15, 24,],
+                         'value_1': ['blue', 'red']})
+
+    i = Interpolation(data, ['year', 'age'], 0)
+
+    query = pd.DataFrame({'year': [1990, 1990],
+                          'age': [15, 20,]},
+                         index=[1, 2])
+
+    import pdb
+    pdb.set_trace()
+
+    expected_result = pd.DataFrame({'value_1': [10.0, 15.0, -1.0, 27.0, -1.0],
+                                    'value_2': [1200.0, -602.0, 0.0, 1528.0, 0.0]},
+                                   index=[1, 2, 17, 5, -1])
+
+    assert i(query).equals(expected_result)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -116,7 +116,8 @@ def test_order_zero_1d():
 
 def test_validate_parameters__empty_data():
     with pytest.warns(UserWarning) as record:
-        out, data = validate_parameters(pd.DataFrame(columns=["age", "sex", "year", "value"]), ["age", "year"], 1)
+        out, data, _ = validate_parameters(pd.DataFrame(columns=["age", "sex", "year", "value"]), ["sex"],
+                                        ["age", "year"], 1)
     assert len(record) == 2
     message = record[0].message.args[0] + " " + record[1].message.args[0]
     assert "age" in message and "year" in message

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -108,7 +108,7 @@ def test_order_zero_1d():
     s = pd.Series({0: 0, 1: 1}).reset_index()
     f = Interpolation(s, tuple(), ('index', ), order=0)
 
-    df = pd.DataFrame({'index': [0, 1, 1]}, index=[3, 7, 2])
+    df = pd.DataFrame({'index': [1, 0, 1, 1]}, index=[12, 3, 7, 2])
     f(df)
 
     assert f(pd.DataFrame({'index': [0]}))[0][0] == 0, 'should be precise at index values'


### PR DESCRIPTION
Probably easier if you review the refactor PR first, which cleans up the code a bunch. This PR is just the added order 0/bin edges functionality. 

Adds order 0 interpolation with bin edges for any number of parameters. Requires bin edges for all continuous parameters. Uses start of bin as inclusive and end as exclusive (which is how gbd age bins are constructed). 

For now only allows order 0 interpolation (order 1 hasn't been updated to use bin edges).

Adds an 'extrapolate' option to the interpolation config that allows constant (for order 0) extrapolation beyond bin edges.

All smoke tests run with interpolation order set to 0. See attached files for how changing order to 0 changes incidence rate pipeline in sim. 
![incidence_rate_pipeline_order0](https://user-images.githubusercontent.com/33732724/46965814-b6604380-d060-11e8-82c2-ef24077c3249.png)
![incidence_rate_pipeline_order1](https://user-images.githubusercontent.com/33732724/46965816-b6604380-d060-11e8-8726-ea771cee56c6.png)



