### PR TITLE
Fix bug writing invalid artifact hdf keys

### DIFF
--- a/src/vivarium/framework/artifact/artifact.py
+++ b/src/vivarium/framework/artifact/artifact.py
@@ -118,8 +118,8 @@ class Artifact:
         elif data is None:
             raise ArtifactException(f'Attempting to write to key {entity_key} with no data.')
         else:
-            self._keys.append(entity_key)
             hdf.write(self._path, entity_key, data)
+            self._keys.append(entity_key)
 
     def remove(self, entity_key: str):
         """Removes data associated with the provided key from the artifact.

--- a/tests/framework/artifact/test_artifact.py
+++ b/tests/framework/artifact/test_artifact.py
@@ -182,8 +182,8 @@ def test_artifact_write(hdf_mock, keys_mock):
     assert key in a.keys
     assert key not in a._cache
     expected_call = [call(path, 'metadata.keyspace', ['metadata.keyspace']),
-                     call(path, 'metadata.keyspace', keys_mock + [key]),
-                     call(path, key, 'data')]
+                     call(path, key, 'data'),
+                     call(path, 'metadata.keyspace', keys_mock + [key])]
     assert hdf_mock.write.call_args_list == expected_call
     assert set(a.keys) == set(initial_keys + [key])
 
@@ -296,8 +296,8 @@ def test_replace(hdf_mock, keys_mock):
     new_keyspace = [k for k in keys_mock + [key]]
 
     assert hdf_mock.write.call_args_list == [call(path, keyspace_key, [str(keyspace_key)]),
-                                             call(path, keyspace_key, new_keyspace),
-                                             call(path, key, 'data')]
+                                             call(path, key, 'data'),
+                                             call(path, keyspace_key, new_keyspace)]
 
     hdf_mock.reset_mock()
 
@@ -308,7 +308,8 @@ def test_replace(hdf_mock, keys_mock):
     assert hdf_mock.remove.call_args_list == expected_calls_remove
 
     expected_calls_write = [call(path, keyspace_key, new_keyspace),
-                            call(path, keyspace_key, new_keyspace), call(path, key, 'new_data')]
+                            call(path, key, 'new_data'),
+                            call(path, keyspace_key, new_keyspace)]
     assert hdf_mock.write.call_args_list == expected_calls_write
     assert key in a.keys
 

--- a/tests/framework/artifact/test_hdf.py
+++ b/tests/framework/artifact/test_hdf.py
@@ -272,7 +272,8 @@ def test_EntityKey_init_failure():
     bad_keys = ['hello', 'a.b.c.d', '', '.', '.coconut', 'a.', 'a..c']
 
     for k in bad_keys:
-        with pytest.raises(ValueError):
+        error_msg = f'Invalid format for HDF key: {k}. Acceptable formats are "type.name.measure" and "type.measure"'
+        with pytest.raises(ValueError, match=error_msg):
             hdf.EntityKey(k)
 
 


### PR DESCRIPTION
We were adding a new key to the list of keys before validating the key. Key validation happens automatically within the `hdf.write()` method, so moving that before appending the key fixes the issue. 

Underlying `test_hdf` tests all relevant functionality, so merely testing that the call to `hdf.write()` happens before `self._keys.append()` is sufficient.