### PR TITLE
track names and enforce uniqueness

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         'pyyaml>=5.1',
         'scipy',
         'click',
-        'tables',
+        'tables<=3.5.1',
     ]
 
     interactive_requirements = [

--- a/src/vivarium/examples/boids/location.py
+++ b/src/vivarium/examples/boids/location.py
@@ -11,6 +11,9 @@ class Location:
         }
     }
 
+    def __init__(self):
+        self.name = 'location'
+
     def setup(self, builder):
         self.width = builder.configuration.location.width
         self.height = builder.configuration.location.height

--- a/src/vivarium/examples/boids/neighbors.py
+++ b/src/vivarium/examples/boids/neighbors.py
@@ -10,6 +10,9 @@ class Neighbors:
         }
     }
 
+    def __init__(self):
+        self.name = 'Neighbors'
+
     def setup(self, builder):
         self.radius = builder.configuration.neighbors.radius
 

--- a/src/vivarium/examples/boids/population.py
+++ b/src/vivarium/examples/boids/population.py
@@ -10,6 +10,9 @@ class Population:
         }
     }
 
+    def __init__(self):
+        self.name = 'population'
+
     def setup(self, builder):
         self.colors = builder.configuration.population.colors
 

--- a/src/vivarium/examples/disease_model/mortality.py
+++ b/src/vivarium/examples/disease_model/mortality.py
@@ -22,6 +22,9 @@ class Mortality:
         }
     }
 
+    def __init__(self):
+        self.name = 'mortality'
+
     def setup(self, builder: Builder):
         """Performs this component's simulation setup.
 

--- a/src/vivarium/examples/disease_model/observer.py
+++ b/src/vivarium/examples/disease_model/observer.py
@@ -7,6 +7,9 @@ class Observer:
         }
     }
 
+    def __init__(self):
+        self.name = 'observer'
+
     def setup(self, builder):
         self.life_expectancy = builder.configuration.mortality.life_expectancy
         self.population_view = builder.population.get_view(['age', 'alive'])

--- a/src/vivarium/examples/disease_model/population.py
+++ b/src/vivarium/examples/disease_model/population.py
@@ -25,6 +25,9 @@ class BasePopulation:
         },
     }
 
+    def __init__(self):
+        self.name = 'base_population'
+
     def setup(self, builder: Builder):
         """Performs this component's simulation setup.
 

--- a/src/vivarium/framework/components/__init__.py
+++ b/src/vivarium/framework/components/__init__.py
@@ -1,2 +1,2 @@
-from .manager import ComponentManager, ComponentInterface, ComponentConfigError
+from .manager import OrderedComponentSet, ComponentManager, ComponentInterface, ComponentConfigError
 from .parser import ComponentConfigurationParser

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -35,16 +35,9 @@ class ComponentList:
         if args:
             self.extend(args)
 
-    def _check_conditions(self, component):
-        if not hasattr(component, "name"):
-            raise ComponentConfigError(f"Attempting to add a component {component} with no name. Vivarium "
-                                       "requires each component in a simulation have a name attribute with"
-                                       "a unique name.")
-        if component.name in self.names:
-            raise ComponentConfigError(f"Attempting to add a component with duplicate name: {component}")
-
     def append(self, component) -> None:
-        self._check_conditions(component)
+        if component in self:
+            raise ComponentConfigError(f"Attempting to add a component with duplicate name: {component}")
         self.names.add(component.name)
         self.components.append(component)
 
@@ -63,15 +56,11 @@ class ComponentList:
 
     def __contains__(self, component) -> bool:
         if not hasattr(component, "name"):
-            raise ValueError("Must use an object with a name attribute when checking "
-                             "membership against ComponentList")
-        if component.name in self.names:
-            return True
-        return False
+            raise ComponentConfigError(f"Component {component} has no name attribute")
+        return component.name in self.names
 
     def __iter__(self) -> any:
-        for component in self.components:
-            yield component
+        return iter(self.components)
 
     def __len__(self) -> int:
         return len(self.components)

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -77,7 +77,7 @@ class ComponentManager:
                                                "requires each component in a simulation have a name attribute with"
                                                "a unique name.")
                 if component.name in self._names:
