### PR TITLE
Clean up and de-engineer some of the resource manager

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -86,8 +86,6 @@ class SimulationContext:
         for name, controller in self._plugin_manager.get_optional_controllers().items():
             setattr(self, f'_{name}', controller)
 
-        self._resource.add_group('initialization')
-
         # The order the managers are added is important.  It represents the
         # order in which they will be set up.  The clock is required by
         # several of the other managers, including the lifecycle manager.  The
@@ -109,6 +107,10 @@ class SimulationContext:
         self._lifecycle.add_constraint(self.get_population, restrict_during=['initialization', 'setup', 'post_setup'])
 
         self.add_components(components)
+
+    @property
+    def name(self):
+        return 'simulation_context'
 
     def setup(self):
         self._lifecycle.set_state('setup')
@@ -182,7 +184,7 @@ class Builder:
         self.value = plugin_manager.get_plugin_interface('value')                   # type: ValuesInterface
         self.event = plugin_manager.get_plugin_interface('event')                   # type: EventInterface
         self.population = plugin_manager.get_plugin_interface('population')         # type: PopulationInterface
-        self.resource = plugin_manager.get_plugin_interface('resource')             # type: ResourceInterface
+        self.resources = plugin_manager.get_plugin_interface('resource')             # type: ResourceInterface
         self.randomness = plugin_manager.get_plugin_interface('randomness')         # type: RandomnessInterface
         self.time = plugin_manager.get_plugin_interface('clock')                    # type: TimeInterface
         self.components = plugin_manager.get_plugin_interface('component_manager')  # type: ComponentInterface

--- a/src/vivarium/framework/lifecycle.py
+++ b/src/vivarium/framework/lifecycle.py
@@ -376,7 +376,7 @@ class ConstraintMaker:
         has been constrained before.
 
         """
-        return f'{str(id(method.__self__))}.{method.__name__}'
+        return f'{method.__self__.name}.{method.__name__}'
 
     def __call__(self, method: MethodType, permitted_states: List[str]) -> MethodType:
         """Only permit a method to be called during the provided states.

--- a/src/vivarium/framework/randomness.py
+++ b/src/vivarium/framework/randomness.py
@@ -428,6 +428,10 @@ class RandomnessStream:
         self._manager = manager
         self._for_initialization = for_initialization
 
+    @property
+    def name(self):
+        return f'randomness_stream_{self.key}'
+
     def _key(self, additional_key: Any = None) -> str:
         """Construct a hashable key from this object's state.
 
@@ -621,7 +625,7 @@ class RandomnessManager:
         pop_size = builder.configuration.population.population_size
         self._key_mapping.map_size = max(map_size, 10*pop_size)
 
-        self.initialization_resources = builder.resource.get_resource_group('initialization')
+        self.resources = builder.resources
         self._add_constraint = builder.lifecycle.add_constraint
         builder.lifecycle.add_constraint(self.get_randomness_stream, allow_during=['setup'])
         builder.lifecycle.add_constraint(self.register_simulants,
@@ -651,8 +655,8 @@ class RandomnessManager:
         """
         stream = self._get_randomness_stream(decision_point, for_initialization)
         if not for_initialization:  # We need the key columns to be created before this stream can be called.
-            self.initialization_resources.add_resources('stream', [decision_point], stream,
-                                                        [f'column.{name}' for name in self._key_columns])
+            self.resources.add_resources('stream', [decision_point], stream,
+                                         [f'column.{name}' for name in self._key_columns])
         self._add_constraint(stream.get_draw, restrict_during=['initialization', 'setup', 'post_setup'])
         self._add_constraint(stream.get_seed, restrict_during=['initialization'])
         self._add_constraint(stream.filter_for_probability, restrict_during=['initialization', 'setup', 'post_setup'])

--- a/src/vivarium/framework/resource.py
+++ b/src/vivarium/framework/resource.py
@@ -11,22 +11,22 @@ or :mod:`named value pipelines <vivarium.framework.values>`.
 
 Because these resources need to be created before they can be used, they are
 sensitive to ordering. The intent behind this tool is to provide an interface
