### PR TITLE
Mic992 pull pdb behavior to vivarium

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 scipy
 tables
 click
+loguru

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ if __name__ == "__main__":
         'scipy',
         'click',
         'tables',
+        'loguru'
     ]
 
     interactive_requirements = [

--- a/src/vivarium/framework/configuration.py
+++ b/src/vivarium/framework/configuration.py
@@ -43,7 +43,14 @@ def validate_model_specification_file(file_path: str) -> str:
     if extension not in ['yaml', 'yml']:
         raise ConfigurationError(f'Model specification files must be in a yaml format. You provided {extension}')
     # Attempt to load
-    yaml.full_load(file_path)
+    with open(file_path) as f:
+        raw_spec = yaml.full_load(f)
+    top_keys = set(raw_spec.keys())
+    valid_keys = {'plugins', 'components', 'configuration'}
+    if not top_keys <= valid_keys:
+        raise ConfigurationError(f'Model specification contains additional top level '
+                                 f'keys {valid_keys.difference(top_keys)}.')
+
     return file_path
 
 

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -84,7 +84,7 @@ class SimulationContext:
     def step(self):
         _log.debug(self.clock.time)
         for event in self.time_step_events:
-            self.time_step_emitters[event](Event(self.population.get_population(True).index))
+            self.time_step_emitters[event](self.population.get_population(True).index)
         self.clock.step_forward()
 
     def initialize_simulants(self):
@@ -97,7 +97,7 @@ class SimulationContext:
         self.clock.step_forward()
 
     def finalize(self):
-        self.end_emitter(Event(self.population.get_population(True).index))
+        self.end_emitter(self.population.get_population(True).index)
 
     def report(self):
         return self.values.get_value('metrics')(self.population.get_population(True).index)

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -27,12 +27,12 @@ For more information, see the associated event
 
 """
 from collections import defaultdict
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, NamedTuple, Mapping, Any, Optional
+from .time import Time, Timedelta
 
 import pandas as pd
 
-
-class Event:
+class Event(NamedTuple):
     """An Event object represents the context of an event.
 
     Events themselves are just a bundle of data.  They must be emitted
@@ -41,23 +41,21 @@ class Event:
 
     Attributes
     ----------
-    index : pandas.Index
+    index 
         An index into the population table containing all simulants
         affected by this event.
-    time  : pandas.Timestamp
+    user_data 
+        Any additional data provided by the user about the event.
+    time  
         The simulation time at which this event will resolve. The current
         simulation size plus the current time step size.
-    step_size : pandas.Timedelta
+    step_size 
         The current step size at the time of the event.
-    user_data : dict
-        Any additional data provided by the user about the event.
-
     """
-    def __init__(self, index: pd.Index, user_data: Dict = None):
-        self.index = index
-        self.user_data = user_data if user_data is not None else {}
-        self.time = None
-        self.step_size = None
+    index: pd.Index
+    user_data: Mapping[str, Any]
+    time: Time
+    step_size: Timedelta
 
     def split(self, new_index: pd.Index) -> 'Event':
         """Create a copy of this event with a new index.
@@ -77,10 +75,7 @@ class Event:
             The new event.
 
         """
-        new_event = Event(new_index, self.user_data)
-        new_event.time = self.time
-        new_event.step_size = self.step_size
-        return new_event
+        return Event(new_index, self.user_data, self.time, self.step_size)
 
     def __repr__(self):
         return f"Event(user_data={self.user_data}, time={self.time}, step_size={self.step_size})"
@@ -95,7 +90,7 @@ class _EventChannel:
         self.manager = manager
         self.listeners = [[] for _ in range(10)]
 
-    def emit(self, event: Event) -> Event:
+    def emit(self, index: pd.Index, user_data: Dict = None) -> Event:
         """Notifies all listeners to this channel that an event has occurred.
 
         Events are emitted to listeners in order of priority (with order 0 being
@@ -104,18 +99,23 @@ class _EventChannel:
 
         Parameters
         ----------
-        event
-            The event to be emitted.
+        index 
+            An index into the population table containing all simulants
+            affected by this event.
+        user_data 
+            Any additional data provided by the user about the event.
 
         """
-        if hasattr(event, 'time'):
-            event.step_size = self.manager.step_size()
-            event.time = self.manager.clock() + self.manager.step_size()
+        if not user_data:
+            user_data = {}
+        e = Event(index, user_data,
+                self.manager.clock() + self.manager.step_size(),
+                self.manager.step_size())
 
         for priority_bucket in self.listeners:
             for listener in priority_bucket:
-                listener(event)
-        return event
+                listener(e)
+        return e
 
     def __repr__(self):
         return f"_EventChannel(listeners: {[listener for bucket in self.listeners for listener in bucket]})"
@@ -152,7 +152,7 @@ class EventManager:
         self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
 
-    def get_emitter(self, name: str) -> Callable:
+    def get_emitter(self, name: str) -> Callable[[pd.Index, Optional[Dict]], Event]:
         """Get an emitter function for the named event.
 
         Parameters
@@ -162,8 +162,9 @@ class EventManager:
 
         Returns
         -------
-            A function that accepts an Event object and distributes
-            it to all listeners for this event.
+            A function that accepts an index and optional user data. This function
+            creates and timestamps an Event and distributes it to all interested
+            listeners
 
         """
         return self._event_types[name].emit
@@ -227,7 +228,7 @@ class EventInterface:
     def __init__(self, event_manager: EventManager):
         self._event_manager = event_manager
 
-    def get_emitter(self, name: str) -> Callable[[Event], Event]:
+    def get_emitter(self, name: str) -> Callable[[pd.Index, Optional[Dict]], Event]:
         """Gets an emitter for a named event.
 
         Parameters

--- a/tests/framework/test_configuration.py
+++ b/tests/framework/test_configuration.py
@@ -8,18 +8,32 @@ from vivarium.framework.configuration import (ConfigurationError, build_simulati
                                               _get_default_specification, DEFAULT_PLUGINS)
 
 
-def test_get_default_specification_user_config(mocker):
+def get_file(name):
     test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config.yaml'
+    path = test_dir + '/../test_data/' + name
+    assert os.path.exists(path), 'Test directory structure is broken'
+    return path
 
+
+@pytest.fixture(params=['.yaml', '.yml'])
+def test_spec(request):
+    return get_file('mock_model_specification' + request.param)
+
+
+@pytest.fixture(params=['.yaml', '.yml'])
+def test_user_config(request):
+    return get_file('mock_user_config' + request.param)
+
+
+def test_get_default_specification_user_config(mocker, test_user_config):
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
-    expand_user_mock.return_value = user_config
+    expand_user_mock.return_value = test_user_config
 
     default_spec = _get_default_specification()
 
     assert expand_user_mock.called_once_with('~/vivarium.yaml')
 
-    with open(user_config) as f:
+    with open(test_user_config) as f:
         data = {'configuration': yaml.full_load(f)}
 
     data.update(DEFAULT_PLUGINS)
@@ -44,72 +58,72 @@ def test_get_default_specification_no_user_config(mocker):
     assert default_spec.to_dict() == data
 
 
-def test_validate_model_specification_failures():
+def test_validate_model_specification_failures(mocker, test_spec):
     with pytest.raises(ConfigurationError):
         validate_model_specification_file('made_up_file.yaml')
 
     with pytest.raises(ConfigurationError):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        model_spec = test_dir + '/../test_data/bad_model_specification.txt'
-        assert os.path.exists(model_spec), 'Test directory structure is broken'
+        model_spec = get_file('bad_model_specification.txt')
         validate_model_specification_file(model_spec)
 
+    with open(test_spec) as f:
+        spec_dict = yaml.full_load(f)
+    spec_dict.update({'invalid_key': 'some_value'})
+    load_mock = mocker.patch('vivarium.framework.configuration.yaml.full_load')
+    load_mock.return_value = spec_dict
+    with pytest.raises(ConfigurationError):
+        validate_model_specification_file(test_spec)
 
-def test_validate_model_specification():
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    model_spec = test_dir + '/../test_data/mock_model_specification.yaml'
-    assert os.path.exists(model_spec), 'Test directory structure is broken'
-    validate_model_specification_file(model_spec)
+
+def test_validate_model_specification(test_spec):
+    validate_model_specification_file(test_spec)
 
 
-def test_build_simulation_configuration(mocker):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config.yaml'
-
+def test_build_simulation_configuration(mocker, test_user_config):
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
-    expand_user_mock.return_value = user_config
+    expand_user_mock.return_value = test_user_config
 
     config = build_simulation_configuration()
 
     assert expand_user_mock.called_once_with('~/vivarium.yaml')
 
-    with open(user_config) as f:
+    with open(test_user_config) as f:
         data = yaml.full_load(f)
 
     assert config.to_dict() == data
 
 
-def test_build_model_specification_failure():
+def test_build_model_specification_failure(mocker, test_spec):
     with pytest.raises(ConfigurationError):
         build_model_specification('made_up_file.yaml')
 
     with pytest.raises(ConfigurationError):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        model_spec = test_dir + '/../test_data/bad_model_specification.txt'
-        assert os.path.exists(model_spec), 'Test directory structure is broken'
+        model_spec = get_file('bad_model_specification.txt')
         build_model_specification(model_spec)
 
+    with open(test_spec) as f:
+        spec_dict = yaml.full_load(f)
+    spec_dict.update({'invalid_key': 'some_value'})
+    load_mock = mocker.patch('vivarium.framework.configuration.yaml.full_load')
+    load_mock.return_value = spec_dict
+    with pytest.raises(ConfigurationError):
+        build_model_specification(test_spec)
 
-@pytest.mark.parametrize('user_config_ext', ['.yaml', '.yml'])
-@pytest.mark.parametrize('model_config_ext', ['.yaml', '.yml'])
-def test_build_model_specification(mocker, user_config_ext, model_config_ext):
-    test_dir = os.path.dirname(os.path.realpath(__file__))
-    user_config = test_dir + '/../test_data/mock_user_config' + user_config_ext
-    model_spec = test_dir + '/../test_data/mock_model_specification' + model_config_ext
 
+def test_build_model_specification(mocker, test_spec, test_user_config):
     expand_user_mock = mocker.patch('vivarium.framework.configuration.os.path.expanduser')
-    expand_user_mock.return_value = user_config
+    expand_user_mock.return_value = test_user_config
 
-    loaded_model_spec = build_model_specification(model_spec)
+    loaded_model_spec = build_model_specification(test_spec)
 
     test_data = DEFAULT_PLUGINS
 
-    with open(model_spec) as f:
+    with open(test_spec) as f:
         model_data = yaml.full_load(f)
 
     test_data.update(model_data)
 
-    with open(user_config) as f:
+    with open(test_user_config) as f:
         user_data = yaml.full_load(f)
 
     test_data['configuration'].update(user_data)

--- a/tests/framework/test_event.py
+++ b/tests/framework/test_event.py
@@ -1,21 +1,57 @@
 import pandas as pd
 import numpy as np
+import pytest
 
 from vivarium.framework.event import Event, EventManager
 
+@pytest.fixture
+def event_init():
+    return {
+        'orig': {
+            'index': pd.Index(range(10)),
+            'user_data': {'key': 'value'},
+            'time': pd.Timestamp('1/1/2000'),
+            'step_size': 12,
+        },
+        'new_val': {
+            'index': pd.Index(range(3)),
+            'user_data': {'new_key': 'new_value'},
+            'time': pd.Timestamp.now(),
+            'step_size': 30,
+        }
+    }
+def test_proper_access(event_init):
+    # Event attributes are meant to be read-only
+    event_data = event_init['orig']
+    e1 = Event(event_data['index'],
+               event_data['user_data'],
+               event_data['time'],
+               event_data['step_size'])
 
-def test_split_event():
-    index1 = pd.Index(range(10))
-    index2 = pd.Index(range(5))
+    assert (event_data['index'] == e1.index).all()
+    assert event_data['user_data'] == e1.user_data
+    assert event_data['time'] == e1.time
+    assert event_data['step_size'] == e1.step_size
 
-    e1 = Event(index1)
-    e2 = e1.split(index2)
+    attribute_data = event_init['new_val']
+    for key, value in attribute_data.items():
+        with pytest.raises(AttributeError) as _:
+            setattr(e1, key, value)
 
-    assert e1.index is index1
-    assert e2.index is index2
+def test_split_event(event_init):
+    event_data = event_init['orig']
+    e1 = Event(event_data['index'],
+               event_data['user_data'],
+               event_data['time'],
+               event_data['step_size'])
 
+    new_idx = event_init['new_val']['index']
+    e2 = e1.split(new_idx)
 
-def test_emission():
+    assert e1.index is event_data['index']
+    assert e2.index is new_idx
+
+def test_emission(event_init):
     signal = [False]
 
     def listener(*_, **__):
@@ -26,18 +62,18 @@ def test_emission():
     manager.step_size = lambda: pd.Timedelta(30, unit='D')
     emitter = manager.get_emitter('test_event')
     manager.register_listener('test_event', listener)
-    emitter(Event(None))
+    emitter(event_init['orig']['index'])
 
     assert signal[0]
 
     signal[0] = False
 
     emitter = manager.get_emitter('test_unheard_event')
-    emitter(Event(None))
+    emitter(event_init['new_val']['index'])
     assert not signal[0]
 
 
-def test_listener_priority():
+def test_listener_priority(event_init):
     signal = [False, False, False]
 
     def listener1(*_, **__):
@@ -63,7 +99,7 @@ def test_listener_priority():
     manager.register_listener('test_event', listener2)
     manager.register_listener('test_event', listener3, priority=9)
 
-    emitter(Event(None))
+    emitter(event_init['orig']['index'])
     assert np.all(signal)
 
 

--- a/tests/framework/test_utilities.py
+++ b/tests/framework/test_utilities.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 
 from vivarium.framework.utilities import (from_yearly, to_yearly, rate_to_probability, probability_to_rate,
-                                          collapse_nested_dict, import_by_path)
+                                          collapse_nested_dict, import_by_path, handle_exceptions)
 
 
 def test_from_yearly():
@@ -74,3 +74,13 @@ def test_bad_import_by_path():
         import_by_path('junk.garbage.SillyClass')
     with pytest.raises(AttributeError):
         import_by_path('vivarium.framework.components.SillyClass')
+
+class CustomException(Exception): pass
+@pytest.mark.parametrize("test_input", [KeyboardInterrupt, RuntimeError, CustomException])
+def test_handle_exceptions(test_input):
+    def raise_me(ex):
+        raise ex
+
+    with pytest.raises(test_input):
+        func = handle_exceptions(raise_me(test_input), False)
+        func()


### PR DESCRIPTION
Copy handle_exceptions() into vivarium utilities:
 - add loguru to requirements
 - necessary imports to utilities.py
 - basic test to test_utilities.py

Implementations still exist in:
 - vivarium_cluster_tools/psimulate/utilities.py
 - vivarium_development/src/vadmin/utilities.py

When we have a new vivarium release we need to:
 - reference the new version
 - remove versions from existing locations
 - use the implementation in the new vivarium release