### PR TITLE
correct ConfigTree __str__ behavior. Unrelated - add test for freeze()

### DIFF
--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -105,66 +105,66 @@ configuration by simply printing it.
 
     randomness:
         key_columns:
-            ['entrance_time', 'age']
+            model_override: ['entrance_time', 'age']
         map_size:
-            1000000
+            component_configs: 1000000
         random_seed:
-            0
+            component_configs: 0
         additional_seed:
-            None
+            component_configs: None
     time:
         start:
             year:
-                2005
+                model_override: 2005
             month:
-                7
+                model_override: 7
             day:
-                1
+                model_override: 1
         end:
             year:
-                2006
+                model_override: 2006
             month:
-                7
+                model_override: 7
             day:
-                1
+                model_override: 1
         step_size:
-            3
+            model_override: 3
     population:
         population_size:
-            10000
+            model_override: 10000
         age_start:
-            0
+            model_override: 0
         age_end:
-            30
+            model_override: 30
     mortality:
         mortality_rate:
-            0.05
+            model_override: 0.05
         life_expectancy:
-            80
+            model_override: 80
     diarrhea:
         incidence:
-            2.5
+            model_override: 2.5
         remission:
-            42
+            model_override: 42
         excess_mortality:
-            12
+            model_override: 12
     child_growth_failure:
         proportion_exposed:
-            0.5
+            model_override: 0.5
     effect_of_child_growth_failure_on_infected_with_diarrhea.incidence_rate:
         relative_risk:
-            5
+            model_override: 5
     effect_of_child_growth_failure_on_infected_with_diarrhea.excess_mortality_rate:
         relative_risk:
-            5
+            model_override: 5
     breastfeeding_promotion:
         effect_size:
-            0.5
+            model_override: 0.5
     interpolation:
         order:
-            0
+            component_configs: 0
         extrapolate:
-            True
+            component_configs: True
 
 
 What do we see here?  The configuration is *hierarchical*.  There are a set of
@@ -178,13 +178,13 @@ just those subsets if we like.
 .. testoutput::
 
     key_columns:
-        ['entrance_time', 'age']
+        model_override: ['entrance_time', 'age']
     map_size:
-        1000000
+        component_configs: 1000000
     random_seed:
-        0
+        component_configs: 0
     additional_seed:
-        None
+        component_configs: None
 
 This subset of configuration data contains more keys.  All of the keys in
 our example here (key_columns, map_size, random_seed, and additional_seed)

--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -103,68 +103,68 @@ configuration by simply printing it.
 
 .. testoutput::
 
-   randomness:
-       key_columns:
-           model_override: ['entrance_time', 'age']
-       map_size:
-           component_configs: 1000000
-       random_seed:
-           component_configs: 0
-       additional_seed:
-           component_configs: None
-   time:
-       start:
-           year:
-               model_override: 2005
-           month:
-               model_override: 7
-           day:
-               model_override: 1
-       end:
-           year:
-               model_override: 2006
-           month:
-               model_override: 7
-           day:
-               model_override: 1
-       step_size:
-           model_override: 3
-   population:
-       population_size:
-           model_override: 10000
-       age_start:
-           model_override: 0
-       age_end:
-           model_override: 30
-   mortality:
-       mortality_rate:
-           model_override: 0.05
-       life_expectancy:
-           model_override: 80
-   diarrhea:
-       incidence:
-           model_override: 2.5
-       remission:
-           model_override: 42
-       excess_mortality:
-           model_override: 12
-   child_growth_failure:
-       proportion_exposed:
-           model_override: 0.5
-   effect_of_child_growth_failure_on_infected_with_diarrhea.incidence_rate:
-       relative_risk:
-           model_override: 5
-   effect_of_child_growth_failure_on_infected_with_diarrhea.excess_mortality_rate:
-       relative_risk:
-           model_override: 5
-   breastfeeding_promotion:
-       effect_size:
-           model_override: 0.5
-   interpolation:
-       order:
-           component_configs: 0
-       extrapolate:
-           component_configs: True
+    randomness:
+        key_columns:
+            ['entrance_time', 'age']
+        map_size:
+            1000000
+        random_seed:
+            0
+        additional_seed:
+            None
+    time:
+        start:
+            year:
+                2005
+            month:
+                7
+            day:
+                1
+        end:
+            year:
+                2006
+            month:
+                7
+            day:
+                1
+        step_size:
+            3
+    population:
+        population_size:
+            10000
+        age_start:
+            0
+        age_end:
+            30
+    mortality:
+        mortality_rate:
+            0.05
+        life_expectancy:
+            80
+    diarrhea:
+        incidence:
+            2.5
+        remission:
+            42
+        excess_mortality:
+            12
+    child_growth_failure:
+        proportion_exposed:
+            0.5
+    effect_of_child_growth_failure_on_infected_with_diarrhea.incidence_rate:
+        relative_risk:
+            5
+    effect_of_child_growth_failure_on_infected_with_diarrhea.excess_mortality_rate:
+        relative_risk:
+            5
+    breastfeeding_promotion:
+        effect_size:
+            0.5
+    interpolation:
+        order:
+            0
+        extrapolate:
+            True
 
 
 What do we see here?  The configuration is *hierarchical*.  There are a set of
