### PR TITLE
Check for python version 3.6-3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,14 @@
+import sys
+if sys.version_info < (3, 6) or sys.version_info >= (3, 9):
+    # Python 3.5 does not support f-strings
+    py_version = '.'.join([str(v) for v in sys.version_info[:3]])
+    error = ('\n----------------------------------------\n'
+            'Error: Vivarium runs under python 3.6-3.8.\n'
+            'You are running python {py_version}'.format(py_version = py_version))
+    print(error, file=sys.stderr)
+    sys.exit(1)
+
+
 from pathlib import Path
 
 from setuptools import setup, find_packages


### PR DESCRIPTION
Tested under virtual environments using 3.5-3.9
The entire error message looks like this:

```
Looking in indexes: https://pypi.org/simple, https://artifactory.ihme.washington.edu/artifactory/api/pypi/pypi-shared/simple
Obtaining file:///home/kjells/repos/framework/vivarium
    ERROR: Command errored out with exit status 1:
     command: /home/kjells/miniconda3/envs/p39/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/kjells/repos/framework/vivarium/setup.py'"'"'; __file__='"'"'/home/kjells/repos/framework/vivarium/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-nyfs0lnc
         cwd: /home/kjells/repos/framework/vivarium/
    Complete output (4 lines):
    
    ----------------------------------------
    Error: Vivarium runs under python 3.6-3.8.
    You are running python 3.9.6
    ----------------------------------------
WARNING: Discarding file:///home/kjells/repos/framework/vivarium. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

```