### PR TITLE
remove vivarium dependencies on location in configuration file

### DIFF
--- a/src/vivarium/framework/artifact/__init__.py
+++ b/src/vivarium/framework/artifact/__init__.py
@@ -1,4 +1,3 @@
 from .hdf import EntityKey
 from .artifact import Artifact, ArtifactException
-from .manager import (ArtifactManager, ArtifactInterface, parse_artifact_path_config,
-                      get_location_term, filter_data, validate_filter_term)
+from .manager import ArtifactManager, ArtifactInterface, parse_artifact_path_config, filter_data, validate_filter_term

--- a/src/vivarium/framework/artifact/manager.py
+++ b/src/vivarium/framework/artifact/manager.py
@@ -29,7 +29,6 @@ class ArtifactManager:
             'artifact_path': None,
             'artifact_filter_term': None,
             'input_draw_number': None,
-            'location': None,
         }
     }
 
@@ -183,7 +182,7 @@ def _subset_rows(data: pd.DataFrame, **column_filters: _Filter) -> pd.DataFrame:
 
 def _subset_columns(data: pd.DataFrame, **column_filters) -> pd.DataFrame:
     """Filters out unwanted columns and default columns from the data using provided filters."""
-    columns_to_remove = set(list(column_filters.keys()) + ['draw', 'location'])
+    columns_to_remove = set(list(column_filters.keys()) + ['draw'])
     columns_to_remove = columns_to_remove.intersection(data.columns)
     return data.drop(columns=columns_to_remove)
 
@@ -196,24 +195,7 @@ def get_base_filter_terms(configuration: ConfigTree):
     if draw is not None:
         base_filter_terms.append(f'draw == {draw}')
 
-    location = configuration.input_data.location
-    if location is not None:
-        base_filter_terms.append(get_location_term(location))
-
     return base_filter_terms
-
-
-def get_location_term(location: str) -> str:
-    """Generates a location filter term from a location name."""
-    template = "location == {quote_mark}{loc}{quote_mark} | location == {quote_mark}Global{quote_mark}"
-    if "'" in location and '"' in location:  # Because who knows
-        raise NotImplementedError(f"Unhandled location string {location}")
-    elif "'" in location:
-        quote_mark = '"'
-    else:
-        quote_mark = "'"
-
-    return template.format(quote_mark=quote_mark, loc=location)
 
 
 def parse_artifact_path_config(config: ConfigTree) -> str:

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -59,13 +59,16 @@ def simulate():
 @simulate.command()
 @click.argument('model_specification',
                 type=click.Path(exists=True, dir_okay=False, resolve_path=True))
+@click.option('--location', '-l', help='Location to run the simulation in.')
+@click.option('--artifact_path', '-i', type=click.Path(resolve_path=True), help='The path to the artifact data file.')
 @click.option('--results_directory', '-o', type=click.Path(resolve_path=True),
               default=Path('~/vivarium_results/').expanduser(),
               help='The directory to write results to. A folder will be created '
                    'in this directory with the same name as the configuration file.')
 @click.option('--verbose', '-v', is_flag=True, help='Report each time step.')
 @click.option('--pdb', 'with_debugger', is_flag=True, help='Drop into python debugger if an error occurs.')
-def run(model_specification, results_directory, verbose, with_debugger):
+def run(model_specification: Path, location: str, artifact_path: Path, results_directory: Path, verbose: int,
+        with_debugger: bool):
     """Run a simulation from the command line.
 
     The simulation itself is defined by the given MODEL_SPECIFICATION yaml file.
@@ -83,8 +86,15 @@ def run(model_specification, results_directory, verbose, with_debugger):
     configure_logging_to_file(results_root)
     shutil.copy(model_specification, results_root / 'model_specification.yaml')
 
+    output_data = {'results_directory': str(results_root)}
+    input_data = {}
+    if location:
+        input_data['location'] = location
+    if artifact_path:
+        input_data['artifact_path'] = artifact_path
+    override_configuration = {'output_data': output_data, 'input_data': input_data}
+
     main = handle_exceptions(run_simulation, logger, with_debugger)
-    override_configuration = {'output_data': {'results_directory': str(results_root)}}
     finished_sim = main(model_specification, configuration=override_configuration)
 
     metrics = pd.DataFrame(finished_sim.report(), index=[0])

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -78,7 +78,7 @@ class TestPopulation(NonCRNTestPopulation):
                                         'age': age.values}, index=pop_data.index)
         self.register(core_population)
 
-        location = self.config.input_data.location
+        location = self.config.input_data.location if 'location' in self.config.input_data.keys() else None
         population = _build_population(core_population, location, self.randomness)
         self.population_view.update(population)
 

--- a/tests/framework/artifact/test_manager.py
+++ b/tests/framework/artifact/test_manager.py
@@ -4,7 +4,7 @@ import pandas as pd
 
 import pytest
 from vivarium.testing_utilities import build_table, metadata
-from vivarium.framework.artifact.manager import (_subset_rows, _subset_columns, get_location_term,
+from vivarium.framework.artifact.manager import (_subset_rows, _subset_columns,
                                                  parse_artifact_path_config, ArtifactManager,
                                                  _config_filter, validate_filter_term)
 
@@ -44,8 +44,8 @@ def test_subset_rows():
 
 
 def test_subset_columns():
-    values = [0, 'Kenya', 'red', 100]
-    data = build_table(values, 1990, 2010, columns=('age', 'year', 'sex', 'draw', 'location', 'color', 'value'))
+    values = [0, 'red', 100]
+    data = build_table(values, 1990, 2010, columns=('age', 'year', 'sex', 'draw', 'color', 'value'))
 
     filtered_data = _subset_columns(data)
     assert filtered_data.equals(data[['age_start', 'age_end', 'year_start',
@@ -54,13 +54,6 @@ def test_subset_columns():
     filtered_data = _subset_columns(data, color='red')
     assert filtered_data.equals(data[['age_start', 'age_end', 'year_start',
                                       'year_end', 'sex', 'value']])
-
-
-def test_location_term():
-    assert get_location_term("Cote d'Ivoire") == 'location == "Cote d\'Ivoire" | location == "Global"'
-    assert get_location_term("Kenya") == "location == 'Kenya' | location == 'Global'"
-    with pytest.raises(NotImplementedError):
-        get_location_term("W'eird \"location\"")
 
 
 def test_parse_artifact_path_config(base_config, test_data_dir):


### PR DESCRIPTION
Tested by running against a version of lung cancer with an artifact that had the location column stripped from the artifact.
Also works running against a version of lung cancer with the standard artifact including location columns in the artifact, which use column filters in data loading (i.e. `builder.data.load(key, location='SwissRE Coverage')` rather than `builder.data.load(key)`)
Test suite passes.

If we want to support artifacts having a location column, we will need some changes in `vivarium_public_health` to change all calls to `builder.data.load` to have the location filter.