@@ -177,14 +177,14 @@ just those subsets if we like.
 
 .. testoutput::
 
-   key_columns:
-       model_override: ['entrance_time', 'age']
-   map_size:
-       component_configs: 1000000
-   random_seed:
-       component_configs: 0
-   additional_seed:
-       component_configs: None
+    key_columns:
+        ['entrance_time', 'age']
+    map_size:
+        1000000
+    random_seed:
+        0
+    additional_seed:
+        None
 
 This subset of configuration data contains more keys.  All of the keys in
 our example here (key_columns, map_size, random_seed, and additional_seed)

--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -103,68 +103,68 @@ configuration by simply printing it.
 
 .. testoutput::
 
-    randomness:
-        key_columns:
-            model_override: ['entrance_time', 'age']
-        map_size:
-            component_configs: 1000000
-        random_seed:
-            component_configs: 0
-        additional_seed:
-            component_configs: None
-    time:
-        start:
-            year:
-                model_override: 2005
-            month:
-                model_override: 7
-            day:
-                model_override: 1
-        end:
-            year:
-                model_override: 2006
-            month:
-                model_override: 7
-            day:
-                model_override: 1
-        step_size:
-            model_override: 3
-    population:
-        population_size:
-            model_override: 10000
-        age_start:
-            model_override: 0
-        age_end:
-            model_override: 30
-    mortality:
-        mortality_rate:
-            model_override: 0.05
-        life_expectancy:
-            model_override: 80
-    diarrhea:
-        incidence:
-            model_override: 2.5
-        remission:
-            model_override: 42
-        excess_mortality:
-            model_override: 12
-    child_growth_failure:
-        proportion_exposed:
-            model_override: 0.5
-    effect_of_child_growth_failure_on_infected_with_diarrhea.incidence_rate:
-        relative_risk:
-            model_override: 5
-    effect_of_child_growth_failure_on_infected_with_diarrhea.excess_mortality_rate:
-        relative_risk:
-            model_override: 5
-    breastfeeding_promotion:
-        effect_size:
-            model_override: 0.5
-    interpolation:
-        order:
-            component_configs: 0
-        extrapolate:
-            component_configs: True
+   randomness:
+       key_columns:
+           model_override: ['entrance_time', 'age']
+       map_size:
+           component_configs: 1000000
+       random_seed:
+           component_configs: 0
+       additional_seed:
+           component_configs: None
+   time:
+       start:
+           year:
+               model_override: 2005
+           month:
+               model_override: 7
+           day:
+               model_override: 1
+       end:
+           year:
+               model_override: 2006
+           month:
+               model_override: 7
+           day:
+               model_override: 1
+       step_size:
+           model_override: 3
+   population:
+       population_size:
+           model_override: 10000
+       age_start:
+           model_override: 0
+       age_end:
+           model_override: 30
+   mortality:
+       mortality_rate:
+           model_override: 0.05
+       life_expectancy:
+           model_override: 80
+   diarrhea:
+       incidence:
+           model_override: 2.5
+       remission:
+           model_override: 42
+       excess_mortality:
+           model_override: 12
+   child_growth_failure:
+       proportion_exposed:
+           model_override: 0.5
+   effect_of_child_growth_failure_on_infected_with_diarrhea.incidence_rate:
+       relative_risk:
+           model_override: 5
+   effect_of_child_growth_failure_on_infected_with_diarrhea.excess_mortality_rate:
+       relative_risk:
+           model_override: 5
+   breastfeeding_promotion:
+       effect_size:
+           model_override: 0.5
+   interpolation:
+       order:
+           component_configs: 0
+       extrapolate:
+           component_configs: True
 
 
 What do we see here?  The configuration is *hierarchical*.  There are a set of
@@ -177,14 +177,14 @@ just those subsets if we like.
 
 .. testoutput::
 
-    key_columns:
-        model_override: ['entrance_time', 'age']
-    map_size:
-        component_configs: 1000000
-    random_seed:
-        component_configs: 0
-    additional_seed:
-        component_configs: None
+   key_columns:
+       model_override: ['entrance_time', 'age']
+   map_size:
+       component_configs: 1000000
+   random_seed:
+       component_configs: 0
+   additional_seed:
+       component_configs: None
 
 This subset of configuration data contains more keys.  All of the keys in
 our example here (key_columns, map_size, random_seed, and additional_seed)

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -192,7 +192,7 @@ class ConfigNode:
                                    for layer, value in self._values.items()]))
 
     def __str__(self):
-        return [f'{layer}: {value[1]}' for layer, value in self._values.items()][-1]
+        return '{}'.format(self.get_value_with_source()[1])
 
 
 class ConfigTree:

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -188,8 +188,11 @@ class ConfigNode:
             del self._values[layer]
 
     def __repr__(self):
