### PR TITLE
Feature/extend interactive context

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -48,7 +48,7 @@ class SimulationContext:
         self.component_manager.add_managers(
             [self.clock, self.population, self.randomness, self.values, self.events, self.tables])
         self.component_manager.add_managers(list(plugin_manager.get_optional_controllers().values()))
-        self.component_manager.add_components(components + [Metrics()])
+        self.add_components(components + [Metrics()])
 
     def setup(self):
         self.component_manager.setup_components(self.builder, self.configuration)
@@ -58,8 +58,8 @@ class SimulationContext:
         self.time_step_events = ['time_step__prepare', 'time_step', 'time_step__cleanup', 'collect_metrics']
         self.time_step_emitters = {k: self.builder.event.get_emitter(k) for k in self.time_step_events}
         self.end_emitter = self.builder.event.get_emitter('simulation_end')
-        self.builder.event.get_emitter('post_setup')(None)
         self._setup = True
+        self.builder.event.get_emitter('post_setup')(None)
 
     def step(self):
         _log.debug(self.clock.time)

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -7,7 +7,7 @@ from vivarium.config_tree import ConfigTree
 
 from .utilities import run_from_ipython, log_progress, raise_if_not_setup
 
-from typing import Mapping, Union, List
+from typing import Mapping, List
 
 
 class InteractiveContext(SimulationContext):
@@ -117,7 +117,7 @@ class InteractiveContext(SimulationContext):
         self.component_manager.add_components([new_component])
 
 
