### PR TITLE
Bugfix/none in component config

### DIFF
--- a/src/vivarium/framework/components/parser.py
+++ b/src/vivarium/framework/components/parser.py
@@ -81,6 +81,8 @@ class ComponentConfigurationParser:
 
 def _parse_component_config(component_config: Union[List[str], Dict[str, Union[Dict, List]]]) -> List[str]:
 
+    _check_valid_component_config(component_config)
+
     def _process_level(level, prefix):
         if isinstance(level, list):
             return ['.'.join(prefix + [child]) for child in level]
@@ -93,6 +95,9 @@ def _parse_component_config(component_config: Union[List[str], Dict[str, Union[D
 
     return _process_level(component_config, [])
 
+def _check_valid_component_config(component_config: Union[List[str], Dict[str, Union[Dict, List]]]) -> bool:
+
+    import pdb; pdb.set_trace()
 
 def _prep_components(component_list: Sequence[str]) -> List[Tuple[str, Tuple[str]]]:
     """Transform component description strings into tuples of component paths and required arguments.

--- a/src/vivarium/framework/components/parser.py
+++ b/src/vivarium/framework/components/parser.py
@@ -81,9 +81,10 @@ class ComponentConfigurationParser:
 
 def _parse_component_config(component_config: Union[List[str], Dict[str, Union[Dict, List]]]) -> List[str]:
 
-    _check_valid_component_config(component_config)
-
     def _process_level(level, prefix):
+        if not level:
+            raise ParsingError(f'Check your configuration. Component {prefix} should not be left empty with the header')
+
         if isinstance(level, list):
             return ['.'.join(prefix + [child]) for child in level]
 
@@ -95,9 +96,6 @@ def _parse_component_config(component_config: Union[List[str], Dict[str, Union[D
 
     return _process_level(component_config, [])
 
-def _check_valid_component_config(component_config: Union[List[str], Dict[str, Union[Dict, List]]]) -> bool:
-
-    import pdb; pdb.set_trace()
 
 def _prep_components(component_list: Sequence[str]) -> List[Tuple[str, Tuple[str]]]:
     """Transform component description strings into tuples of component paths and required arguments.

--- a/tests/framework/components/test_parser.py
+++ b/tests/framework/components/test_parser.py
@@ -4,7 +4,7 @@ import yaml
 from vivarium.framework.configuration import build_simulation_configuration
 from vivarium.framework.components.parser import (ComponentConfigurationParser, _parse_component_config,
                                                   _prep_components, _import_and_instantiate_components,
-                                                  ParsingError, _check_valid_component_config)
+                                                  ParsingError)
 
 from .mocks import MockComponentA, MockComponentB
 
@@ -132,7 +132,7 @@ def test_ComponentConfigurationParser_get_components(import_and_instantiate_mock
     import_and_instantiate_mock.assert_called_once_with(TEST_COMPONENTS_PREPPED)
 
 
-def test__check_valid_component_config():
+def test_components_config_valid():
     bad_config = yaml.load(TEST_COMPONENTS_BAD)['components']
-    _check_valid_component_config(bad_config)
-    import pdb; pdb.set_trace()
+    with pytest.raises(ParsingError):
+        _parse_component_config(bad_config)

--- a/tests/framework/components/test_parser.py
+++ b/tests/framework/components/test_parser.py
@@ -4,7 +4,7 @@ import yaml
 from vivarium.framework.configuration import build_simulation_configuration
 from vivarium.framework.components.parser import (ComponentConfigurationParser, _parse_component_config,
                                                   _prep_components, _import_and_instantiate_components,
-                                                  ParsingError)
+                                                  ParsingError, _check_valid_component_config)
 
 from .mocks import MockComponentA, MockComponentB
 
@@ -18,6 +18,18 @@ components:
     pet_shop:
        - Parrot()
        - dangerous_animals.Crocodile('gold_tooth', 'teacup', '3.14')
+"""
+
+# common case when users comment out and ends up having none
+TEST_COMPONENTS_BAD = """
+components:
+    ministry.silly_walk:
+       - Prance()
+       - Jump('front_flip')
+       - PratFall('15')
+    pet_shop:
+#       - Parrot()
+#       - dangerous_animals.Crocodile('gold_tooth', 'teacup', '3.14')
 """
 
 TEST_COMPONENTS_FLAT = """
@@ -60,9 +72,9 @@ def import_and_instantiate_mock(mocker):
 
 
 def test_parse_component_config(components):
+
     source = yaml.load(components)['components']
     component_list = _parse_component_config(source)
-
     assert set(TEST_COMPONENTS_PARSED) == set(component_list)
 
 
@@ -118,3 +130,9 @@ def test_ComponentConfigurationParser_get_components(import_and_instantiate_mock
     parser.get_components(config.components)
 
     import_and_instantiate_mock.assert_called_once_with(TEST_COMPONENTS_PREPPED)
+
+
+def test__check_valid_component_config():
+    bad_config = yaml.load(TEST_COMPONENTS_BAD)['components']
+    _check_valid_component_config(bad_config)
+    import pdb; pdb.set_trace()


### PR DESCRIPTION
This is addressing MIC-281. During parsing, we check whether the component is left none and if so, we raise an error so that the user knows which component to look at. 