### PR TITLE
Add networkx.DiGraph to list of nitpick exceptions for sphinx

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -7,6 +7,9 @@ py:class pandas.core.frame.DataFrame
 py:class pandas.core.series.Series
 py:class pandas.core.generic.PandasObject
 
+# networkx
+py:class networkx.classes.digraph.DiGraph
+
 # vivarium
 # Type aliases don't play nicely with sphinx when you import them
 # elsewhere.  Works fine for static type checker though.  I think this


### PR DESCRIPTION
I am not sure exactly what changed since [the last successful CI run in August](https://github.com/ihmeuw/vivarium/runs/3343091799), but I can reproduce [the CI failure on my pull request](https://github.com/ihmeuw/vivarium/pull/189/checks?check_run_id=3832985713) on `main` -- it isn't related to my changes.

This PR adds networkx.DiGraph to the list of nitpicks sphinx should ignore while building the documentation, which fixes the issue.