### PR TITLE
Bugfix/pipeline not filter untracked simulants

### DIFF
--- a/src/vivarium/examples/boids/visualization.py
+++ b/src/vivarium/examples/boids/visualization.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 def plot_birds(simulation, plot_velocity=False):
     width = simulation.configuration.location.width
     height = simulation.configuration.location.height
-    pop = simulation.population.population
+    pop = simulation.population._population
 
     plt.figure(figsize=[12, 12])
     plt.scatter(pop.x, pop.y, color=pop.color)

--- a/src/vivarium/examples/boids/visualization.py
+++ b/src/vivarium/examples/boids/visualization.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 def plot_birds(simulation, plot_velocity=False):
     width = simulation.configuration.location.width
     height = simulation.configuration.location.height
-    pop = simulation.population._population
+    pop = simulation.get_population()
 
     plt.figure(figsize=[12, 12])
     plt.scatter(pop.x, pop.y, color=pop.color)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -64,7 +64,7 @@ class SimulationContext:
     def step(self):
         _log.debug(self.clock.time)
         for event in self.time_step_events:
-            self.time_step_emitters[event](Event(self.population.population.index))
+            self.time_step_emitters[event](Event(self.population._population.index))
         self.clock.step_forward()
 
     def initialize_simulants(self):
@@ -77,10 +77,10 @@ class SimulationContext:
         self.clock.step_forward()
 
     def finalize(self):
-        self.end_emitter(Event(self.population.population.index))
+        self.end_emitter(Event(self.population._population.index))
 
     def report(self):
-        return self.values.get_value('metrics')(self.population.population.index)
+        return self.values.get_value('metrics')(self.population._population.index)
 
     def add_components(self, component_list):
         if self._setup:
@@ -158,4 +158,4 @@ def run(simulation):
     simulation.finalize()
     metrics = simulation.report()
     metrics['simulation_run_time'] = time() - start
-    return metrics, simulation.population.population
+    return metrics, simulation.population._population

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -64,7 +64,7 @@ class SimulationContext:
     def step(self):
         _log.debug(self.clock.time)
         for event in self.time_step_events:
-            self.time_step_emitters[event](Event(self.population._population.index))
+            self.time_step_emitters[event](Event(self.population.get_population(True).index))
         self.clock.step_forward()
 
     def initialize_simulants(self):
@@ -77,10 +77,10 @@ class SimulationContext:
         self.clock.step_forward()
 
     def finalize(self):
-        self.end_emitter(Event(self.population._population.index))
+        self.end_emitter(Event(self.population.get_population(True).index))
 
     def report(self):
-        return self.values.get_value('metrics')(self.population._population.index)
+        return self.values.get_value('metrics')(self.population.get_population(True).index)
 
     def add_components(self, component_list):
         if self._setup:
@@ -158,4 +158,4 @@ def run(simulation):
     simulation.finalize()
     metrics = simulation.report()
     metrics['simulation_run_time'] = time() - start
-    return metrics, simulation.population._population
+    return metrics, simulation.population.get_population(True)

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -98,11 +98,9 @@ class ScalarTable:
     -----
     These should not be created directly. Use the `lookup` method on the builder during setup.
     """
-    def __init__(self, values: Union[List[ScalarValue], Tuple[ScalarValue]], population_view: PopulationView,
-                 value_columns: Union[List[str], Tuple[str]]):
+    def __init__(self, values: Union[List[ScalarValue], Tuple[ScalarValue]], value_columns: Union[List[str], Tuple[str]]):
 
         self.values = values
-        self.population_view = population_view
         self.value_columns = value_columns
 
     def __call__(self, index) -> pd.DataFrame:
@@ -118,11 +116,10 @@ class ScalarTable:
         pd.DataFrame
             A table with a column for each of the scalar values for the population requested.
         """
-        pop = self.population_view.get(index)
         if not isinstance(self.values, (list, tuple)):
-            values = pd.Series(self.values, index=pop.index, name=self.value_columns[0] if self.value_columns else None)
+            values = pd.Series(self.values, index=index, name=self.value_columns[0] if self.value_columns else None)
         else:
