### PR TITLE
switch decision points to a dict

### DIFF
--- a/src/vivarium/framework/randomness.py
+++ b/src/vivarium/framework/randomness.py
@@ -627,8 +627,7 @@ class RandomnessManager:
         pop_size = builder.configuration.population.population_size
         self._key_mapping.map_size = max(map_size, 10*pop_size)
 
-    def get_randomness_stream(self, decision_point: str, for_initialization: bool=False,
-                              throw_error: bool=True) -> RandomnessStream:
+    def get_randomness_stream(self, decision_point: str, for_initialization: bool=False) -> RandomnessStream:
         """Provides a new source of random numbers for the given decision point.
 
         Parameters
@@ -650,15 +649,11 @@ class RandomnessManager:
             with the same identifier.
         """
         if decision_point in self._decision_points:
-            if throw_error:
-                raise RandomnessError(f"Two separate places are attempting to create "
-                                      f"the same randomness stream for {decision_point}")
-            else:
-                stream = self._decision_points[decision_point]
-        else:
-            stream = RandomnessStream(key=decision_point, clock=self._clock, seed=self._seed,
-                                      index_map=self._key_mapping, manager=self, for_initialization=for_initialization)
-            self._decision_points[decision_point] = stream
+            raise RandomnessError(f"Two separate places are attempting to create "
+                                  f"the same randomness stream for {decision_point}")
+        stream = RandomnessStream(key=decision_point, clock=self._clock, seed=self._seed,
+                                  index_map=self._key_mapping, manager=self, for_initialization=for_initialization)
+        self._decision_points[decision_point] = stream
         return stream
 
     def register_simulants(self, simulants: pd.DataFrame):

--- a/tests/framework/test_randomness.py
+++ b/tests/framework/test_randomness.py
@@ -126,7 +126,7 @@ def test_RandomnessManager_get_randomness_stream():
     assert stream.key == 'test'
     assert stream.seed == seed
     assert stream.clock is mock_clock
-    assert rm._decision_points == {'test'}
+    assert set(rm._decision_points.keys()) == {'test'}
 
     with pytest.raises(RandomnessError):
         rm.get_randomness_stream('test')

--- a/tests/framework/test_utilities.py
+++ b/tests/framework/test_utilities.py
@@ -21,22 +21,22 @@ def test_to_yearly():
 
 
 def test_rate_to_probability():
-    rate = 0.001
+    rate = np.array([0.001])
     prob = rate_to_probability(rate)
-    assert round(prob, 5) == round(0.00099950016662497809, 5)
+    assert np.isclose(prob, 0.00099950016662497809)
 
 
 def test_probability_to_rate():
-    prob = 0.00099950016662497809
+    prob = np.array([0.00099950016662497809])
     rate = probability_to_rate(prob)
-    assert round(rate, 5) == round(0.001, 5)
+    assert np.isclose(rate, 0.001)
 
 
 def test_rate_to_probability_symmetry():
-    rate = 0.0001
+    rate = np.array([0.0001])
     for _ in range(100):
         prob = rate_to_probability(rate)
-        assert round(rate, 5) == round(probability_to_rate(prob), 5)
+        assert np.isclose(rate, probability_to_rate(prob))
         rate += (1-0.0001)/100.0
 
 


### PR DESCRIPTION
Here we alter the randomness manager to maintain a dict of streams rather than a set. We can use that dict to return an existing stream by key if explicitly told not to throw an error