### PR TITLE
swap try-except for explicit raise in popview get

### DIFF
--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -10,7 +10,6 @@ simulants and providing the ability for components to view and update simulant
 state safely during runtime.
 
 """
-import warnings
 from types import MethodType
 from typing import List, Callable, Union, Dict, Any, NamedTuple, Tuple
 

--- a/src/vivarium/framework/population.py
+++ b/src/vivarium/framework/population.py
@@ -10,6 +10,7 @@ simulants and providing the ability for components to view and update simulant
 state safely during runtime.
 
 """
+import warnings
 from types import MethodType
 from typing import List, Callable, Union, Dict, Any, NamedTuple, Tuple
 
@@ -168,11 +169,11 @@ class PopulationView:
             return pop
         else:
             columns = self._columns
-            try:
-                return pop.loc[:, columns]
-            except KeyError:
-                non_existent_columns = set(columns) - set(pop.columns)
+            non_existent_columns = set(columns) - set(pop.columns)
+            if non_existent_columns:
                 raise PopulationError(f'Requested column(s) {non_existent_columns} not in population table.')
+            else:
+                return pop.loc[:, columns]
 
     def update(self, population_update: Union[pd.DataFrame, pd.Series]):
         """Updates the state table with the provided data.


### PR DESCRIPTION
The old try-except didn't work because a KeyError was not thrown on missing columns (unless only one column was passed).