-                    raise ComponentConfigError(f"Attempting to add duplicate component with name {component.name}")
+                    raise ComponentConfigError(f"Attempting to add duplicate component with name {component.name}.")
 
                 component_list.append(component)
                 self._names.append(component.name)

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -31,7 +31,6 @@ class OrderedComponentSet:
     uniqueness by name, and provides a subset of set-like semantics."""
 
     def __init__(self, *args):
-        self.names = []
         self.components = []
         if args:
             self.update(args)
@@ -39,7 +38,6 @@ class OrderedComponentSet:
     def add(self, component: Any) -> None:
         if component in self:
             raise ComponentConfigError(f"Attempting to add a component with duplicate name: {component}")
-        self.names.append(component.name)
         self.components.append(component)
 
     def update(self, components: Union[List, Tuple]):
@@ -49,7 +47,7 @@ class OrderedComponentSet:
     def __contains__(self, component: Any) -> bool:
         if not hasattr(component, "name"):
             raise ComponentConfigError(f"Component {component} has no name attribute")
-        return component.name in self.names
+        return component.name in [c.name for c in self.components]
 
     def __iter__(self) -> Iterator:
         return iter(self.components)
@@ -62,13 +60,12 @@ class OrderedComponentSet:
 
     def __eq__(self, other) -> bool:
         try:
-            return type(self) is type(other) and self.names == other.names
+            return type(self) is type(other) and [c.name for c in self.components] == [c.name for c in other.components]
         except TypeError:
             return False
 
     def pop(self) -> Any:
         component = self.components.pop(0)
-        self.names.remove(component.name)
         return component
 
     def __repr__(self):

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -41,7 +41,7 @@ class ComponentList:
                                        "requires each component in a simulation have a name attribute with"
                                        "a unique name.")
         if component.name in self.names:
-            raise ComponentConfigError(f"Attempting to append component with duplicate name: {component}")
+            raise ComponentConfigError(f"Attempting to add a component with duplicate name: {component}")
 
     def append(self, component) -> None:
         self._check_conditions(component)
@@ -75,12 +75,15 @@ class ComponentList:
         return bool(self.components)
 
     def __eq__(self, other) -> bool:
-        for a, b in zip(self, other):
-            if a.name != b.name:
-                return False
-        return True
+        try:
+            for a, b in zip(self, other):
+                if a.name != b.name:
+                    return False
+            return True
+        except TypeError:
+            return False
 
-    def pop(self, index) -> Any:
+    def pop(self, index=-1) -> Any:
         component = self.components.pop(index)
         self.names.remove(component.name)
         return component

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -27,6 +27,7 @@ class ComponentConfigError(VivariumError):
 
 
 class ComponentList(list):
+    """Container for Vivarium components that enforces uniqueness according to name."""
 
     def _check_conditions(self, component):
         if not hasattr(component, "name"):
@@ -48,11 +49,11 @@ class ComponentList(list):
         self._check_conditions(component)
         super().insert(i, component)
 
-    def __setitem__(self, key, value):
-        self._check_conditions(value)
-        super().__setitem__(key, value)
+    def __setitem__(self, key, component):
+        self._check_conditions(component)
+        super().__setitem__(key, component)
 
-    def __contains__(self, component):
+    def __contains__(self, component) -> bool:
         for c in self:
             if component.name == c.name:
                 return True

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -72,11 +72,15 @@ class ComponentManager:
             if isinstance(component, list) or isinstance(component, tuple):
                 self._add_components(component_list, component)
             else:
+                if not hasattr(component, "name"):
+                    raise ComponentConfigError(f"Attempting to add a component {component} with no name. Vivarium "
+                                               "requires each component in a simulation have a name attribute with"
+                                               "a unique name.")
                 if component.name in self._names:
                     raise ComponentConfigError(f"Attempting to add duplicate component with name {component.name}")
-                else:
-                    component_list.append(component)
-                    self._names.append(component.name)
+
+                component_list.append(component)
+                self._names.append(component.name)
 
     def get_components(self, component_type: Any) -> List:
         """Gets a list of components currently held by the component manager

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -54,12 +54,15 @@ class ComponentList:
 
     def __getitem__(self, name) -> Any:
         if name not in self.names:
-            raise KeyError(f"{name} not in ComponentList()")
+            raise KeyError(f"{name} not in ComponentList")
         for c in self.components:
             if c.name == name:
                 return c
 
     def __contains__(self, component) -> bool:
+        if not hasattr(component, "name"):
+            raise ValueError("Must use an object with a name attribute when checking "
+                             "membership against ComponentList")
         if component.name in self.names:
             return True
         return False
@@ -76,6 +79,8 @@ class ComponentList:
 
     def __eq__(self, other) -> bool:
         try:
+            if len(self) != len(other):
+                return False
             for a, b in zip(self, other):
                 if a.name != b.name:
                     return False

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -62,7 +62,7 @@ class OrderedComponentSet:
 
     def __eq__(self, other) -> bool:
         try:
