### PR TITLE
Make error message clearer

### DIFF
--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -220,8 +220,9 @@ class PopulationManager:
             required_columns.extend(required)
 
         if not set(required_columns) <= set(created_columns):
-            raise PopulationError(f"The initializers {initializers} could not be added.  "
-                                  "Check for missing dependencies in your components.")
+            missing_columns = set(required_columns).difference(set(created_columns))
+            raise PopulationError(f"The columns {missing_columns} are required, but are not "
+                                  f"created by any components in the system.")
 
     def _order_initializers(self) -> None:
         unordered_initializers = deque(self._population_initializers)

--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -219,8 +219,8 @@ class PopulationManager:
             created_columns.extend(created)
             required_columns.extend(required)
 
-        if not set(required_columns) <= set(created_columns):
-            missing_columns = set(required_columns).difference(set(created_columns))
+        missing_columns = set(required_columns).difference(set(created_columns))
+        if missing_columns:
             raise PopulationError(f"The columns {missing_columns} are required, but are not "
                                   f"created by any components in the system.")
 

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -39,7 +39,7 @@ def test_cyclic_dependencies(num_nodes, edges):
 
     dag = make_initializer_dag(num_nodes, edges)
     for node in dag:
-        manager.register_simulant_initializer(lambda: node['name'], 
+        manager.register_simulant_initializer(lambda: node['name'],
                                                       node['creates'],
                                                       node['requires'])
 
@@ -56,11 +56,11 @@ def test_missing_dependencies(num_nodes, edges):
 
     dag = make_initializer_dag(num_nodes, edges)
     for node in dag:
-        manager.register_simulant_initializer(lambda: node['name'], 
+        manager.register_simulant_initializer(lambda: node['name'],
                                                       node['creates'],
                                                       node['requires'])
 
-    with pytest.raises(PopulationError, match="Check for missing dependencies"):
+    with pytest.raises(PopulationError, match="are not created by any components in the system"):
         manager._order_initializers()
 
 


### PR DESCRIPTION
The previous error message dumped a bunch of info about initializers but didn't state what was missing clearly.  