### PR TITLE
update builder api docs and add link to existing artifact manager docs

### DIFF
--- a/docs/source/api_reference/framework/artifact/manager.rst
+++ b/docs/source/api_reference/framework/artifact/manager.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium.framework.artifact.manager

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -183,32 +183,32 @@ class Builder:
     Attributes
     ----------
     lookup: LookupTableInterface
-        provides access to simulant-specific data via the
-        :ref:`lookup table<lookup_concept>` abstraction
+        Provides access to simulant-specific data via the
+        :ref:`lookup table<lookup_concept>` abstraction.
     value: ValuesInterface
-        provides access to computed simulant attribute values via the
-        :ref:`value pipeline<values_concept>` system
+        Provides access to computed simulant attribute values via the
+        :ref:`value pipeline<values_concept>` system.
     event: EventInterface
-        provides access to event listeners utilized in the
-        :ref:`event<event_concept>` system
+        Provides access to event listeners utilized in the
+        :ref:`event<event_concept>` system.
     population: PopulationInterface
-        provides access to simulant state table via the
-        :ref:`population<population_concept>` system
+        Provides access to simulant state table via the
+        :ref:`population<population_concept>` system.
     resource: ResourceInterface
-        provides access to the :ref:`resource<resource_concept>` system,
-        which manages dependencies between components
+        Provides access to the :ref:`resource<resource_concept>` system,
+        which manages dependencies between components.
     time: TimeInterface
-        provides access to the simulation's :ref:`clock<time_concept>`
+        Provides access to the simulation's :ref:`clock<time_concept>`.
     components: ComponentInterface
-        provides access to the :ref:`component management<components_concept>`
+        Provides access to the :ref:`component management<components_concept>`
         system, which maintains a reference to all managers and components in
-        the simulation
+        the simulation.
     lifecycle: LifeCycleInterface
-        provides access to the :ref:`life-cycle<lifecycle_concept>` system,
-        which manages the simulation's execution life-cycle
+        Provides access to the :ref:`life-cycle<lifecycle_concept>` system,
+        which manages the simulation's execution life-cycle.
     data: ArtifactInterface
-        provides access to the simulation's input data housed in the
-        :ref:`data artifact<data_concept>`
+        Provides access to the simulation's input data housed in the
+        :ref:`data artifact<data_concept>`.
 
     Notes
     -----

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -175,7 +175,47 @@ class SimulationContext:
 
 
 class Builder:
-    """Toolbox for constructing and configuring simulation components."""
+    """Toolbox for constructing and configuring simulation components.
+
+    This is the access point for components through which they are able to
+    utilize a variety of interfaces to interact with the simulation framework.
+
+    Attributes
+    ----------
+    lookup: LookupTableInterface
+        provides access to simulant-specific data via the
+        :ref:`lookup table<lookup_concept>` abstraction
+    value: ValuesInterface
+        provides access to computed simulant attribute values via the
+        :ref:`value pipeline<values_concept>` system
+    event: EventInterface
+        provides access to event listeners utilized in the
+        :ref:`event<event_concept>` system
+    population: PopulationInterface
+        provides access to simulant state table via the
+        :ref:`population<population_concept>` system
+    resource: ResourceInterface
+        provides access to the :ref:`resource<resource_concept>` system,
+        which manages dependencies between components
+    time: TimeInterface
+        provides access to the simulation's :ref:`clock<time_concept>`
+    components: ComponentInterface
+        provides access to the :ref:`component management<components_concept>`
+        system, which maintains a reference to all managers and components in
+        the simulation
+    lifecycle: LifeCycleInterface
+        provides access to the :ref:`life-cycle<lifecycle_concept>` system,
+        which manages the simulation's execution life-cycle
+    data: ArtifactInterface
+        provides access to the simulation's input data housed in the
+        :ref:`data artifact<data_concept>`
+
+    Notes
+    -----
+    A `Builder` should never be created directly. It will automatically be
+    created during the initialization of a :class:`SimulationContext`
+
+    """
 
     def __init__(self, configuration, plugin_manager):
         self.configuration = configuration

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -50,7 +50,7 @@ class InterpolatedTable:
     Notes
     -----
     These should not be created directly. Use the `lookup` interface on the
-    class:`Builder` during setup.
+    :class:`Builder` during setup.
 
     """
     def __init__(self,

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -50,7 +50,7 @@ class InterpolatedTable:
     Notes
     -----
     These should not be created directly. Use the `lookup` interface on the
-    :class:`Builder` during setup.
+    :class:`builder <vivarium.framework.engine.Builder>` during setup.
 
     """
     def __init__(self,


### PR DESCRIPTION
Added API docs for the `Builder` object. 

Fixed a broken link in `lookup.py`.

Added the file to enable auto-generation of the missing `Artifact Manager` page.