-            return type(self) is type(other) and self.names == other.anmes
+            return type(self) is type(other) and self.names == other.names
         except TypeError:
             return False
 

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -31,7 +31,7 @@ class OrderedComponentSet:
     uniqueness by name, and provides a subset of set-like semantics."""
 
     def __init__(self, *args):
-        self.names = set()
+        self.names = []
         self.components = []
         if args:
             self.update(args)
@@ -39,7 +39,7 @@ class OrderedComponentSet:
     def add(self, component: Any) -> None:
         if component in self:
             raise ComponentConfigError(f"Attempting to add a component with duplicate name: {component}")
-        self.names.add(component.name)
+        self.names.append(component.name)
         self.components.append(component)
 
     def update(self, components: Union[List, Tuple]):
@@ -62,12 +62,7 @@ class OrderedComponentSet:
 
     def __eq__(self, other) -> bool:
         try:
-            if len(self) != len(other):
-                return False
-            for a, b in zip(self, other):
-                if a.name != b.name:
-                    return False
-            return True
+            return type(self) is type(other) and self.names == other.anmes
         except TypeError:
             return False
 

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -26,35 +26,27 @@ class ComponentConfigError(VivariumError):
     pass
 
 
-class ComponentList:
-    """Container for Vivarium components that enforces uniqueness according to name."""
+class OrderedComponentSet:
+    """A container for Vivarium components. It preserves ordering, enforces
+    uniqueness by name, and provides a subset of set-like semantics."""
 
     def __init__(self, *args):
         self.names = set()
         self.components = []
         if args:
-            self.extend(args)
+            self.update(args)
 
-    def append(self, component) -> None:
+    def add(self, component: Any) -> None:
         if component in self:
             raise ComponentConfigError(f"Attempting to add a component with duplicate name: {component}")
         self.names.add(component.name)
         self.components.append(component)
 
-    def extend(self, components):
+    def update(self, components: Union[List, Tuple]):
         for c in components:
-            self.append(c)
+            self.add(c)
 
-    def __getitem__(self, name) -> Any:
-        if isinstance(name, slice):
-            raise TypeError("ComponentList does not support slicing")
-        if name not in self.names:
-            raise KeyError(f"{name} not in ComponentList")
-        for c in self.components:
-            if c.name == name:
-                return c
-
-    def __contains__(self, component) -> bool:
+    def __contains__(self, component: Any) -> bool:
         if not hasattr(component, "name"):
             raise ComponentConfigError(f"Component {component} has no name attribute")
         return component.name in self.names
@@ -79,13 +71,13 @@ class ComponentList:
         except TypeError:
             return False
 
-    def pop(self, index=-1) -> Any:
-        component = self.components.pop(index)
+    def pop(self) -> Any:
+        component = self.components.pop(0)
         self.names.remove(component.name)
         return component
 
     def __repr__(self):
-        return "ComponentList()"
+        return "OrderedComponentSet()"
 
 
 class ComponentManager:
@@ -103,8 +95,8 @@ class ComponentManager:
     """
 
     def __init__(self):
-        self._managers = ComponentList()
-        self._components = ComponentList()
+        self._managers = OrderedComponentSet()
+        self._components = OrderedComponentSet()
 
     @property
     def name(self):
@@ -132,12 +124,12 @@ class ComponentManager:
         """
         self._add_components(self._components, components)
 
-    def _add_components(self, component_list: ComponentList, components: Union[List, Tuple]):
+    def _add_components(self, component_list: OrderedComponentSet, components: Union[List, Tuple]):
         for component in components:
             if isinstance(component, list) or isinstance(component, tuple):
                 self._add_components(component_list, component)
             else:
-                component_list.append(component)
+                component_list.add(component)
 
     def get_components(self, component_type: Any) -> List:
         """Gets a list of components currently held by the component manager
@@ -216,7 +208,7 @@ class ComponentInterface:
         return self._component_manager.get_components(component_type)
 
 
-def setup_components(builder, component_list: ComponentList, configuration: ConfigTree) -> List:
+def setup_components(builder, component_list: OrderedComponentSet, configuration: ConfigTree) -> OrderedComponentSet:
     """Configure and set up a list of components or managers.
 
     This function first loops over ``component_list`` and applies configuration
@@ -252,7 +244,7 @@ def setup_components(builder, component_list: ComponentList, configuration: Conf
 
     setup = []
     while component_list:  # mutated at runtime by calls to setup
-        c = component_list.pop(0)
+        c = component_list.pop()
         if c is None:
             raise ComponentConfigError('None in component list. This likely '
                                        'indicates a bug in a factory function')
@@ -266,7 +258,7 @@ def setup_components(builder, component_list: ComponentList, configuration: Conf
                 c.setup(builder)
             setup.append(c)
 
-    return setup
+    return OrderedComponentSet(*setup)
 
 
 def apply_component_default_configuration(configuration: ConfigTree, component: Any):

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -53,6 +53,8 @@ class ComponentList:
             self.append(c)
 
     def __getitem__(self, name) -> Any:
+        if isinstance(name, slice):
+            raise TypeError("ComponentList does not support slicing")
         if name not in self.names:
             raise KeyError(f"{name} not in ComponentList")
         for c in self.components:

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -15,7 +15,7 @@ setup everything it holds when the context itself is setup.
 
 """
 import inspect
-from typing import Union, List, Tuple, Any
+from typing import Union, List, Tuple, Any, Iterator
 
 from vivarium.config_tree import ConfigTree
 from vivarium.exceptions import VivariumError
@@ -51,7 +51,7 @@ class OrderedComponentSet:
             raise ComponentConfigError(f"Component {component} has no name attribute")
         return component.name in self.names
 
-    def __iter__(self) -> any:
+    def __iter__(self) -> Iterator:
         return iter(self.components)
 
     def __len__(self) -> int:

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -43,6 +43,7 @@ class ComponentManager:
     def __init__(self):
         self._managers = []
         self._components = []
