### PR TITLE
Feature/api docs

### DIFF
--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from vivarium.framework.state_machine import State, Machine, Transition
 from vivarium.framework.utilities import rate_to_probability
-from vivarium.framework.values import list_combiner, joint_value_post_processor
+from vivarium.framework.values import list_combiner, union_post_processor
 
 
 class DiseaseTransition(Transition):
@@ -23,7 +23,7 @@ class DiseaseTransition(Transition):
             f'{self.rate_name}.population_attributable_fraction',
             source=lambda index: [pd.Series(0, index=index)],
             preferred_combiner=list_combiner,
-            preferred_post_processor=joint_value_post_processor)
+            preferred_post_processor=union_post_processor)
 
     def _probability(self, index):
         effective_rate = self.transition_rate(index)
@@ -64,7 +64,7 @@ class DiseaseState(State):
             f'{self.state_id}.excess_mortality_rate.population_attributable_fraction',
             source=lambda index: [pd.Series(0, index=index)],
             preferred_combiner=list_combiner,
-            preferred_post_processor=joint_value_post_processor
+            preferred_post_processor=union_post_processor
         )
 
         builder.value.register_value_modifier('mortality_rate', self.add_in_excess_mortality)

--- a/src/vivarium/framework/resource.py
+++ b/src/vivarium/framework/resource.py
@@ -30,7 +30,7 @@ class ResourceError(VivariumError):
     pass
 
 
-RESOURCE_TYPES = {'value', 'value_source', 'value_modifier', 'column', 'stream'}
+RESOURCE_TYPES = {'value', 'value_source', 'missing_value_source', 'value_modifier', 'column', 'stream'}
 
 
 class ResourceProducer:

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -339,9 +339,9 @@ class ValuesManager:
             when called. If the pipeline has a ``replace_combiner``, the
             modifier should accept the same arguments as the pipeline source
             with an additional last positional argument for the results of the
-            previous stage in the pipeline. For the ``list_combiner`` and
-            ``set_combiner`` strategies, the pipeline modifiers should have
-            the same signature as the pipeline source.
+            previous stage in the pipeline. For the ``list_combiner`` strategy,
+            the pipeline modifiers should have the same signature as the pipeline
+            source.
         requires_columns
             A list of the state table columns that already need to be present
             and populated in the state table before the pipeline modifier
@@ -477,10 +477,9 @@ class ValuesInterface:
         preferred_combiner
             A strategy for combining the source and the results of any calls
             to mutators in the pipeline. ``vivarium`` provides the strategies
-            ``replace_combiner`` (the default), ``list_combiner``, and
-            ``set_combiner`` which are importable from
-            ``vivarium.framework.values``.  Client code may define additional
-            strategies as necessary.
+            ``replace_combiner`` (the default) and ``list_combiner``, which
+            are importable from ``vivarium.framework.values``.  Client code
+            may define additional strategies as necessary.
         preferred_post_processor
             A strategy for processing the final output of the pipeline.
             ``vivarium`` provides the strategies ``rescale_post_processor``
@@ -555,9 +554,9 @@ class ValuesInterface:
             when called. If the pipeline has a ``replace_combiner``, the
             modifier should accept the same arguments as the pipeline source
             with an additional last positional argument for the results of the
-            previous stage in the pipeline. For the ``list_combiner`` and
-            ``set_combiner`` strategies, the pipeline modifiers should have
-            the same signature as the pipeline source.
+            previous stage in the pipeline. For the ``list_combiner`` strategy,
+            the pipeline modifiers should have the same signature as the pipeline
+            source.
         requires_columns
             A list of the state table columns that already need to be present
             and populated in the state table before the pipeline modifier

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -48,7 +48,7 @@ def test_SimulationContext_init_default(components):
     assert isinstance(sim._builder.lookup, LookupTableInterface)
     assert sim._builder.lookup._lookup_table_manager is sim._tables
     assert isinstance(sim._builder.value, ValuesInterface)
-    assert sim._builder.value._value_manager is sim._values
+    assert sim._builder.value._manager is sim._values
     assert isinstance(sim._builder.event, EventInterface)
     assert sim._builder.event._event_manager is sim._events
     assert isinstance(sim._builder.population, PopulationInterface)

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -2,8 +2,7 @@ import pytest
 import pandas as pd
 import numpy as np
 
-from vivarium.framework.values import (set_combiner, list_combiner,
-                                       joint_value_post_processor, ValuesManager)
+from vivarium.framework.values import list_combiner, union_post_processor, ValuesManager
 
 
 @pytest.fixture
@@ -34,7 +33,7 @@ def test_joint_value(manager):
     value = manager.register_value_producer('test',
                                             source=lambda idx: [pd.Series(0, index=idx)],
                                             preferred_combiner=list_combiner,
-                                            preferred_post_processor=joint_value_post_processor)
+                                            preferred_post_processor=union_post_processor)
     assert np.all(value(index) == 0)
 
     manager.register_value_modifier('test', modifier=lambda idx: pd.Series(0.5, index=idx))
@@ -42,22 +41,6 @@ def test_joint_value(manager):
 
     manager.register_value_modifier('test', modifier=lambda idx: pd.Series(0.5, index=idx))
     assert np.all(value(index) == 0.75)
-
-
-def test_set_combiner(manager):
-    # This is the normal configuration for collecting lists of meids for calculating cause deleted tables
-    value = manager.register_value_producer('test', source=lambda: set(), preferred_combiner=set_combiner)
-
-    assert value() == set()
-
-    manager.register_value_modifier('test', modifier=lambda: 'thing one')
-    assert value() == {'thing one'}
-
-    manager.register_value_modifier('test', modifier=lambda: 'thing one')
-    assert value() == {'thing one'}  # duplicates are truly removed
-
-    manager.register_value_modifier('test', modifier=lambda: 'thing two')
-    assert value() == {'thing one', 'thing two'}  # but unique values are collected
 
 
 def test_contains(manager):


### PR DESCRIPTION
- joint value post processor renamed to union post processor.  Reasoning in the doc string.
- Added a 'missing_value_source' type and put pipelines with missing sources explicitly in the dependency graph.  This will be used later for visualization.
- Renamed the interface manager to just '_manager', which i've been doing piecemeal for a while.  I should just do one pr with all of them.  Todo soon.
- Axe the set combiner since it was never used

Everything else is docs
