### PR TITLE
Fix stratification by different sized groups

### DIFF
--- a/src/vivarium/framework/results.py
+++ b/src/vivarium/framework/results.py
@@ -13,6 +13,7 @@ if typing.TYPE_CHECKING:
 
 
 class ResultsContext:
+    """Core logic for results production from population state information."""
 
     default_grouper = 'default'
     default_grouper_value = True
@@ -187,6 +188,11 @@ class ResultsContext:
 
     @staticmethod
     def _broadcast_results(aggregates: pd.Series) -> pd.DataFrame:
+        """Broadcasts results over all unobserved values.
+
+        This method requires that index levels are all categorical and
+        contain information about all possible observations.
+        """
         # First clear out the default grouper
         aggregates = ResultsContext._clear_default_grouper(aggregates)
 
@@ -212,6 +218,7 @@ class ResultsContext:
 
     @staticmethod
     def _clear_default_grouper(aggregates: pd.Series) -> pd.Series:
+        """Removes default grouper from index levels."""
         if isinstance(aggregates.index, pd.MultiIndex):
             aggregates.index = aggregates.index.droplevel(level=ResultsContext.default_grouper)
         else:

--- a/src/vivarium/framework/results.py
+++ b/src/vivarium/framework/results.py
@@ -1,6 +1,6 @@
 from collections import defaultdict, Counter
 import typing
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple
 
 import pandas as pd
 from pandas.core.groupby import GroupBy


### PR DESCRIPTION
```
# No stratification

{'MEASURE_ylds_due_to_all_causes': 14.986007572096149,
 'MEASURE_ylds_due_to_diarrheal_diseases': 195.35331299339617,
 'total_population': 10000,
 'total_population_tracked': 10000,
 'total_population_untracked': 0}

# Single column stratification

{'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4': 5.080433034508548,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal': 1.1368200674839861,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal': 8.768754470103614,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4': 66.22707348555784,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal': 14.819261593987672,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal': 114.30697791385069,
 'total_population': 10000,
 'total_population_tracked': 10000,
 'total_population_untracked': 0}

# Multi-column stratification

{'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4_CURRENT_YEAR_2020_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4_CURRENT_YEAR_2020_SEX_male': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4_CURRENT_YEAR_2021_SEX_female': 1.2482099550846524,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4_CURRENT_YEAR_2021_SEX_male': 1.311003346855611,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4_CURRENT_YEAR_2022_SEX_female': 1.1608162595992735,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_1_to_4_CURRENT_YEAR_2022_SEX_male': 1.3604034729690109,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal_CURRENT_YEAR_2020_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal_CURRENT_YEAR_2020_SEX_male': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal_CURRENT_YEAR_2021_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal_CURRENT_YEAR_2021_SEX_male': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal_CURRENT_YEAR_2022_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_early_neonatal_CURRENT_YEAR_2022_SEX_male': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal_CURRENT_YEAR_2020_SEX_female': 0.5859792686640221,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal_CURRENT_YEAR_2020_SEX_male': 0.5508407988199642,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal_CURRENT_YEAR_2021_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal_CURRENT_YEAR_2021_SEX_male': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal_CURRENT_YEAR_2022_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_late_neonatal_CURRENT_YEAR_2022_SEX_male': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal_CURRENT_YEAR_2020_SEX_female': 1.8350359712695008,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal_CURRENT_YEAR_2020_SEX_male': 2.0012946543282735,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal_CURRENT_YEAR_2021_SEX_female': 2.4191700925587054,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal_CURRENT_YEAR_2021_SEX_male': 2.513253751947134,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal_CURRENT_YEAR_2022_SEX_female': 0.0,
 'MEASURE_ylds_due_to_all_causes_AGE_GROUP_post_neonatal_CURRENT_YEAR_2022_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4_CURRENT_YEAR_2020_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4_CURRENT_YEAR_2020_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4_CURRENT_YEAR_2021_SEX_female': 16.27130834306779,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4_CURRENT_YEAR_2021_SEX_male': 17.08986505722492,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4_CURRENT_YEAR_2022_SEX_female': 15.13206909834767,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_1_to_4_CURRENT_YEAR_2022_SEX_male': 17.733830986917457,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal_CURRENT_YEAR_2020_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal_CURRENT_YEAR_2020_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal_CURRENT_YEAR_2021_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal_CURRENT_YEAR_2021_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal_CURRENT_YEAR_2022_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_early_neonatal_CURRENT_YEAR_2022_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal_CURRENT_YEAR_2020_SEX_female': 7.638658323655999,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal_CURRENT_YEAR_2020_SEX_male': 7.180603270331674,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal_CURRENT_YEAR_2021_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal_CURRENT_YEAR_2021_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal_CURRENT_YEAR_2022_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_late_neonatal_CURRENT_YEAR_2022_SEX_male': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal_CURRENT_YEAR_2020_SEX_female': 23.921004625477426,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal_CURRENT_YEAR_2020_SEX_male': 26.08830531535071,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal_CURRENT_YEAR_2021_SEX_female': 31.535610135140274,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal_CURRENT_YEAR_2021_SEX_male': 32.76205783788229,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal_CURRENT_YEAR_2022_SEX_female': 0.0,
 'MEASURE_ylds_due_to_diarrheal_diseases_AGE_GROUP_post_neonatal_CURRENT_YEAR_2022_SEX_male': 0.0,
 'total_population': 10000,
 'total_population_tracked': 10000,
 'total_population_untracked': 0}
```