-def initialize_simulation(components: List, input_config: Union[Mapping, ConfigTree]=None,
+def initialize_simulation(components: List, input_config: Mapping=None,
                           plugin_config: Mapping=None) -> InteractiveContext:
     config = build_simulation_configuration()
     config.update(input_config)
@@ -126,7 +126,7 @@ def initialize_simulation(components: List, input_config: Union[Mapping, ConfigT
     return InteractiveContext(config, components, plugin_manager)
 
 
-def setup_simulation(components: List, input_config: Union[Mapping, ConfigTree]=None,
+def setup_simulation(components: List, input_config: Mapping=None,
                      plugin_config: Mapping=None) -> InteractiveContext:
     simulation = initialize_simulation(components, input_config, plugin_config)
     simulation.setup()

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -4,7 +4,7 @@ from vivarium.framework.configuration import build_simulation_configuration, bui
 from vivarium.framework.plugins import PluginManager
 from vivarium.framework.engine import SimulationContext
 
-from .utilities import run_from_ipython, log_progress, raise_if_not_setup
+from .utilities import run_from_ipython, log_progress, raise_if_not_setup, InteractiveError
 
 
 class InteractiveContext(SimulationContext):
@@ -115,6 +115,11 @@ class InteractiveContext(SimulationContext):
         new_component.setup(self.builder)
         self.component_manager.add_components([new_component])
 
+    def add_components(self, component_list):
+        if self._setup:
+            raise InteractiveError('Components cannot be added to a simulation once it is setup.')
+        self.component_manager.add_components(component_list)
+
 
 def initialize_simulation(components, input_config=None, plugin_config=None):
     config = build_simulation_configuration()
@@ -137,7 +142,8 @@ def initialize_simulation_from_model_specification(model_specification_file):
     plugin_config = model_specification.plugins
     component_config = model_specification.components
     simulation_config = model_specification.configuration
-
+    import pdb
+    pdb.set_trace()
     plugin_manager = PluginManager(plugin_config)
     component_config_parser = plugin_manager.get_plugin('component_configuration_parser')
     components = component_config_parser.get_components(component_config)

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -142,8 +142,7 @@ def initialize_simulation_from_model_specification(model_specification_file):
     plugin_config = model_specification.plugins
     component_config = model_specification.components
     simulation_config = model_specification.configuration
-    import pdb
-    pdb.set_trace()
+
     plugin_manager = PluginManager(plugin_config)
     component_config_parser = plugin_manager.get_plugin('component_configuration_parser')
     components = component_config_parser.get_components(component_config)

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -5,7 +5,7 @@ from vivarium.framework.plugins import PluginManager
 from vivarium.framework.engine import SimulationContext
 from vivarium.config_tree import ConfigTree
 
-from .utilities import run_from_ipython, log_progress, raise_if_not_setup, InteractiveError
+from .utilities import run_from_ipython, log_progress, raise_if_not_setup
 
 from typing import Mapping, Union, List
 
@@ -15,13 +15,11 @@ class InteractiveContext(SimulationContext):
     def __init__(self, configuration, components, plugin_manager=None):
         super().__init__(configuration, components, plugin_manager)
         self._initial_population = None
-        self._setup = False
 
     def setup(self):
         super().setup()
         self._start_time = self.clock.time
         self.initialize_simulants()
-        self._setup = True
 
     def initialize_simulants(self):
         super().initialize_simulants()
@@ -117,11 +115,6 @@ class InteractiveContext(SimulationContext):
         self.component_manager._components.remove(old_component)
         new_component.setup(self.builder)
         self.component_manager.add_components([new_component])
-
-    def add_components(self, component_list):
-        if self._setup:
-            raise InteractiveError('Components cannot be added to a simulation once it is setup.')
-        self.component_manager.add_components(component_list)
 
 
 def initialize_simulation(components: List, input_config: Union[Mapping, ConfigTree]=None,

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -3,8 +3,11 @@ from math import ceil
 from vivarium.framework.configuration import build_simulation_configuration, build_model_specification
 from vivarium.framework.plugins import PluginManager
 from vivarium.framework.engine import SimulationContext
+from vivarium.config_tree import ConfigTree
 
 from .utilities import run_from_ipython, log_progress, raise_if_not_setup, InteractiveError
+
+from typing import Mapping, Union, List
 
 
 class InteractiveContext(SimulationContext):
@@ -121,7 +124,8 @@ class InteractiveContext(SimulationContext):
         self.component_manager.add_components(component_list)
 
 
-def initialize_simulation(components, input_config=None, plugin_config=None):
+def initialize_simulation(components: List, input_config: Union[Mapping, ConfigTree]=None,
+                          plugin_config: Mapping=None) -> InteractiveContext:
     config = build_simulation_configuration()
     config.update(input_config)
     plugin_manager = PluginManager(plugin_config)
@@ -129,14 +133,15 @@ def initialize_simulation(components, input_config=None, plugin_config=None):
     return InteractiveContext(config, components, plugin_manager)
 
 
-def setup_simulation(components, input_config=None, plugin_config=None):
+def setup_simulation(components: List, input_config: Union[Mapping, ConfigTree]=None,
+                     plugin_config: Mapping=None) -> InteractiveContext:
     simulation = initialize_simulation(components, input_config, plugin_config)
     simulation.setup()
 
     return simulation
 
 
-def initialize_simulation_from_model_specification(model_specification_file):
+def initialize_simulation_from_model_specification(model_specification_file: str) -> InteractiveContext:
     model_specification = build_model_specification(model_specification_file)
 
     plugin_config = model_specification.plugins
@@ -150,7 +155,7 @@ def initialize_simulation_from_model_specification(model_specification_file):
     return InteractiveContext(simulation_config, components, plugin_manager)
 
 
-def setup_simulation_from_model_specification(model_specification_file):
+def setup_simulation_from_model_specification(model_specification_file: str) -> InteractiveContext:
     simulation = initialize_simulation_from_model_specification(model_specification_file)
     simulation.setup()
 

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -110,12 +110,6 @@ class InteractiveContext(SimulationContext):
     def reload_component(self, component):
         raise NotImplementedError()
 
-    @raise_if_not_setup(system_type='component')
-    def replace_component(self, old_component, new_component):
-        self.component_manager._components.remove(old_component)
-        new_component.setup(self.builder)
-        self.component_manager.add_components([new_component])
-
 
 def initialize_simulation(components: List, input_config: Mapping=None,
                           plugin_config: Mapping=None) -> InteractiveContext:


### PR DESCRIPTION
Adding an add components method to InteractiveContext that Abie had patched in in ceam experiments

Adding type hints because I got a little confused trying to extend these in public health when I thought plugin config could be more types than it is 