### PR TITLE
Mic1019 emitters no events

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -84,7 +84,7 @@ class SimulationContext:
     def step(self):
         _log.debug(self.clock.time)
         for event in self.time_step_events:
-            self.time_step_emitters[event](Event(self.population.get_population(True).index))
+            self.time_step_emitters[event](self.population.get_population(True).index)
         self.clock.step_forward()
 
     def initialize_simulants(self):
@@ -97,7 +97,7 @@ class SimulationContext:
         self.clock.step_forward()
 
     def finalize(self):
-        self.end_emitter(Event(self.population.get_population(True).index))
+        self.end_emitter(self.population.get_population(True).index)
 
     def report(self):
         return self.values.get_value('metrics')(self.population.get_population(True).index)

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -77,6 +77,12 @@ class Event(NamedTuple):
         """
         return Event(new_index, self.user_data, self.time, self.step_size)
 
+    def __repr__(self):
+        return f"Event(user_data={self.user_data}, time={self.time}, step_size={self.step_size})"
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
 
 class _EventChannel:
     """A named subscription channel that passes events to event listeners."""

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -41,15 +41,15 @@ class Event(NamedTuple):
 
     Attributes
     ----------
-    index :
+    index 
         An index into the population table containing all simulants
         affected by this event.
-    user_data :
+    user_data 
         Any additional data provided by the user about the event.
-    time  :
+    time  
         The simulation time at which this event will resolve. The current
         simulation size plus the current time step size.
-    step_size :
+    step_size 
         The current step size at the time of the event.
     """
     index: pd.Index
@@ -99,10 +99,10 @@ class _EventChannel:
 
         Parameters
         ----------
-        index :
+        index 
             An index into the population table containing all simulants
             affected by this event.
-        user_data :
+        user_data 
             Any additional data provided by the user about the event.
 
         """

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -90,7 +90,7 @@ class _EventChannel:
         self.manager = manager
         self.listeners = [[] for _ in range(10)]
 
-    def emit(self, index: pd.Index, user_data: Dict = None) -> Event:
+    def emit(self, index: pd.Index, user_data: Dict = {}) -> Event:
         """Notifies all listeners to this channel that an event has occurred.
 
         Events are emitted to listeners in order of priority (with order 0 being

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -27,12 +27,12 @@ For more information, see the associated event
 
 """
 from collections import defaultdict
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, NamedTuple, Mapping, Any
+from .time import Time, Timedelta
 
 import pandas as pd
 
-
-class Event:
+class Event(NamedTuple):
     """An Event object represents the context of an event.
 
     Events themselves are just a bundle of data.  They must be emitted
@@ -44,36 +44,18 @@ class Event:
     index : pandas.Index
         An index into the population table containing all simulants
         affected by this event.
-    time  : pandas.Timestamp
-        The simulation time at which this event will resolve. The current
-        simulation size plus the current time step size.
-    step_size : pandas.Timedelta
-        The current step size at the time of the event.
     user_data : dict
         Any additional data provided by the user about the event.
-
+    time  : time.Time
+        The simulation time at which this event will resolve. The current
+        simulation size plus the current time step size.
+    step_size : time.Timedelta
+        The current step size at the time of the event.
     """
-    def __init__(self, index: pd.Index, user_data: Dict = None):
-        self._index = index
-        self._user_data = user_data if user_data is not None else {}
-        self._time = None
-        self._step_size = None
-
-    @property
-    def index(self):
-        return self._index
-
-    @property
-    def user_data(self):
-        return self._user_data
-
-    @property
-    def time(self):
-        return self._time
-
-    @property
-    def step_size(self):
-        return self._step_size
+    index: pd.Index
+    user_data: Mapping[str, Any]
+    time: Time
+    step_size: Timedelta
 
     def split(self, new_index: pd.Index) -> 'Event':
         """Create a copy of this event with a new index.
@@ -93,16 +75,7 @@ class Event:
             The new event.
 
         """
-        new_event = Event(new_index, self._user_data)
-        new_event._time = self._time
-        new_event._step_size = self._step_size
-        return new_event
-
-    def __repr__(self):
-        return f"Event(user_data={self._user_data}, time={self._time}, step_size={self._step_size})"
-
-    def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        return Event(new_index, self.user_data, self.time, self.step_size)
 
 
 class _EventChannel:
@@ -111,7 +84,7 @@ class _EventChannel:
         self.manager = manager
         self.listeners = [[] for _ in range(10)]
 
-    def emit(self, event: Event) -> Event:
+    def emit(self, index: pd.Index, user_data: Dict = None) -> Event:
         """Notifies all listeners to this channel that an event has occurred.
 
         Events are emitted to listeners in order of priority (with order 0 being
@@ -125,14 +98,14 @@ class _EventChannel:
             The event to be emitted.
 
         """
-        if hasattr(event, 'time'):
-            event._step_size = self.manager.step_size()
-            event._time = self.manager.clock() + self.manager.step_size()
+        e = Event(index, user_data,
+            self.manager.clock() + self.manager.step_size(),
+            self.manager.step_size())
 
         for priority_bucket in self.listeners:
             for listener in priority_bucket:
-                listener(event)
-        return event
+                listener(e)
+        return e
 
     def __repr__(self):
         return f"_EventChannel(listeners: {[listener for bucket in self.listeners for listener in bucket]})"
@@ -169,7 +142,7 @@ class EventManager:
         self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
 
-    def get_emitter(self, name: str) -> Callable:
+    def get_emitter(self, name: str) -> Callable[[pd.Index, Dict], Event]:
         """Get an emitter function for the named event.
 
         Parameters

--- a/tests/framework/test_event.py
+++ b/tests/framework/test_event.py
@@ -20,7 +20,7 @@ def event_init():
             'step_size': 30,
         }
     }