-that allows other managers to register resources with the dependency manager
+that allows other managers to register resources with the resource manager
 and in turn ask for ordered sequences of these resources according to their
 dependencies or raise exceptions if this is not possible.
 
 """
 from types import MethodType
 from typing import List, Any, Iterable
-import warnings
 
+from loguru import logger
 import networkx as nx
 
 from vivarium.exceptions import VivariumError
 
 
 class ResourceError(VivariumError):
-    """Error raised when a dependency requirement is violated"""
+    """Error raised when a dependency requirement is violated."""
     pass
 
 
@@ -34,124 +34,271 @@ RESOURCE_TYPES = {'value', 'value_source', 'missing_value_source', 'value_modifi
 NULL_RESOURCE_TYPE = 'null'
 
 
-class ResourceProducer:
+class ResourceGroup:
+    """Resource groups are the nodes in the resource dependency graph.
+
+    A resource group represents the pool of resources produced by a single
+    callable and all the dependencies necessary to produce that resource.
+    When thinking of the dependency graph, this represents a vertex and
+    all in-edges.  This is a local-information representation that can be
+    used to construct the entire dependency graph once all resources are
+    specified.
+
+    """
 
     def __init__(self, resource_type: str, resource_names: List[str], producer: MethodType, dependencies: List[str]):
-        self.resource_type = resource_type
-        self.resource_names = resource_names
-        self.producer = producer
-        self.dependencies = dependencies
+        self._resource_type = resource_type
+        self._resource_names = resource_names
+        self._producer = producer
+        self._dependencies = dependencies
 
-    def __repr__(self):
-        resources = ', '.join([f'{self.resource_type}.{name}' for name in self.resource_names])
+    @property
+    def type(self) -> str:
+        """The type of resource produced by this resource group's producer.
+
+        Must be one of :data:`RESOURCE_TYPES`.
+
+        """
+        return self._resource_type
+
+    @property
+    def names(self) -> List[str]:
+        """The long names (including type) of all resources in this group."""
+        return [f'{self._resource_type}.{name}' for name in self._resource_names]
+
+    @property
+    def producer(self) -> Any:
+        """The method or object that produces this group of resources."""
+        return self._producer
+
+    @property
+    def dependencies(self) -> List[str]:
+        """The long names (including type) of dependencies for this group."""
+        return self._dependencies
+
+    def __iter__(self) -> Iterable[str]:
+        return iter(self.names)
+
+    def __repr__(self) -> str:
+        resources = ', '.join(self)
         return f'ResourceProducer({resources})'
 
-    def __str__(self):
-        resources = ', '.join([f'{self.resource_type}.{name}' for name in self.resource_names])
+    def __str__(self) -> str:
+        resources = ', '.join(self)
         return f'({resources})'
 
 
-class EmptySet:
+class ResourceManager:
+    """Manages all the resources needed for population initialization."""
 
-    def add(self, item: Any):
-        pass
-
-    def __contains__(self, item: Any) -> bool:
-        return False
-
-
-class ResourceGroup:
-
-    def __init__(self, phase: str):
-        self.phase = phase
-        self.resources = {}
-        self._graph = None
-        # null producers are those that don't produce any resources externally but still consume
-        # other resources (i.e., have dependencies) - these are only pop initializers as of 9/26/2019
+    def __init__(self):
+        # This will be a dict with string keys representing the the resource
+        # and the resource group they belong to. This is a one to many mapping
+        # as some resource groups contain many resources.
+        self._resource_group_map = {}
+        # null producers are those that don't produce any resources externally
+        # but still consume other resources (i.e., have dependencies) - these
+        # are only pop initializers as of 9/26/2019. Tracker is here to assign
+        # them unique ids.
         self._null_producer_count = 0
+        # Attribute used for lazy (but cached) graph initialization.
+        self._graph = None
+        # Attribute used for lazy (but cached) graph topo sort.
+        self._sorted_nodes = None
 
     @property
-    def graph(self):
+    def name(self) -> str:
+        """The name of this manager."""
+        return "resource_manager"
+
+    @property
+    def graph(self) -> nx.DiGraph:
+        """The networkx graph representation of the resource pool."""
         if self._graph is None:
             self._graph = self._to_graph()
         return self._graph
 
+    @property
+    def sorted_nodes(self):
+        """Returns a topological sort of the resource graph.
+
+        Notes
+        -----
+        Topological sorts are not stable. Be wary of depending on order
+        where you shouldn't.
+
+        """
+        if self._sorted_nodes is None:
+            try:
+                self._sorted_nodes = list(nx.algorithms.topological_sort(self.graph))
+            except nx.NetworkXUnfeasible:
+                raise ResourceError(f'The resource pool contains at least one cycle: '
+                                    f'{nx.find_cycle(self.graph)}.')
+        return self._sorted_nodes
+
     def add_resources(self, resource_type: str, resource_names: List[str],
-                      producer: MethodType, dependencies: List[str]):
+                      producer: Any, dependencies: List[str]):
+        """Adds managed resources to the resource pool.
+
+        Parameters
+        ----------
+        resource_type
+            The type of the resources being added. Must be one of
+            :data:`RESOURCE_TYPES`.
+        resource_names
+            A list of names of the resources being added.
+        producer
+            A method or object that will produce the resources.
+        dependencies
+            A list of resource names formatted as
+            ``resource_type.resource_name`` that the producer requires.
+
+        Raises
+        ------
+        ResourceError
+            If either the resource type is invalid, a component has multiple
+            resource producers for the ``column`` resource type, or
+            there are multiple producers of the same resource.
+
+        """
         if resource_type not in RESOURCE_TYPES:
-            raise ResourceError(f'Unknown resource type {resource_type}.  Permitted types are {RESOURCE_TYPES}.')
+            raise ResourceError(f'Unknown resource type {resource_type}. '
+                                f'Permitted types are {RESOURCE_TYPES}.')
 
-        producer = self._get_producer(resource_type, resource_names, producer, dependencies)
-        for resource_name in producer.resource_names:
-            key = f'{producer.resource_type}.{resource_name}'
-            if key in self.resources:
-                raise ResourceError  # More than one producer for resource ...
-            self.resources[key] = producer
+        resource_group = self._get_resource_group(resource_type, resource_names, producer, dependencies)
 
-    def _get_producer(self, resource_type, resource_names, producer, dependencies):
-        if not resource_names:  # null producer
+        for resource in resource_group:
+            if resource in self._resource_group_map:
+                other_producer = self._resource_group_map[resource].producer
+                raise ResourceError(f'Both {producer} and {other_producer} are registered as '
+                                    f'producers for {resource}.')
+            self._resource_group_map[resource] = resource_group
+
+    def _get_resource_group(self, resource_type: str, resource_names: List[str],
+                            producer: MethodType, dependencies: List[str]) -> ResourceGroup:
+        """Packages resource information into a resource group.
+
+        See Also
+        --------
+        :class:`ResourceGroup`
+
+        """
+        if not resource_names:
+            # We have a "producer" that doesn't produce anything, but
+            # does have dependencies. This is necessary for components that
+            # want to track private state information.
             resource_type = NULL_RESOURCE_TYPE
             resource_names = [str(self._null_producer_count)]
             self._null_producer_count += 1
 
-        return ResourceProducer(resource_type, resource_names, producer, dependencies)
+        return ResourceGroup(resource_type, resource_names, producer, dependencies)
+
+    def _to_graph(self) -> nx.DiGraph:
+        """Constructs the full resource graph from information in the groups.
+
+        Components specify local dependency information during setup time.
+        When the resources are required at population creation time,
+        the graph is generated as all resources must be registered at that
+        point.
+
+        Notes
+        -----
+        We are taking advantage of lazy initialization to sneak this in
+        between post setup time when the :class:`values manager
+        <vivarium.framework.values.ValuesManager>` finalizes pipeline
+        dependencies and population creation time.
+
+        """
+        resource_graph = nx.DiGraph()
+        # networkx ignores duplicates
+        resource_graph.add_nodes_from(self._resource_group_map.values())
+
+        for resource_group in resource_graph.nodes:
+            for dependency in resource_group.dependencies:
+                if dependency not in self._resource_group_map:
+                    # Warn here because this sometimes happens naturally
+                    # if observer components are missing from a simulation.
+                    logger.warning(f'Resource {dependency} is not provided by any component but is needed to '
+                                   f'compute {resource_group}.')
+                    continue
+                dependency_group = self._resource_group_map[dependency]
+                resource_graph.add_edge(dependency_group, resource_group)
+
+        return resource_graph
 
     def __iter__(self) -> Iterable[MethodType]:
-        try:
-            sorted_nodes = list(nx.algorithms.topological_sort(self.graph))
-        except nx.NetworkXUnfeasible:
-            raise ResourceError(f'The resource group {self.phase} contains at least one cycle: '
-                                f'{nx.find_cycle(self.graph)}.')
-        return iter([r.producer for r in sorted_nodes if r.resource_type in {'column', NULL_RESOURCE_TYPE}])
+        """Returns a dependency-sorted iterable of population initializers.
 
