### PR TITLE
Bugfix/return from wrapped

### DIFF
--- a/src/vivarium/framework/utilities.py
+++ b/src/vivarium/framework/utilities.py
@@ -64,7 +64,7 @@ def handle_exceptions(func: Callable, logger: Any, with_debugger: bool) -> Calla
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
         try:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         except (BdbQuit, KeyboardInterrupt):
             raise
         except Exception as e:


### PR DESCRIPTION
this fixes the handle exceptions wrapper to return the results of the wrapped function. Previously it just ate it which broke simulate run since it wasn't getting back the simulation context obj