-        return '\n'.join(reversed([f'{layer}: {value[1]}\n    source: {value[0]}'
-                                   for layer, value in self._values.items()]))
+        out = []
+        for layer in reversed(self._layers):
+            if layer in self._values:
+                out.append(f'{layer}: {self._values[layer][1]}\n    source: {self._values[layer][0]}')
+        return '\n'.join(out)
 
     def __str__(self):
         last_override_layer = [layer for layer in self._layers if layer in self._values][-1]

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -192,7 +192,9 @@ class ConfigNode:
                                    for layer, value in self._values.items()]))
 
     def __str__(self):
-        return '{}'.format(self.get_value_with_source()[1])
+        last_override_layer = [layer for layer in self._layers if layer in self._values][-1]
+        value = self._values[last_override_layer][1]
+        return f'{last_override_layer}: {value}'
 
 
 class ConfigTree:

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -192,7 +192,7 @@ class ConfigNode:
                                    for layer, value in self._values.items()]))
 
     def __str__(self):
-        return [f'{layer}: {value[1]}' for layer, value in self._values.items()][0]
+        return [f'{layer}: {value[1]}' for layer, value in self._values.items()][-1]
 
 
 class ConfigTree:

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -221,6 +221,7 @@ def test_freeze():
     with pytest.raises(TypeError):
         config.update(data={'configuration': {'time': {'end': {'year': 2001}}}})
 
+
 LAYER_INNER = 'inner'
 LAYER_MIDDLE = 'middle'
 LAYER_OUTER = 'outer'
@@ -239,3 +240,34 @@ def test_retrieval_behavior():
         assert cfg.get_from_layer(DEFAULT_CFG_VALUE, layer=LAYER_OUTER) == LAYER_OUTER
         assert cfg.get_from_layer(DEFAULT_CFG_VALUE, layer=LAYER_MIDDLE) == LAYER_MIDDLE
         assert cfg.get_from_layer(DEFAULT_CFG_VALUE, layer=LAYER_INNER) == LAYER_INNER
+
+
+EXPECTED_REPR= \
+'''Key1:
+    override_2: value_ov_2
+        source: ov2_src
+    override_1: value_ov_1
+        source: ov1_src
+    base: value_base
+        source: base_src'''
+def test_repr_display():
+    # codifies the notion that repr() displays values from most to least overridden
+    #  regardless of initialization order
+    layers = ['base', 'override_1', 'override_2']
+    cfg = ConfigTree(layers=layers)
+
+    cfg.update({'Key1': 'value_ov_2'}, layer='override_2', source='ov2_src')
+    cfg.update({'Key1': 'value_ov_1'}, layer='override_1', source='ov1_src')
+    cfg.update({'Key1': 'value_base'}, layer='base', source='base_src')
+    assert repr(cfg) == EXPECTED_REPR
+
+    cfg = ConfigTree(layers=layers)
+    cfg.update({'Key1': 'value_base'}, layer='base', source='base_src')
+    cfg.update({'Key1': 'value_ov_1'}, layer='override_1', source='ov1_src')
+    cfg.update({'Key1': 'value_ov_2'}, layer='override_2', source='ov2_src')
+    assert repr(cfg) == EXPECTED_REPR
+
+
+
+
+

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -220,3 +220,22 @@ def test_freeze():
 
     with pytest.raises(TypeError):
         config.update(data={'configuration': {'time': {'end': {'year': 2001}}}})
+
+LAYER_INNER = 'inner'
+LAYER_MIDDLE = 'middle'
+LAYER_OUTER = 'outer'
+
+DEFAULT_CFG_VALUE='value_a'
+def test_retrieval_behavior():
+    layer_list = [LAYER_INNER, LAYER_MIDDLE, LAYER_OUTER]
+    # update the ConfigTree layers in different order and verify that has no effect on
+    #  the values retrieved ("outer" is retrieved when no layer is specified regardless of
+    #  the initialization order
+    for scenario in [layer_list, reversed(layer_list)]:
+        cfg = ConfigTree(layers=layer_list)
+        for layer in scenario:
+            cfg.update({DEFAULT_CFG_VALUE: layer}, layer=layer)
+        assert cfg.get_from_layer(DEFAULT_CFG_VALUE) == LAYER_OUTER
+        assert cfg.get_from_layer(DEFAULT_CFG_VALUE, layer=LAYER_OUTER) == LAYER_OUTER
+        assert cfg.get_from_layer(DEFAULT_CFG_VALUE, layer=LAYER_MIDDLE) == LAYER_MIDDLE
+        assert cfg.get_from_layer(DEFAULT_CFG_VALUE, layer=LAYER_INNER) == LAYER_INNER

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -212,3 +212,11 @@ def test_update():
     non_yaml_file = test_dir + '/../test_data/bad_model_specifiaction.txt'
     with pytest.raises(ValueError):
         config.update(non_yaml_file)
+
+
+def test_freeze():
+    config = ConfigTree(data={'configuration': {'time': {'start': {'year': 2000}}}})
+    config.freeze()
+
+    with pytest.raises(TypeError):
+        config.update(data={'configuration': {'time': {'end': {'year': 2001}}}})


### PR DESCRIPTION
First change addresses mic1026

Second change - I saw an infinite recursion error invoking freeze that I was not able to reproduce. It wasn't tested so I added one.