### PR TITLE
Check for invalid keys in model spec

### DIFF
--- a/src/vivarium/framework/configuration.py
+++ b/src/vivarium/framework/configuration.py
@@ -43,7 +43,14 @@ def validate_model_specification_file(file_path: str) -> str:
     if extension not in ['yaml', 'yml']:
         raise ConfigurationError(f'Model specification files must be in a yaml format. You provided {extension}')
     # Attempt to load
-    yaml.full_load(file_path)
+    with open(file_path) as f:
+        raw_spec = yaml.full_load(f)
+    top_keys = set(raw_spec.keys())
+    valid_keys = {'plugins', 'components', 'configuration'}
+    if not top_keys <= valid_keys:
+        raise ConfigurationError(f'Model specification contains additional top level '
+                                 f'keys {valid_keys.difference(top_keys)}.')
+
     return file_path
 
 

--- a/tests/framework/test_configuration.py
+++ b/tests/framework/test_configuration.py
@@ -8,18 +8,32 @@ from vivarium.framework.configuration import (ConfigurationError, build_simulati
                                               _get_default_specification, DEFAULT_PLUGINS)
 
 
-def test_get_default_specification_user_config(mocker):
+def get_file(name):
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config.yaml'
+    path = test_dir + '/../test_data/' + name
+    assert os.path.exists(path), 'Test directory structure is broken'
+    return path
 
+
+@pytest.fixture(params=['.yaml', '.yml'])
+def test_spec(request):
+    return get_file('mock_model_specification' + request.param)
+
+
+@pytest.fixture(params=['.yaml', '.yml'])
+def test_user_config(request):
+    return get_file('mock_user_config' + request.param)
+
+
+def test_get_default_specification_user_config(mocker, test_user_config):
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
-    expand_user_mock.return_value = user_config
+    expand_user_mock.return_value = test_user_config
 
     default_spec = _get_default_specification()
 
     assert expand_user_mock.called_once_with('~/vivarium.yaml')
 
-    with open(user_config) as f:
+    with open(test_user_config) as f:
         data = {'configuration': yaml.full_load(f)}
 
     data.update(DEFAULT_PLUGINS)
@@ -44,72 +58,72 @@ def test_get_default_specification_no_user_config(mocker):
     assert default_spec.to_dict() == data
 
 
-def test_validate_model_specification_failures():
+def test_validate_model_specification_failures(mocker, test_spec):
     with pytest.raises(ConfigurationError):
         validate_model_specification_file('made_up_file.yaml')
 
     with pytest.raises(ConfigurationError):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        model_spec = test_dir + '/../test_data/bad_model_specification.txt'
-        assert os.path.exists(model_spec), 'Test directory structure is broken'
+        model_spec = get_file('bad_model_specification.txt')
         validate_model_specification_file(model_spec)
 
+    with open(test_spec) as f:
+        spec_dict = yaml.full_load(f)
+    spec_dict.update({'invalid_key': 'some_value'})
+    load_mock = mocker.patch('vivarium.framework.configuration.yaml.full_load')
+    load_mock.return_value = spec_dict
+    with pytest.raises(ConfigurationError):
+        validate_model_specification_file(test_spec)
 
-def test_validate_model_specification():
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    model_spec = test_dir + '/../test_data/mock_model_specification.yaml'
-    assert os.path.exists(model_spec), 'Test directory structure is broken'
-    validate_model_specification_file(model_spec)
+
+def test_validate_model_specification(test_spec):
+    validate_model_specification_file(test_spec)
 
 
-def test_build_simulation_configuration(mocker):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config.yaml'
-
+def test_build_simulation_configuration(mocker, test_user_config):
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
-    expand_user_mock.return_value = user_config
+    expand_user_mock.return_value = test_user_config
 
     config = build_simulation_configuration()
 
     assert expand_user_mock.called_once_with('~/vivarium.yaml')
 
-    with open(user_config) as f:
+    with open(test_user_config) as f:
         data = yaml.full_load(f)
 
     assert config.to_dict() == data
 
 
-def test_build_model_specification_failure():
+def test_build_model_specification_failure(mocker, test_spec):
     with pytest.raises(ConfigurationError):
         build_model_specification('made_up_file.yaml')
 
     with pytest.raises(ConfigurationError):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        model_spec = test_dir + '/../test_data/bad_model_specification.txt'
-        assert os.path.exists(model_spec), 'Test directory structure is broken'
+        model_spec = get_file('bad_model_specification.txt')
         build_model_specification(model_spec)
 
+    with open(test_spec) as f:
+        spec_dict = yaml.full_load(f)
+    spec_dict.update({'invalid_key': 'some_value'})
+    load_mock = mocker.patch('vivarium.framework.configuration.yaml.full_load')
+    load_mock.return_value = spec_dict
+    with pytest.raises(ConfigurationError):
+        build_model_specification(test_spec)
 
-@pytest.mark.parametrize('user_config_ext', ['.yaml', '.yml'])
-@pytest.mark.parametrize('model_config_ext', ['.yaml', '.yml'])
-def test_build_model_specification(mocker, user_config_ext, model_config_ext):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config' + user_config_ext
-    model_spec = test_dir + '/../test_data/mock_model_specification' + model_config_ext
 
+def test_build_model_specification(mocker, test_spec, test_user_config):
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
-    expand_user_mock.return_value = user_config
+    expand_user_mock.return_value = test_user_config
 
-    loaded_model_spec = build_model_specification(model_spec)
+    loaded_model_spec = build_model_specification(test_spec)
 
     test_data = DEFAULT_PLUGINS
 
-    with open(model_spec) as f:
+    with open(test_spec) as f:
         model_data = yaml.full_load(f)
 
     test_data.update(model_data)
 
-    with open(user_config) as f:
+    with open(test_user_config) as f:
         user_data = yaml.full_load(f)
 
     test_data['configuration'].update(user_data)


### PR DESCRIPTION
I had some production runs produce invalid results because one of the configuration keys got dedented to the top level.  This, at least, catches that error.