-    def _to_graph(self) -> Iterable[ResourceProducer]:
-        g = nx.DiGraph()
-        g.add_nodes_from(self.resources.values())
+        We exclude all non-initializer dependencies. They were necessary in
+        graph construction, but we only need the column producers at population
+        creation time.
 
-        for r in g.nodes:
-            for dependency_key in r.dependencies:
-                if dependency_key not in self.resources:
-                    warnings.warn(f'Resource {dependency_key} is not provided by any component but is needed to '
-                                  f'compute {r.resource_names}.')
-                    continue
-
-                d = self.resources[dependency_key]
-                g.add_edge(d, r)
-        return g
+        """
+        return iter([r.producer for r in self.sorted_nodes if r.type in {'column', NULL_RESOURCE_TYPE}])
 
     def __repr__(self):
         out = {}
-        for resource in set(self.resources.values()):
-            produced = ', '.join([f'{resource.resource_type}.{name}' for name in resource.resource_names])
-            out[produced] = ', '.join(resource.dependencies)
+        for resource_group in set(self._resource_group_map.values()):
+            produced = ', '.join(resource_group)
+            out[produced] = ', '.join(resource_group.dependencies)
         return '\n'.join([f'{produced} : {depends}' for produced, depends in out.items()])
 
 
-class ResourceManager:
-
-    def __init__(self):
-        self._resource_groups = {}
-
-    @property
-    def name(self) -> str:
-        return "resource_manager"
-
-    def add_group(self, phase: str):
-        if phase in self._resource_groups:
-            raise ResourceError  # One resource group per phase
-        self._resource_groups[phase] = ResourceGroup(phase)
-
-    def get_resource_group(self, phase: str) -> ResourceGroup:
-        return self._resource_groups[phase]
-
-    def display(self, phase: str):
-        raise NotImplementedError
-
-
 class ResourceInterface:
+    """The resource management system.
+
+    A resource in :mod:`vivarium` is something like a state table column
+    or a randomness stream. These resources are used to initialize or alter
+    the state of the simulation. Many of these resources might depend on each
+    other and therefore need to be created or updated in a particular order.
+    These dependency chains can be quite long and complex.
+
+    Placing the ordering responsibility on end users makes simulations very
+    fragile and difficult to understand. Instead, the resource management
+    system allows users to only specify local dependencies. The system then
+    uses the local dependency information to construct a full dependency
+    graph, validate that there are no cyclic dependencies, and return
+    resources and their producers in an order that makes sense.
+
+    """
 
     def __init__(self, manager: ResourceManager):
         self._manager = manager
 
-    def get_resource_group(self, phase: str) -> ResourceGroup:
-        return self._manager.get_resource_group(phase)
+    def add_resources(self, resource_type: str, resource_names: List[str],
+                      producer: Any, dependencies: List[str]):
+        """Adds managed resources to the resource pool.
+
+        Parameters
+        ----------
+        resource_type
+            The type of the resources being added. Must be one of
+            :data:`RESOURCE_TYPES`.
+        resource_names
+            A list of names of the resources being added.
+        producer
+            A method or object that will produce the resources.
+        dependencies
+            A list of resource names formatted as
+            ``resource_type.resource_name`` that the producer requires.
+
+        Raises
+        ------
+        ResourceError
+            If either the resource type is invalid, a component has multiple
+            resource producers for the ``column`` resource type, or
+            there are multiple producers of the same resource.
+
+        """
+        self._manager.add_resources(resource_type, resource_names, producer, dependencies)
+
+    def __iter__(self):
+        """Returns a dependency-sorted iterable of population initializers.
+
+        We exclude all non-initializer dependencies. They were necessary in
+        graph construction, but we only need the column producers at population
+        creation time.
+
+        """
+        return iter(self._manager)
+

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -55,8 +55,8 @@ def test_SimulationContext_init_default(components):
     assert sim._builder.population._manager is sim._population
     assert isinstance(sim._builder.randomness, RandomnessInterface)
     assert sim._builder.randomness._manager is sim._randomness
-    assert isinstance(sim._builder.resource, ResourceInterface)
-    assert sim._builder.resource._manager is sim._resource
+    assert isinstance(sim._builder.resources, ResourceInterface)
+    assert sim._builder.resources._manager is sim._resource
     assert isinstance(sim._builder.time, TimeInterface)
     assert sim._builder.time._manager is sim._clock
     assert isinstance(sim._builder.components, ComponentInterface)

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -11,7 +11,7 @@ class DummyPopulationManager:
 
 def test_create_PopulationView_with_all_columns():
     manager = DummyPopulationManager()
-    view = PopulationView(manager)
+    view = PopulationView(manager, 0)
     assert set(view.columns) == {'age', 'sex'}
 
 


### PR DESCRIPTION
I was going back to write tests and I realized I severely overengineered the resource manager, which made things way more confusing.  Notes in the code.  Included are docstring and comments in the resource manager code that should make this review less confusing than the initial version.