### PR TITLE
Bugfix/state transition series

### DIFF
--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -61,7 +61,7 @@ def _groupby_new_state(index, outputs, decisions):
     """
     output_map = {o: i for i, o in enumerate(outputs)}
     groups = pd.Series(index).groupby([output_map[d] for d in decisions])
-    results = [(outputs[i], sub_group.index) for i, sub_group in groups]
+    results = [(outputs[i], pd.Index(sub_group.values)) for i, sub_group in groups]
     selected_outputs = [o for o, _ in results]
     for output in outputs:
         if output not in selected_outputs:

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -61,7 +61,7 @@ def _groupby_new_state(index, outputs, decisions):
     """
     output_map = {o: i for i, o in enumerate(outputs)}
     groups = pd.Series(index).groupby([output_map[d] for d in decisions])
-    results = [(outputs[i], sub_group) for i, sub_group in groups]
+    results = [(outputs[i], sub_group.index) for i, sub_group in groups]
     selected_outputs = [o for o, _ in results]
     for output in outputs:
         if output not in selected_outputs:


### PR DESCRIPTION
This addresses MIC-266.

The _groupby_new_state function was casting to a Series in order to use groupby() but was not re-casting to an index when collecting the results. This func isn't necessarily called each time through a state transition, and if it is called it ends up going back down _next_state with the grouped index which can lead to an index being transformed into a Series in what seems like an inconsistent or random way.

also, it passes smoke + unit tests