### PR TITLE
Bugfix/supports yml

### DIFF
--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -348,7 +348,7 @@ class ConfigTree:
             # TODO: set this to parse the other config tree including layer and source info.  Maybe.
             self._read_dict(data.to_dict(), layer, source)
         elif isinstance(data, str):
-            if data.endswith('.yaml'):
+            if data.endswith(('.yaml', '.yml')):
                 source = source if source else data
                 self._load(data, layer, source)
             else:

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -352,7 +352,10 @@ class ConfigTree:
                 source = source if source else data
                 self._load(data, layer, source)
             else:
-                self._loads(data, layer, source)
+                try:
+                    self._loads(data, layer, source)
+                except AttributeError:
+                    raise ValueError("The string data should be yaml formated string or path to .yaml/.yml file")
         elif data is None:
             pass
         else:

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -1,4 +1,6 @@
+import os
 import pytest
+import yaml
 
 from vivarium.config_tree import ConfigTree
 
@@ -185,3 +187,28 @@ def test_unused_keys():
     _ = d.test_key.test_key3
 
     assert not d.unused_keys()
+
+
+def test_update():
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+
+    config = ConfigTree()
+    test_dict = {'configuration': {'time': {'start': {'year': 2000}}}}
+    config.update(test_dict)
+    assert config.to_dict() == test_dict
+
+    test_yaml = test_dir + '/../test_data/mock_model_specification.yaml'
+    config.update(test_yaml)
+    with open(test_yaml) as f:
+        yaml_config = yaml.load(f)
+    assert yaml_config == config.to_dict()
+
+    test_yml = test_dir + '/../test_data/mock_model_specification.yml'
+    config.update(test_yml)
+    with open(test_yml) as f:
+        yml_config = yaml.load(f)
+    assert yml_config == config.to_dict()
+
+    non_yaml_file = test_dir + '/../test_data/bad_model_specifiaction.txt'
+    with pytest.raises(ValueError):
+        config.update(non_yaml_file)

--- a/tests/framework/test_configuration.py
+++ b/tests/framework/test_configuration.py
@@ -90,10 +90,12 @@ def test_build_model_specification_failure():
         build_model_specification(model_spec)
 
 
-def test_build_model_specification(mocker):
+@pytest.mark.parametrize('user_config_ext', ['.yaml', '.yml'])
+@pytest.mark.parametrize('model_config_ext', ['.yaml', '.yml'])
+def test_build_model_specification(mocker, user_config_ext, model_config_ext):
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config.yaml'
-    model_spec = test_dir + '/../test_data/mock_model_specification.yaml'
+    user_config = test_dir + '/../test_data/mock_user_config' + user_config_ext
+    model_spec = test_dir + '/../test_data/mock_model_specification' + model_config_ext
 
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
     expand_user_mock.return_value = user_config

--- a/tests/test_data/mock_model_specification.yml
+++ b/tests/test_data/mock_model_specification.yml
@@ -1,0 +1,17 @@
+components:
+    vivarium:
+        test_util:
+            - TestPopulation()
+        framework:
+            - randomness.RandomnessManager()
+            - event.EventManager()
+
+configuration:
+    time:
+        start:
+            year: 2000
+        end:
+            year: 2005
+        step_size: 30.5  # Days
+    randomness:
+        map_size: 1000

--- a/tests/test_data/mock_user_config.yml
+++ b/tests/test_data/mock_user_config.yml
@@ -1,0 +1,2 @@
+my_guitar_amp:
+    volume_setting: 15


### PR DESCRIPTION
This PR is a quick fix for yml file error. It should work without try-except block in config_tree.py. But we currently allow users to pass in string data (not only the file path) to update the ConfigTree and if it's not type of .yml/.yaml, users end up getting an error message not clear to understand what is wrong (just like this case with .yml when only .yaml is accepted). So I just add the except block to catch whenever the user provide some other file type (like .txt).  