### PR TITLE
require pop view update columns to be subset of view columns

### DIFF
--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -134,7 +134,9 @@ class PopulationView:
                                           'name or there is only a single column in the view')
             else:
                 if not set(pop.columns).issubset(self._columns):
-                    raise PopulationError('Cannot update with a DataFrame that contains columns the view does not.')
+                    raise PopulationError(f'Cannot update with a DataFrame that contains columns the view does not. '
+                                          f'Dataframe contains the following extra columns: '
+                                          f'{set(pop.columns).difference(self._columns)}.')
                 affected_columns = set(pop.columns)
 
             affected_columns = set(affected_columns).intersection(self._columns)

--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -115,10 +115,10 @@ class PopulationView:
         ----------
         pop
             The data which should be copied into the simulation's state. If
-            ``pop`` is a DataFrame only those columns included in the view's
-            columns will be used. If ``pop`` is a Series it must have a name
-            that matches one of the view's columns unless the view only has
-            one column in which case the Series will be assumed to refer to
+            ``pop`` is a DataFrame, it can contain a subset of the view's
+            columns but no extra columns. If ``pop`` is a Series it must have
+            a name that matches one of the view's columns unless the view only
+            has one column in which case the Series will be assumed to refer to
             that regardless of its name.
 
         """
@@ -132,6 +132,8 @@ class PopulationView:
                     raise PopulationError('Cannot update with a Series unless the series name equals a column '
                                           'name or there is only a single column in the view')
             else:
+                if not set(pop.columns).issubset(self._columns):
+                    raise PopulationError('Cannot update with a DataFrame that contains columns the view does not.')
                 affected_columns = set(pop.columns)
 
             affected_columns = set(affected_columns).intersection(self._columns)


### PR DESCRIPTION
I got bitten in the htn sim because if you call update on a pop view and pass it more columns than are in the view, it silently ignores them. This changes so it will actually error and tell you which extra columns you have.

With the corresponding PR in vph, all tests pass in vivarium + vph and I can still run the htn sim