-def test_proper_access2(event_init):
+def test_proper_access(event_init):
     # Event attributes are meant to be read-only
     event_data = event_init['orig']
     e1 = Event(event_data['index'],

--- a/tests/framework/test_event.py
+++ b/tests/framework/test_event.py
@@ -4,72 +4,55 @@ import pytest
 
 from vivarium.framework.event import Event, EventManager
 
-
-def test_proper_access():
-    ''' Event attributes are meant to be read-only
-    '''
-    idx = pd.Index(range(10))
-    user_data = {'specific_event_data': 'the_data'}
-    e1 = Event(idx, user_data)
-
-    assert (idx == e1.index).all()
-    assert user_data == e1.user_data
-    assert e1.time == None
-    assert e1.step_size == None
-
-    with pytest.raises(AttributeError) as _:
-        e1.index = pd.Index(range(3))
-
-    with pytest.raises(AttributeError) as _:
-        e1.user_data = {'key': 'value'}
-
-    with pytest.raises(AttributeError) as _:
-        e1.time = pd.Timestamp('1/1/2000')
-
-    with pytest.raises(AttributeError) as _:
-        e1.step_size = 43
-
-
 @pytest.fixture
 def event_init():
-    return (
-        (pd.Index(range(10)), {'specific_event_data': 'the_data'}),
-        {
-            'index': pd.Index(range(3)),
+    return {
+        'orig': {
+            'index': pd.Index(range(10)),
             'user_data': {'key': 'value'},
             'time': pd.Timestamp('1/1/2000'),
-            'step_size': 43,
+            'step_size': 12,
+        },
+        'new_val': {
+            'index': pd.Index(range(3)),
+            'user_data': {'new_key': 'new_value'},
+            'time': pd.Timestamp.now(),
+            'step_size': 30,
         }
-    )
+    }
 def test_proper_access2(event_init):
     ''' Event attributes are meant to be read-only
     '''
-    event_data = event_init[0]
-    idx = event_data[0]
-    user_data = event_data[1]
-    e1 = Event(idx, user_data)
+    event_data = event_init['orig']
+    e1 = Event(event_data['index'],
+               event_data['user_data'],
+               event_data['time'],
+               event_data['step_size'])
 
-    assert (idx == e1.index).all()
-    assert user_data == e1.user_data
-    assert e1.time == None
-    assert e1.step_size == None
+    assert (event_data['index'] == e1.index).all()
+    assert event_data['user_data'] == e1.user_data
+    assert event_data['time'] == e1.time
+    assert event_data['step_size'] == e1.step_size
 
-    attribute_data = event_init[1]
+    attribute_data = event_init['new_val']
     for key, value in attribute_data.items():
         with pytest.raises(AttributeError) as _:
             setattr(e1, key, value)
 
-def test_split_event():
-    index1 = pd.Index(range(10))
-    index2 = pd.Index(range(5))
+def test_split_event(event_init):
+    event_data = event_init['orig']
+    e1 = Event(event_data['index'],
+               event_data['user_data'],
+               event_data['time'],
+               event_data['step_size'])
 
-    e1 = Event(index1)
-    e2 = e1.split(index2)
+    new_idx = event_init['new_val']['index']
+    e2 = e1.split(new_idx)
 
-    assert e1.index is index1
-    assert e2.index is index2
+    assert e1.index is event_data['index']
+    assert e2.index is new_idx
 
-def test_emission():
+def test_emission(event_init):
     signal = [False]
 
     def listener(*_, **__):
@@ -80,18 +63,18 @@ def test_emission():
     manager.step_size = lambda: pd.Timedelta(30, unit='D')
     emitter = manager.get_emitter('test_event')
     manager.register_listener('test_event', listener)
-    emitter(Event(None))
+    emitter(event_init['orig']['index'])
 
     assert signal[0]
 
     signal[0] = False
 
     emitter = manager.get_emitter('test_unheard_event')
-    emitter(Event(None))
+    emitter(event_init['new_val']['index'])
     assert not signal[0]
 
 
-def test_listener_priority():
+def test_listener_priority(event_init):
     signal = [False, False, False]
 
     def listener1(*_, **__):
@@ -117,7 +100,7 @@ def test_listener_priority():
     manager.register_listener('test_event', listener2)
     manager.register_listener('test_event', listener3, priority=9)
 
-    emitter(Event(None))
+    emitter(event_init['orig']['index'])
     assert np.all(signal)
 
 

--- a/tests/framework/test_event.py
+++ b/tests/framework/test_event.py
@@ -21,8 +21,7 @@ def event_init():
         }
     }
 def test_proper_access2(event_init):
-    ''' Event attributes are meant to be read-only
-    '''
+    # Event attributes are meant to be read-only
     event_data = event_init['orig']
     e1 = Event(event_data['index'],
                event_data['user_data'],


### PR DESCRIPTION
Event emitters no longer take an Event as an argument:
 - correct arguments in engine.py
 - modify testing code in test_event.py 
Event becomes a namedtuple
 - change type information in Event.py
 - modify signatures in Event.py
 - update documentation in Events.py