+        self._names = []
 
     def add_managers(self, managers: Union[List, Tuple, Any]):
         """Registers new managers with the component manager. Managers are
@@ -71,7 +72,11 @@ class ComponentManager:
             if isinstance(component, list) or isinstance(component, tuple):
                 self._add_components(component_list, component)
             else:
-                component_list.append(component)
+                if component.name in self._names:
+                    raise ComponentConfigError(f"Attempting to add duplicate component with name {component.name}")
+                else:
+                    component_list.append(component)
+                    self._names.append(component.name)
 
     def get_components(self, component_type: Any) -> List:
         """Gets a list of components currently held by the component manager

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -36,18 +36,14 @@ class NamelessComponent:
 
 
 class Listener(MockComponentB):
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, *args, name='test_listener'):
+        super().__init__(*args, name=name)
         self.post_setup_called = False
         self.time_step__prepare_called = False
         self.time_step_called = False
         self.time_step__cleanup_called = False
         self.collect_metrics_called = False
         self.simulation_end_called = False
-
-    @property
-    def name(self):
-        return "test_listener"
 
     def setup(self, builder):
         super().setup(builder)

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -1,28 +1,24 @@
 
 class MockComponentA:
-    def __init__(self, *args):
+    def __init__(self, *args, name='mock_component_a'):
+        self.name = name
         self.args = args
         self.builder_used_for_setup = None
 
-    @property
-    def name(self):
-        return 'mock_component_a'
-
 
 class MockComponentB(MockComponentA):
+    def __init__(self, *args, name='mock_component_b'):
+        super().__init__(*args, name=name)
+
     def setup(self, builder):
         self.builder_used_for_setup = builder
 
         if len(self.args) > 1:
             children = []
             for arg in self.args:
-                children.append(MockComponentB(arg))
+                children.append(MockComponentB(name=arg))
             builder.components.add_components(children)
         builder.value.register_value_modifier('metrics', self.metrics)
-
-    @property
-    def name(self):
-        return "mock_component_b"
 
     def metrics(self, _, metrics):
         if 'test' in metrics:
@@ -30,6 +26,11 @@ class MockComponentB(MockComponentA):
         else:
             metrics['test'] = 1
         return metrics
+
+
+class NamelessComponent:
+    def __init__(self, *args):
+        self.args = args
 
 
 class Listener(MockComponentB):
@@ -44,7 +45,7 @@ class Listener(MockComponentB):
 
     @property
     def name(self):
-        return "test_listenter"
+        return "test_listener"
 
     def setup(self, builder):
         super().setup(builder)

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -6,9 +6,11 @@ class MockComponentA:
         self.builder_used_for_setup = None
 
 
-class MockComponentB(MockComponentA):
+class MockComponentB:
     def __init__(self, *args, name='mock_component_b'):
-        super().__init__(*args, name=name)
+        self.name = name
+        self.args = args
+        self.builder_used_for_setup = None
 
     def setup(self, builder):
         self.builder_used_for_setup = builder
@@ -16,7 +18,7 @@ class MockComponentB(MockComponentA):
         if len(self.args) > 1:
             children = []
             for arg in self.args:
-                children.append(MockComponentB(name=arg))
+                children.append(MockComponentB(arg, name=arg))
             builder.components.add_components(children)
         builder.value.register_value_modifier('metrics', self.metrics)
 

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -3,10 +3,10 @@ import os
 import pytest
 
 from vivarium.framework.configuration import build_simulation_configuration