-            values = dict(zip(self.value_columns, [pd.Series(v, index=pop.index) for v in self.values]))
+            values = dict(zip(self.value_columns, [pd.Series(v, index=index) for v in self.values]))
         return pd.DataFrame(values)
 
     def __repr__(self):
@@ -150,7 +147,7 @@ class LookupTable:
 
         # Note datetime catches pandas timestamps
         if isinstance(data, (Number, datetime, timedelta, list, tuple)):
-            self._table = ScalarTable(data, population_view(['tracked']), value_columns)
+            self._table = ScalarTable(data, value_columns)
         else:
             callable_parameter_columns = [p[0] for p in parameter_columns]
             view_columns = sorted((set(key_columns) | set(callable_parameter_columns)) - {'year'}) + ['tracked']

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -68,7 +68,9 @@ class InterpolatedTable:
         pd.DataFrame
             A table with the interpolated values for the population requested.
         """
+
         pop = self.population_view.get(index)
+        del pop['tracked']
         if 'year' in [col for p in self.parameter_columns for col in p]:
             current_time = self.clock()
             fractional_year = current_time.year
@@ -96,10 +98,11 @@ class ScalarTable:
     -----
     These should not be created directly. Use the `lookup` method on the builder during setup.
     """
-    def __init__(self, values: Union[List[ScalarValue], Tuple[ScalarValue]],
+    def __init__(self, values: Union[List[ScalarValue], Tuple[ScalarValue]], population_view: PopulationView,
                  value_columns: Union[List[str], Tuple[str]]):
 
         self.values = values
+        self.population_view = population_view
         self.value_columns = value_columns
 
     def __call__(self, index) -> pd.DataFrame:
@@ -115,10 +118,11 @@ class ScalarTable:
         pd.DataFrame
             A table with a column for each of the scalar values for the population requested.
         """
+        pop = self.population_view.get(index)
         if not isinstance(self.values, (list, tuple)):
-            values = pd.Series(self.values, index=index, name=self.value_columns[0] if self.value_columns else None)
+            values = pd.Series(self.values, index=pop.index, name=self.value_columns[0] if self.value_columns else None)
         else:
-            values = dict(zip(self.value_columns, [pd.Series(v, index=index) for v in self.values]))
+            values = dict(zip(self.value_columns, [pd.Series(v, index=pop.index) for v in self.values]))
         return pd.DataFrame(values)
 
     def __repr__(self):
@@ -146,10 +150,10 @@ class LookupTable:
 
         # Note datetime catches pandas timestamps
         if isinstance(data, (Number, datetime, timedelta, list, tuple)):
-            self._table = ScalarTable(data, value_columns)
+            self._table = ScalarTable(data, population_view(['tracked']), value_columns)
         else:
             callable_parameter_columns = [p[0] for p in parameter_columns]
-            view_columns = sorted((set(key_columns) | set(callable_parameter_columns)) - {'year'})
+            view_columns = sorted((set(key_columns) | set(callable_parameter_columns)) - {'year'}) + ['tracked']
             self._table = InterpolatedTable(data, population_view(view_columns), key_columns,
                                             parameter_columns, value_columns, interpolation_order, clock, extrapolate)
 

--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -42,7 +42,7 @@ class PopulationView:
     @property
     def columns(self) -> List[str]:
         if not self._columns:
-            return list(self.manager.population.columns)
+            return list(self.manager._population.columns)
         return list(self._columns)
 
     def subview(self, columns: Sequence[str]) -> 'PopulationView':
@@ -76,7 +76,7 @@ class PopulationView:
             A table with the subset of the population requested.
         """
 
-        pop = self.manager.population.loc[index]
+        pop = self.manager._population.loc[index]
 
         if self._query:
             pop = pop.query(self._query)
@@ -121,7 +121,7 @@ class PopulationView:
                 affected_columns = set(pop.columns)
 
             affected_columns = set(affected_columns).intersection(self._columns)
-            state_table = self.manager.population
+            state_table = self.manager._population
             if not self.manager.growing:
                 affected_columns = set(affected_columns).intersection(state_table.columns)
 
@@ -278,10 +278,6 @@ class PopulationManager:
         metrics['total_population_tracked'] = len(tracked)
         metrics['total_population'] = len(untracked)+len(tracked)
         return metrics
-
-    @property
-    def population(self) -> pd.DataFrame:
-        return self._population.copy()
 
     def __repr__(self):
         return "PopulationManager()"

--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -279,6 +279,12 @@ class PopulationManager:
         metrics['total_population'] = len(untracked)+len(tracked)
         return metrics
 
+    def get_population(self, untracked) -> pd.DataFrame:
+        pop = self._population.copy()
+        if not untracked:
+            pop = pop[pop.tracked==True]
+        return pop
+
     def __repr__(self):
         return "PopulationManager()"
 

--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -42,7 +42,7 @@ class PopulationView:
     @property
     def columns(self) -> List[str]:
         if not self._columns:
-            return list(self.manager._population.columns)
+            return list(self.manager.get_population(True).columns)
         return list(self._columns)
 
     def subview(self, columns: Sequence[str]) -> 'PopulationView':
@@ -76,7 +76,7 @@ class PopulationView:
             A table with the subset of the population requested.
         """
 
-        pop = self.manager._population.loc[index]
+        pop = self.manager.get_population(True).loc[index]
 
         if self._query:
             pop = pop.query(self._query)
@@ -121,7 +121,7 @@ class PopulationView:
                 affected_columns = set(pop.columns)
 
             affected_columns = set(affected_columns).intersection(self._columns)
-            state_table = self.manager._population
+            state_table = self.manager.get_population(True)
             if not self.manager.growing:
                 affected_columns = set(affected_columns).intersection(state_table.columns)
 
@@ -258,7 +258,6 @@ class PopulationManager:
         population_configuration = population_configuration if population_configuration else {}
         if not self._initializers_ordered:
             self._order_initializers()
-
         new_index = range(len(self._population) + count)
         new_population = self._population.reindex(new_index)
         index = new_population.index.difference(self._population.index)

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -23,7 +23,7 @@ class InteractiveContext(SimulationContext):
 
     def initialize_simulants(self):
         super().initialize_simulants()
-        self._initial_population = self.population._population
+        self._initial_population = self.population.get_population(True)
 
     def reset(self):
         # This is super crude, but should work for a great deal of components.
@@ -72,10 +72,7 @@ class InteractiveContext(SimulationContext):
 
     @raise_if_not_setup(system_type='population')
     def get_population(self, untracked=False):
-        pop = self.population._population
-        if not untracked:
-            pop = pop[pop.tracked==True]
-        return pop
+        return self.population.get_population(untracked)
 
     @raise_if_not_setup(system_type='value')
     def list_values(self):

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -74,7 +74,7 @@ class InteractiveContext(SimulationContext):
     def get_population(self, untracked=False):
         pop = self.population.population
         if not untracked:
-            pop = pop[pop.tracked is True]
+            pop = pop[pop.tracked==True]
         return pop
 
     @raise_if_not_setup(system_type='value')

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -71,8 +71,11 @@ class InteractiveContext(SimulationContext):
                 self.step(step_size)
 
     @raise_if_not_setup(system_type='population')
-    def get_population(self):
-        return self.population.population
+    def get_population(self, untracked=False):
+        pop = self.population.population
+        if not untracked:
+            pop = pop[pop.tracked is True]
+        return pop
 
     @raise_if_not_setup(system_type='value')
     def list_values(self):

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -23,7 +23,7 @@ class InteractiveContext(SimulationContext):
 
     def initialize_simulants(self):
         super().initialize_simulants()
-        self._initial_population = self.population.population
+        self._initial_population = self.population._population
 
     def reset(self):
         # This is super crude, but should work for a great deal of components.
@@ -72,7 +72,7 @@ class InteractiveContext(SimulationContext):
 
     @raise_if_not_setup(system_type='population')
     def get_population(self, untracked=False):
-        pop = self.population.population
+        pop = self.population._population
         if not untracked:
             pop = pop[pop.tracked==True]
         return pop

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -172,9 +172,9 @@ def test_SimulationContext_initialize_simulants(base_config, components):
     sim.setup()
     pop_size = sim.configuration.population.population_size
     current_time = sim.clock.time
-    assert sim.population.population.empty
+    assert sim.population._population.empty
     sim.initialize_simulants()
-    assert len(sim.population.population) == pop_size
+    assert len(sim.population._population) == pop_size
     assert sim.clock.time == current_time
 
 
@@ -226,7 +226,7 @@ def test_run(mocker):
     sim_mock.step.side_effect = step
     sim_mock.report.return_value = {}
     pop = list(range(10))
-    sim_mock.population.population = pop
+    sim_mock.population._population = pop
 
     metrics, population = run(sim_mock)
 

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -172,9 +172,9 @@ def test_SimulationContext_initialize_simulants(base_config, components):
     sim.setup()
     pop_size = sim.configuration.population.population_size
     current_time = sim.clock.time
-    assert sim.population._population.empty
+    assert sim.population.get_population(True).empty
     sim.initialize_simulants()
-    assert len(sim.population._population) == pop_size
+    assert len(sim.population.get_population(True)) == pop_size
     assert sim.clock.time == current_time
 
 
@@ -226,8 +226,7 @@ def test_run(mocker):
     sim_mock.step.side_effect = step
     sim_mock.report.return_value = {}
     pop = list(range(10))
-    sim_mock.population._population = pop
-
+    sim_mock.population.get_population.return_value = pop
     metrics, population = run(sim_mock)
 
     sim_mock.initialize_simulants.assert_called_once()

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -24,30 +24,30 @@ def test_interpolated_tables(base_config):
     ages = manager.build_table(ages, key_columns=('sex',), parameter_columns=('age', 'year',), value_columns=None)
     one_d_age = manager.build_table(one_d_age, key_columns=('sex',), parameter_columns=('age',), value_columns=None)
 
-    result_years = years(simulation.population.population.index)
-    result_ages = ages(simulation.population.population.index)
-    result_ages_1d = one_d_age(simulation.population.population.index)
+    result_years = years(simulation.population._population.index)
+    result_ages = ages(simulation.population._population.index)
+    result_ages_1d = one_d_age(simulation.population._population.index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
 
     assert np.allclose(result_years, fractional_year)
-    assert np.allclose(result_ages, simulation.population.population.age)
-    assert np.allclose(result_ages_1d, simulation.population.population.age)
+    assert np.allclose(result_ages, simulation.population._population.age)
+    assert np.allclose(result_ages_1d, simulation.population._population.age)
 
     simulation.clock._time += pd.Timedelta(30.5 * 125, unit='D')
     simulation.population._population.age += 125/12
 
-    result_years = years(simulation.population.population.index)
-    result_ages = ages(simulation.population.population.index)
-    result_ages_1d = one_d_age(simulation.population.population.index)
+    result_years = years(simulation.population._population.index)
+    result_ages = ages(simulation.population._population.index)
+    result_ages_1d = one_d_age(simulation.population._population.index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
 
     assert np.allclose(result_years, fractional_year)
-    assert np.allclose(result_ages, simulation.population.population.age)
-    assert np.allclose(result_ages_1d, simulation.population.population.age)
+    assert np.allclose(result_ages, simulation.population._population.age)
+    assert np.allclose(result_ages_1d, simulation.population._population.age)
 
 
 @pytest.mark.skip(reason='only order 0 interpolation with age bin edges currently supported')
@@ -64,7 +64,7 @@ def test_interpolated_tables_without_uninterpolated_columns(base_config):
     manager = simulation.tables
     years = manager.build_table(years, key_columns=(), parameter_columns=('year', 'age',), value_columns=None)
 
-    result_years = years(simulation.population.population.index)
+    result_years = years(simulation.population._population.index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
@@ -73,7 +73,7 @@ def test_interpolated_tables_without_uninterpolated_columns(base_config):
 
     simulation.clock._time += pd.Timedelta(30.5 * 125, unit='D')
 
-    result_years = years(simulation.population.population.index)
+    result_years = years(simulation.population._population.index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
@@ -98,7 +98,7 @@ def test_interpolated_tables__exact_values_at_input_points(base_config):
 
     for year in input_years:
         simulation.clock._time = pd.Timestamp(year, 1, 1)
-        assert np.allclose(years(simulation.population.population.index),
+        assert np.allclose(years(simulation.population._population.index),
                            simulation.clock.time.year + 1/365)
 
 
@@ -106,7 +106,7 @@ def test_lookup_table_scalar_from_list(base_config):
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
     table = (manager.build_table((1,2), key_columns=None, parameter_columns=None,
-                                 value_columns=['a', 'b'])(simulation.population.population.index))
+                                 value_columns=['a', 'b'])(simulation.population._population.index))
 
     assert isinstance(table, pd.DataFrame)
     assert table.columns.values.tolist() == ['a', 'b']
@@ -118,7 +118,7 @@ def test_lookup_table_scalar_from_single_value(base_config):
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
     table = (manager.build_table(1, key_columns=None, parameter_columns=None,
-                                 value_columns=['a'])(simulation.population.population.index))
+                                 value_columns=['a'])(simulation.population._population.index))
     assert isinstance(table, pd.Series)
     assert np.all(table == 1)
 
@@ -140,7 +140,7 @@ def test_lookup_table_interpolated_return_types(base_config):
     table = (manager.build_table(data, key_columns=('sex',),
                                  parameter_columns=[['age', 'age_group_start', 'age_group_end'],
                                                     ['year', 'year_start', 'year_end']],
-                                 value_columns=None)(simulation.population.population.index))
+                                 value_columns=None)(simulation.population._population.index))
     # make sure a single value column is returned as a series
     assert isinstance(table, pd.Series)
 
@@ -149,7 +149,7 @@ def test_lookup_table_interpolated_return_types(base_config):
     table = (manager.build_table(data, key_columns=('sex',),
                                  parameter_columns=[['age', 'age_group_start', 'age_group_end'],
                                                     ['year', 'year_start', 'year_end']],
-                                 value_columns=None)(simulation.population.population.index))
+                                 value_columns=None)(simulation.population._population.index))
 
     assert isinstance(table, pd.DataFrame)
 

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -24,30 +24,30 @@ def test_interpolated_tables(base_config):
     ages = manager.build_table(ages, key_columns=('sex',), parameter_columns=('age', 'year',), value_columns=None)
     one_d_age = manager.build_table(one_d_age, key_columns=('sex',), parameter_columns=('age',), value_columns=None)
 
-    result_years = years(simulation.population._population.index)
-    result_ages = ages(simulation.population._population.index)
-    result_ages_1d = one_d_age(simulation.population._population.index)
+    result_years = years(simulation.get_population().index)
+    result_ages = ages(simulation.get_population().index)
+    result_ages_1d = one_d_age(simulation.get_population().index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
 
     assert np.allclose(result_years, fractional_year)
-    assert np.allclose(result_ages, simulation.population._population.age)
-    assert np.allclose(result_ages_1d, simulation.population._population.age)
+    assert np.allclose(result_ages, simulation.get_population().age)
+    assert np.allclose(result_ages_1d, simulation.get_population().age)
 
     simulation.clock._time += pd.Timedelta(30.5 * 125, unit='D')
-    simulation.population._population.age += 125/12
+    simulation.get_population().age += 125/12
 
-    result_years = years(simulation.population._population.index)
-    result_ages = ages(simulation.population._population.index)
-    result_ages_1d = one_d_age(simulation.population._population.index)
+    result_years = years(simulation.get_population().index)
+    result_ages = ages(simulation.get_population().index)
+    result_ages_1d = one_d_age(simulation.get_population().index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
 
     assert np.allclose(result_years, fractional_year)
-    assert np.allclose(result_ages, simulation.population._population.age)
-    assert np.allclose(result_ages_1d, simulation.population._population.age)
+    assert np.allclose(result_ages, simulation.get_population().age)
+    assert np.allclose(result_ages_1d, simulation.get_population().age)
 
 
 @pytest.mark.skip(reason='only order 0 interpolation with age bin edges currently supported')
@@ -64,7 +64,7 @@ def test_interpolated_tables_without_uninterpolated_columns(base_config):
     manager = simulation.tables
     years = manager.build_table(years, key_columns=(), parameter_columns=('year', 'age',), value_columns=None)
 
-    result_years = years(simulation.population._population.index)
+    result_years = years(simulation.get_population().index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
@@ -73,7 +73,7 @@ def test_interpolated_tables_without_uninterpolated_columns(base_config):
 
     simulation.clock._time += pd.Timedelta(30.5 * 125, unit='D')
 
-    result_years = years(simulation.population._population.index)
+    result_years = years(simulation.get_population().index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
@@ -98,7 +98,7 @@ def test_interpolated_tables__exact_values_at_input_points(base_config):
 
     for year in input_years:
         simulation.clock._time = pd.Timestamp(year, 1, 1)
-        assert np.allclose(years(simulation.population._population.index),
+        assert np.allclose(years(simulation.get_population().index),
                            simulation.clock.time.year + 1/365)
 
 
@@ -106,7 +106,7 @@ def test_lookup_table_scalar_from_list(base_config):
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
     table = (manager.build_table((1,2), key_columns=None, parameter_columns=None,
-                                 value_columns=['a', 'b'])(simulation.population._population.index))
+                                 value_columns=['a', 'b'])(simulation.get_population().index))
 
     assert isinstance(table, pd.DataFrame)
     assert table.columns.values.tolist() == ['a', 'b']
@@ -118,7 +118,7 @@ def test_lookup_table_scalar_from_single_value(base_config):
     simulation = setup_simulation([TestPopulation()], input_config=base_config)
     manager = simulation.tables
     table = (manager.build_table(1, key_columns=None, parameter_columns=None,
-                                 value_columns=['a'])(simulation.population._population.index))
+                                 value_columns=['a'])(simulation.get_population().index))
     assert isinstance(table, pd.Series)
     assert np.all(table == 1)
 
@@ -140,7 +140,7 @@ def test_lookup_table_interpolated_return_types(base_config):
     table = (manager.build_table(data, key_columns=('sex',),
                                  parameter_columns=[['age', 'age_group_start', 'age_group_end'],
                                                     ['year', 'year_start', 'year_end']],
-                                 value_columns=None)(simulation.population._population.index))
+                                 value_columns=None)(simulation.get_population().index))
     # make sure a single value column is returned as a series
     assert isinstance(table, pd.Series)
 
@@ -149,7 +149,7 @@ def test_lookup_table_interpolated_return_types(base_config):
     table = (manager.build_table(data, key_columns=('sex',),
                                  parameter_columns=[['age', 'age_group_start', 'age_group_end'],
                                                     ['year', 'year_start', 'year_end']],
-                                 value_columns=None)(simulation.population._population.index))
+                                 value_columns=None)(simulation.get_population().index))
 
     assert isinstance(table, pd.DataFrame)
 

--- a/tests/framework/test_lookup.py
+++ b/tests/framework/test_lookup.py
@@ -24,30 +24,31 @@ def test_interpolated_tables(base_config):
     ages = manager.build_table(ages, key_columns=('sex',), parameter_columns=('age', 'year',), value_columns=None)
     one_d_age = manager.build_table(one_d_age, key_columns=('sex',), parameter_columns=('age',), value_columns=None)
 
-    result_years = years(simulation.get_population().index)
-    result_ages = ages(simulation.get_population().index)
-    result_ages_1d = one_d_age(simulation.get_population().index)
+    pop = simulation.get_population(untracked=True)
+    result_years = years(pop.index)
+    result_ages = ages(pop.index)
+    result_ages_1d = one_d_age(pop.index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
 
     assert np.allclose(result_years, fractional_year)
-    assert np.allclose(result_ages, simulation.get_population().age)
-    assert np.allclose(result_ages_1d, simulation.get_population().age)
+    assert np.allclose(result_ages, pop.age)
+    assert np.allclose(result_ages_1d, pop.age)
 
     simulation.clock._time += pd.Timedelta(30.5 * 125, unit='D')
-    simulation.get_population().age += 125/12
+    simulation.population._population.age += 125/12
 
-    result_years = years(simulation.get_population().index)
-    result_ages = ages(simulation.get_population().index)
-    result_ages_1d = one_d_age(simulation.get_population().index)
+    result_years = years(pop.index)
+    result_ages = ages(pop.index)
+    result_ages_1d = one_d_age(pop.index)
 
     fractional_year = simulation.clock.time.year
     fractional_year += simulation.clock.time.timetuple().tm_yday / 365.25
 
     assert np.allclose(result_years, fractional_year)
-    assert np.allclose(result_ages, simulation.get_population().age)
-    assert np.allclose(result_ages_1d, simulation.get_population().age)
+    assert np.allclose(result_ages, pop.age)
+    assert np.allclose(result_ages_1d, pop.age)
 
 
 @pytest.mark.skip(reason='only order 0 interpolation with age bin edges currently supported')

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -6,7 +6,7 @@ from vivarium.framework.population import PopulationView, PopulationManager, Pop
 
 class DummyPopulationManager:
     def __init__(self):
-        self.population = pd.DataFrame({'age': [0, 10, 20, 30, 40, 50, 60, 70], 'sex': ['Male', 'Female']*4})
+        self._population = pd.DataFrame({'age': [0, 10, 20, 30, 40, 50, 60, 70], 'sex': ['Male', 'Female']*4})
 
 
 def test_create_PopulationView_with_all_columns():

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -6,7 +6,7 @@ from vivarium.framework.population import PopulationView, PopulationManager, Pop
 
 class DummyPopulationManager:
     def __init__(self):
-        self._population = pd.DataFrame({'age': [0, 10, 20, 30, 40, 50, 60, 70], 'sex': ['Male', 'Female']*4})
+        self.get_population = lambda _ : pd.DataFrame({'age': [0, 10, 20, 30, 40, 50, 60, 70], 'sex': ['Male', 'Female']*4})
 
 
 def test_create_PopulationView_with_all_columns():

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -38,8 +38,8 @@ def test_transition():
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')])
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population._population.index, event_time)
-    assert np.all(simulation.population._population.state == 'done')
+    machine.transition(simulation.get_population().index, event_time)
+    assert np.all(simulation.get_population().state == 'done')
 
 
 def test_choice(base_config):
@@ -53,9 +53,9 @@ def test_choice(base_config):
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], base_config)
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population._population.index, event_time)
-    a_count = (simulation.population._population.state == 'a').sum()
-    assert round(a_count/len(simulation.population._population), 1) == 0.5
+    machine.transition(simulation.get_population().index, event_time)
+    a_count = (simulation.get_population().state == 'a').sum()
+    assert round(a_count/len(simulation.get_population()), 1) == 0.5
 
 
 def test_null_transition(base_config):
@@ -69,9 +69,9 @@ def test_null_transition(base_config):
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], base_config)
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population._population.index, event_time)
-    a_count = (simulation.population._population.state == 'a').sum()
-    assert round(a_count/len(simulation.population._population), 1) == 0.5
+    machine.transition(simulation.get_population().index, event_time)
+    a_count = (simulation.get_population().state == 'a').sum()
+    assert round(a_count/len(simulation.get_population()), 1) == 0.5
 
 
 def test_no_null_transition(base_config):
@@ -88,9 +88,9 @@ def test_no_null_transition(base_config):
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], base_config)
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population._population.index, event_time)
-    a_count = (simulation.population._population.state == 'a').sum()
-    assert round(a_count/len(simulation.population._population), 1) == 0.5
+    machine.transition(simulation.get_population().index, event_time)
+    a_count = (simulation.get_population().state == 'a').sum()
+    assert round(a_count/len(simulation.get_population()), 1) == 0.5
 
 
 def test_side_effects():
@@ -112,9 +112,9 @@ def test_side_effects():
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start'), _population_fixture('count', 0)])
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population._population.index, event_time)
-    assert np.all(simulation.population._population['count'] == 1)
-    machine.transition(simulation.population._population.index, event_time)
-    assert np.all(simulation.population._population['count'] == 1)
-    machine.transition(simulation.population._population.index, event_time)
-    assert np.all(simulation.population._population['count'] == 2)
+    machine.transition(simulation.get_population().index, event_time)
+    assert np.all(simulation.get_population()['count'] == 1)
+    machine.transition(simulation.get_population().index, event_time)
+    assert np.all(simulation.get_population()['count'] == 1)
+    machine.transition(simulation.get_population().index, event_time)
+    assert np.all(simulation.get_population()['count'] == 2)

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -38,8 +38,8 @@ def test_transition():
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')])
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population.population.index, event_time)
-    assert np.all(simulation.population.population.state == 'done')
+    machine.transition(simulation.population._population.index, event_time)
+    assert np.all(simulation.population._population.state == 'done')
 
 
 def test_choice(base_config):
@@ -53,9 +53,9 @@ def test_choice(base_config):
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], base_config)
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population.population.index, event_time)
-    a_count = (simulation.population.population.state == 'a').sum()
-    assert round(a_count/len(simulation.population.population), 1) == 0.5
+    machine.transition(simulation.population._population.index, event_time)
+    a_count = (simulation.population._population.state == 'a').sum()
+    assert round(a_count/len(simulation.population._population), 1) == 0.5
 
 
 def test_null_transition(base_config):
@@ -69,9 +69,9 @@ def test_null_transition(base_config):
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], base_config)
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population.population.index, event_time)
-    a_count = (simulation.population.population.state == 'a').sum()
-    assert round(a_count/len(simulation.population.population), 1) == 0.5
+    machine.transition(simulation.population._population.index, event_time)
+    a_count = (simulation.population._population.state == 'a').sum()
+    assert round(a_count/len(simulation.population._population), 1) == 0.5
 
 
 def test_no_null_transition(base_config):
@@ -88,9 +88,9 @@ def test_no_null_transition(base_config):
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start')], base_config)
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population.population.index, event_time)
-    a_count = (simulation.population.population.state == 'a').sum()
-    assert round(a_count/len(simulation.population.population), 1) == 0.5
+    machine.transition(simulation.population._population.index, event_time)
+    a_count = (simulation.population._population.state == 'a').sum()
+    assert round(a_count/len(simulation.population._population), 1) == 0.5
 
 
 def test_side_effects():
@@ -112,9 +112,9 @@ def test_side_effects():
 
     simulation = setup_simulation([machine, _population_fixture('state', 'start'), _population_fixture('count', 0)])
     event_time = simulation.clock.time + simulation.clock.step_size
-    machine.transition(simulation.population.population.index, event_time)
-    assert np.all(simulation.population.population['count'] == 1)
-    machine.transition(simulation.population.population.index, event_time)
-    assert np.all(simulation.population.population['count'] == 1)
-    machine.transition(simulation.population.population.index, event_time)
-    assert np.all(simulation.population.population['count'] == 2)
+    machine.transition(simulation.population._population.index, event_time)
+    assert np.all(simulation.population._population['count'] == 1)
+    machine.transition(simulation.population._population.index, event_time)
+    assert np.all(simulation.population._population['count'] == 1)
+    machine.transition(simulation.population._population.index, event_time)
+    assert np.all(simulation.population._population['count'] == 2)


### PR DESCRIPTION
Only two main changes (and each of them is 1-2 lines). 
1. In `lookup.py`, we do not filter down to the tracked people only any more. Always return all the simulants.
2. We do not have `simulation.population.population` any more. If a user wants to call all untracked and tracked simulants, should use `simulation.get_population(untracked=True)`. (otherwise simulation.get_population() only returns the tracked simulants) 

The other changes are  all according to the change in 2. 