-from vivarium.framework.components.manager import (ComponentManager, ComponentConfigError,
+from vivarium.framework.components.manager import (ComponentManager, ComponentConfigError, ComponentList,
                                                    setup_components, apply_component_default_configuration)
 
-from .mocks import MockComponentA, MockComponentB
+from .mocks import MockComponentA, MockComponentB, NamelessComponent
 
 
 @pytest.fixture
@@ -47,20 +47,17 @@ def test_setup_components(mocker, apply_default_config_mock):
     config = build_simulation_configuration()
     builder = mocker.Mock()
 
-    components = [None, MockComponentA('Eric'),  MockComponentB('half', 'a', 'bee')]
+    components = ComponentList([None, MockComponentA('Eric'),  MockComponentB('half', 'a', 'bee')])
 
-    with pytest.raises(ComponentConfigError):
+    with pytest.raises(ComponentConfigError, match='None in component list'):
         setup_components(builder, components, config)
 
-    duplicate = MockComponentA('Eric')
-    components = [duplicate, duplicate]
-    finished = setup_components(builder, components, config)
+    # # child adds duplicate components
+    # components = ComponentList([MockComponentA('Eric'), MockComponentB('Lucy', 'Lucy')])
+    # with pytest.raises(ComponentConfigError, match='duplicate name'):
+    #     setup_components(builder, components, config)
 
-    apply_default_config_mock.assert_not_called()
-    assert [duplicate] == finished
-    apply_default_config_mock.reset_mock()
-
-    components = [MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')]
+    components = ComponentList([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
     finished = setup_components(builder, components, config)
     mock_a, mock_b = finished
 
@@ -79,54 +76,70 @@ def test_setup_components(mocker, apply_default_config_mock):
         }
 
     test_bee = TestBee()
-    components = [MockComponentA('Eric'), MockComponentB('half', 'a', 'bee'), test_bee]
+    components = ComponentList([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee'), test_bee])
     apply_default_config_mock.reset_mock()
     setup_components(builder, components, config)
 
     apply_default_config_mock.assert_called_once()
 
 
-def test_ComponentManager_add_components():
+@pytest.mark.parametrize("components", (
+        (MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')),
+        (MockComponentA('Eric'),)
+))
+def test_ComponentManager__add_components(components):
     manager = ComponentManager()
 
-    components = [None, MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')]
     for list_type in ['_managers', '_components']:
         manager._add_components(getattr(manager, list_type), components)
-        assert getattr(manager, list_type) == components
-        setattr(manager, list_type, [])
-
-    components.append(components[:])
-    for list_type in ['_managers', '_components']:
-        manager._add_components(getattr(manager, list_type), components)
-        assert getattr(manager, list_type) == 2*components[:-1]
+        assert getattr(manager, list_type) == list(components)
 
 
-
-def test_ComponentManager__setup_components(mocker):
-    config = build_simulation_configuration()
+@pytest.mark.parametrize("components", (
+        (MockComponentA(), MockComponentA()),
+        (MockComponentA(), MockComponentA(), MockComponentB('foo', 'bar')),
+))
+def test_ComponentManager__add_components_duplicated(components):
     manager = ComponentManager()
-    builder = mocker.Mock()
-    builder.components = manager
 
-    manager.add_components([None, MockComponentA('Eric'),
-                            MockComponentB('half', 'a', 'bee')])
-    with pytest.raises(ComponentConfigError):
-        manager.setup_components(builder, config)
+    for list_type in ['_managers', '_components']:
+        with pytest.raises(ComponentConfigError, match='duplicate name'):
+            manager._add_components(getattr(manager, list_type), components)
 
-    manager._components = []
-    manager.add_components([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
-    manager.setup_components(builder, config)
 
-    mock_a, mock_b, mock_b_child1, mock_b_child2, mock_b_child3 = manager._components
+@pytest.mark.parametrize("components", (
+        (None,),
+        (NamelessComponent(),),
+        (NamelessComponent(), MockComponentA())
+))
+def test_ComponentManager__add_components_unnamed(components):
+    manager = ComponentManager()
 
-    assert mock_a.builder_used_for_setup is None  # class has no setup method
-    assert mock_b.builder_used_for_setup is builder
-    assert mock_b_child1.args == ('half',)
-    assert mock_b_child1.builder_used_for_setup is builder
-    assert mock_b_child2.args == ('a',)
-    assert mock_b_child2.builder_used_for_setup is builder
-    assert mock_b_child3.args == ('bee',)
-    assert mock_b_child3.builder_used_for_setup is builder
+    for list_type in ['_managers', '_components']:
+        with pytest.raises(ComponentConfigError, match='no name'):
+            manager._add_components(getattr(manager, list_type), components)
+
+
+# def test_ComponentManager__setup_components(mocker):
+#     config = build_simulation_configuration()
+#     manager = ComponentManager()
+#     builder = mocker.Mock()
+#     builder.components = manager
+#
+#     manager._components = []
+#     manager.add_components([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
+#     manager.setup_components(builder, config)
+#
+#     mock_a, mock_b, mock_b_child1, mock_b_child2, mock_b_child3 = manager._components
+#
+#     assert mock_a.builder_used_for_setup is None  # class has no setup method
+#     assert mock_b.builder_used_for_setup is builder
+#     assert mock_b_child1.args == ('half',)
+#     assert mock_b_child1.builder_used_for_setup is builder
+#     assert mock_b_child2.args == ('a',)
+#     assert mock_b_child2.builder_used_for_setup is builder
+#     assert mock_b_child3.args == ('bee',)
+#     assert mock_b_child3.builder_used_for_setup is builder
 
 
 class DummyMachine:
@@ -139,6 +152,10 @@ class DummyMachine:
         }
     }
 
+    def __init__(self):
+        self.name = 'dummy_machine'
+
+
 class DummyMechanic:
     configuration_defaults = {
         'work_level': {
@@ -149,6 +166,9 @@ class DummyMechanic:
             'id': 123,
         }
     }
+
+    def __init__(self):
+        self.name = 'dummy_mechanic'
 
 
 def test_default_configuration_set_by_one_component(mocker):
@@ -216,3 +236,43 @@ def test_default_configuration_set_by_one_component_different_tree_depths(mocker
         manager.setup_components(builder, config)
 
 
+# # TODO:
+# """
+# test the component list
+# test _add_components
+#
+# make sure you can get value error, has no name errors
+#
+# """
+#
+# # def test_component_list():
+# # def test_ComponentManager_add_duplicate_components
+# # def test_ComponentManager_add_unnamed_component
+
+
+def test_Component_List():
+    component_list = ComponentList()
+
+    component_0 = MockComponentA(name='component_0')
+    component_list.append(component_0)
+
+    component_1 = MockComponentA(name='component_1')
+    component_list.insert(-1, component_1)
+
+    # duplicates by name
+    with pytest.raises(ComponentConfigError, match='duplicate name'):
+        component_list.append(component_0)
+    with pytest.raises(ComponentConfigError, match='duplicate name'):
+        component_list.insert(-1, component_0)
+    with pytest.raises(ComponentConfigError, match='duplicate name'):
+        component_list[1] = component_0
+    # no name
+    with pytest.raises(ComponentConfigError, match='no name'):
+        component_list.append(NamelessComponent())
+    with pytest.raises(ComponentConfigError, match='no name'):
+        component_list.insert(0, NamelessComponent())
+    with pytest.raises(ComponentConfigError, match='no name'):
+        component_list[0] = NamelessComponent()
+
+    # __contains__
+    assert component_0 in component_list

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -52,11 +52,6 @@ def test_setup_components(mocker, apply_default_config_mock):
     with pytest.raises(ComponentConfigError, match='None in component list'):
         setup_components(builder, components, config)
 
-    # # child adds duplicate components
-    # components = ComponentList([MockComponentA('Eric'), MockComponentB('Lucy', 'Lucy')])
-    # with pytest.raises(ComponentConfigError, match='duplicate name'):
-    #     setup_components(builder, components, config)
-
     components = ComponentList([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
     finished = setup_components(builder, components, config)
     mock_a, mock_b = finished
@@ -120,26 +115,26 @@ def test_ComponentManager__add_components_unnamed(components):
             manager._add_components(getattr(manager, list_type), components)
 
 
-# def test_ComponentManager__setup_components(mocker):
-#     config = build_simulation_configuration()
-#     manager = ComponentManager()
-#     builder = mocker.Mock()
-#     builder.components = manager
-#
-#     manager._components = []
-#     manager.add_components([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
-#     manager.setup_components(builder, config)
-#
-#     mock_a, mock_b, mock_b_child1, mock_b_child2, mock_b_child3 = manager._components
-#
-#     assert mock_a.builder_used_for_setup is None  # class has no setup method
-#     assert mock_b.builder_used_for_setup is builder
-#     assert mock_b_child1.args == ('half',)
-#     assert mock_b_child1.builder_used_for_setup is builder
-#     assert mock_b_child2.args == ('a',)
-#     assert mock_b_child2.builder_used_for_setup is builder
-#     assert mock_b_child3.args == ('bee',)
-#     assert mock_b_child3.builder_used_for_setup is builder
+def test_ComponentManager__setup_components(mocker):
+    config = build_simulation_configuration()
+    manager = ComponentManager()
+    builder = mocker.Mock()
+    builder.components = manager
+
+    manager._components = []
+    manager.add_components([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
+    manager.setup_components(builder, config)
+
+    mock_a, mock_b, mock_b_child1, mock_b_child2, mock_b_child3 = manager._components
+
+    assert mock_a.builder_used_for_setup is None  # class has no setup method
+    assert mock_b.builder_used_for_setup is builder
+    assert mock_b_child1.args == ('half',)
+    assert mock_b_child1.builder_used_for_setup is builder
+    assert mock_b_child2.args == ('a',)
+    assert mock_b_child2.builder_used_for_setup is builder
+    assert mock_b_child3.args == ('bee',)
+    assert mock_b_child3.builder_used_for_setup is builder
 
 
 class DummyMachine:
@@ -234,20 +229,6 @@ def test_default_configuration_set_by_one_component_different_tree_depths(mocker
 
     with pytest.raises(ComponentConfigError):
         manager.setup_components(builder, config)
-
-
-# # TODO:
-# """
-# test the component list
-# test _add_components
-#
-# make sure you can get value error, has no name errors
-#
-# """
-#
-# # def test_component_list():
-# # def test_ComponentManager_add_duplicate_components
-# # def test_ComponentManager_add_unnamed_component
 
 
 def test_Component_List():

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -293,7 +293,7 @@ def test_Component_List_contains():
     assert component_1 in component_list
     assert component_3 not in component_list
 
-    with pytest.raises(ValueError, match='with a name attribute'):
+    with pytest.raises(ComponentConfigError, match='no name'):
         throwaway = 10 in component_list
 
 

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -47,12 +47,7 @@ def test_setup_components(mocker, apply_default_config_mock):
     config = build_simulation_configuration()
     builder = mocker.Mock()
 
-    components = ComponentList([None, MockComponentA('Eric'),  MockComponentB('half', 'a', 'bee')])
-
-    with pytest.raises(ComponentConfigError, match='None in component list'):
-        setup_components(builder, components, config)
-
-    components = ComponentList([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
+    components = ComponentList(MockComponentA('Eric'), MockComponentB('half', 'a', 'bee'))
     finished = setup_components(builder, components, config)
     mock_a, mock_b = finished
 
@@ -70,8 +65,11 @@ def test_setup_components(mocker, apply_default_config_mock):
             }
         }
 
+        def __init__(self):
+            self.name = 'TestBee'
+
     test_bee = TestBee()
-    components = ComponentList([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee'), test_bee])
+    components = ComponentList(MockComponentA('Eric'), MockComponentB('half', 'a', 'bee'), test_bee)
     apply_default_config_mock.reset_mock()
     setup_components(builder, components, config)
 
@@ -87,7 +85,7 @@ def test_ComponentManager__add_components(components):
 
     for list_type in ['_managers', '_components']:
         manager._add_components(getattr(manager, list_type), components)
-        assert getattr(manager, list_type) == list(components)
+        assert getattr(manager, list_type) == ComponentList(*components)
 
 
 @pytest.mark.parametrize("components", (
@@ -238,22 +236,15 @@ def test_Component_List():
     component_list.append(component_0)
 
     component_1 = MockComponentA(name='component_1')
-    component_list.insert(-1, component_1)
+    component_list.append(component_1)
 
     # duplicates by name
     with pytest.raises(ComponentConfigError, match='duplicate name'):
         component_list.append(component_0)
-    with pytest.raises(ComponentConfigError, match='duplicate name'):
-        component_list.insert(-1, component_0)
-    with pytest.raises(ComponentConfigError, match='duplicate name'):
-        component_list[1] = component_0
     # no name
     with pytest.raises(ComponentConfigError, match='no name'):
         component_list.append(NamelessComponent())
-    with pytest.raises(ComponentConfigError, match='no name'):
-        component_list.insert(0, NamelessComponent())
-    with pytest.raises(ComponentConfigError, match='no name'):
-        component_list[0] = NamelessComponent()
+
 
     # __contains__
     assert component_0 in component_list

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -279,7 +279,7 @@ def test_Component_List_pop():
         component_list.pop()
 
 
-def test_Component_List_dunders():
+def test_Component_List_contains():
     component_list = ComponentList()
 
     assert not bool(component_list)
@@ -290,15 +290,45 @@ def test_Component_List_dunders():
     component_3 = MockComponentA(name='absent')
     component_list = ComponentList(component_1, component_2)
 
-    # test various dunder method behavior
-    assert bool(component_list)
-    assert len(component_list) == 2
     assert component_1 in component_list
     assert component_3 not in component_list
-    assert component_list == component_list
-    assert not component_list == 10
+
+    with pytest.raises(ValueError, match='with a name attribute'):
+        throwaway = 10 in component_list
+
+
+def test_Component_List_get_item():
+    component_1 = MockComponentA()
+    component_2 = MockComponentB()
+    component_list = ComponentList(component_1, component_2)
+
     assert component_1 == component_list[component_1.name]
-    for c in component_list:
-        assert c in component_list
-    with pytest.raises(KeyError):
+
+    with pytest.raises(KeyError, match='not in ComponentList'):
         c = component_list['garbage']
+
+
+def test_Component_List_eq():
+    component_1 = MockComponentA()
+    component_2 = MockComponentB()
+    component_list = ComponentList(component_1, component_2)
+
+    assert component_list == component_list
+    assert component_list != 10
+
+    second_list = ComponentList(component_1)
+    assert component_list != second_list
+
+
+def test_Component_List_bool_len():
+    component_list = ComponentList()
+
+    assert not bool(component_list)
+    assert len(component_list) == 0
+
+    component_1 = MockComponentA()
+    component_2 = MockComponentB()
+    component_list = ComponentList(component_1, component_2)
+
+    assert bool(component_list)
+    assert len(component_list) == 2

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -121,10 +121,6 @@ def test_ComponentManager__setup_components(mocker):
     builder = mocker.Mock()
     builder.components = manager
 
-    manager.add_components([None, MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
-    with pytest.raises(ComponentConfigError, match='no name'):
-        manager.setup_components(builder, config)
-
     manager._components = []
     manager.add_components([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
     manager.setup_components(builder, config)

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -121,6 +121,10 @@ def test_ComponentManager__setup_components(mocker):
     builder = mocker.Mock()
     builder.components = manager
 
+    manager.add_components([None, MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
+    with pytest.raises(ComponentConfigError, match='no name'):
+        manager.setup_components(builder, config)
+
     manager._components = []
     manager.add_components([MockComponentA('Eric'), MockComponentB('half', 'a', 'bee')])
     manager.setup_components(builder, config)

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -229,7 +229,7 @@ def test_default_configuration_set_by_one_component_different_tree_depths(mocker
         manager.setup_components(builder, config)
 
 
-def test_Component_List():
+def test_Component_List_append():
     component_list = ComponentList()
 
     component_0 = MockComponentA(name='component_0')
@@ -241,10 +241,64 @@ def test_Component_List():
     # duplicates by name
     with pytest.raises(ComponentConfigError, match='duplicate name'):
         component_list.append(component_0)
+
     # no name
     with pytest.raises(ComponentConfigError, match='no name'):
         component_list.append(NamelessComponent())
 
 
-    # __contains__
-    assert component_0 in component_list
+def test_Component_List_extend():
+    component_list = ComponentList()
+
+    components = [MockComponentA(name='component_0'), MockComponentA('component_1')]
+
+    component_list.extend(components)
+
+    with pytest.raises(ComponentConfigError, match='duplicate name'):
+        component_list.extend(components)
+    with pytest.raises(ComponentConfigError, match='no name'):
+        component_list.extend([NamelessComponent()])
+
+
+def test_Component_List_initialization():
+    component_1 = MockComponentA()
+    component_2 = MockComponentB()
+
+    component_list = ComponentList(component_1, component_2)
+    assert component_list.components == [component_1, component_2]
+
+
+def test_Component_List_pop():
+    component = MockComponentA()
+    component_list = ComponentList(component)
+
+    c = component_list.pop()
+    assert c == component
+
+    with pytest.raises(IndexError):
+        component_list.pop()
+
+
+def test_Component_List_dunders():
+    component_list = ComponentList()
+
+    assert not bool(component_list)
+    assert len(component_list) == 0
+
+    component_1 = MockComponentA()
+    component_2 = MockComponentB()
+    component_3 = MockComponentA(name='absent')
+    component_list = ComponentList(component_1, component_2)
+
+    # test various dunder method behavior
+    assert bool(component_list)
+    assert len(component_list) == 2
+    assert component_1 in component_list
+    assert component_3 not in component_list
+    assert component_list == component_list
+    assert not component_list == 10
+    assert component_1 == component_list[component_1.name]
+    for c in component_list:
+        assert c in component_list
+    with pytest.raises(KeyError):
+        c = component_list['garbage']

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -3,7 +3,7 @@ import pytest
 from vivarium.framework.engine import SimulationContext, Builder, setup_simulation, run, run_simulation
 from vivarium.framework.event import EventManager, EventInterface
 from vivarium.framework.lookup import LookupTableManager, LookupTableInterface
-from vivarium.framework.components import ComponentManager, ComponentInterface
+from vivarium.framework.components import OrderedComponentSet, ComponentManager, ComponentInterface
 from vivarium.framework.metrics import Metrics
 from vivarium.framework.plugins import PluginManager
 from vivarium.framework.population import PopulationManager, PopulationInterface
@@ -61,7 +61,7 @@ def test_SimulationContext_init_default(base_config, components):
 
     # Ordering matters.
     managers = [sim.clock, sim.population, sim.randomness, sim.values, sim.events, sim.tables]
-    assert sim.component_manager._managers == managers
+    assert sim.component_manager._managers == OrderedComponentSet(*managers)
     assert list(sim.component_manager._components)[:-1] == components
     assert isinstance(list(sim.component_manager._components)[-1], Metrics)
 
@@ -110,7 +110,7 @@ def test_SimulationContext_init_custom(base_config, components):
 
     # Ordering matters.
     managers = [sim.clock, sim.population, sim.randomness, sim.values, sim.events, sim.tables, beekeeper]
-    assert sim.component_manager._managers == managers
+    assert sim.component_manager._managers == OrderedComponentSet(*managers)
     assert list(sim.component_manager._components)[:-1] == components
     assert isinstance(list(sim.component_manager._components)[-1], Metrics)
 

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -62,8 +62,8 @@ def test_SimulationContext_init_default(base_config, components):
     # Ordering matters.
     managers = [sim.clock, sim.population, sim.randomness, sim.values, sim.events, sim.tables]
     assert sim.component_manager._managers == managers
-    assert sim.component_manager._components[:-1] == components
-    assert isinstance(sim.component_manager._components[-1], Metrics)
+    assert list(sim.component_manager._components)[:-1] == components
+    assert isinstance(list(sim.component_manager._components)[-1], Metrics)
 
 
 def test_SimulationContext_init_custom(base_config, components):
@@ -111,8 +111,8 @@ def test_SimulationContext_init_custom(base_config, components):
     # Ordering matters.
     managers = [sim.clock, sim.population, sim.randomness, sim.values, sim.events, sim.tables, beekeeper]
     assert sim.component_manager._managers == managers
-    assert sim.component_manager._components[:-1] == components
-    assert isinstance(sim.component_manager._components[-1], Metrics)
+    assert list(sim.component_manager._components)[:-1] == components
+    assert isinstance(list(sim.component_manager._components)[-1], Metrics)
 
 
 def test_SimulationContext_setup_default(base_config, components):

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -12,7 +12,7 @@ def _population_fixture(column, initial_value):
 
         @property
         def name(self):
-            return "test_pop_fixture"
+            return f"test_pop_fixture_{column}_{initial_value}"
 
         def setup(self, builder):
             self.population_view = builder.population.get_view([column])


### PR DESCRIPTION
Adds a component container class that handles vivarium components and behaves like an ordered set, checking the conditions we care about:
1. has a name
2. name not already present

Several dunders are necessary for the way this is used in setting up components. I think this is a satisfactory minimal set we could build from.

I had to refactor the tests just a bit because we were testing behavior of duplicates. I added tests for the component list class, and smudged together exercising the dunder capabilities rather than making lots of little methods. Lemme know if you'd rather have separate funcs