### PR TITLE
Add current time to interactive sim

### DIFF
--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -38,6 +38,11 @@ class InteractiveContext(SimulationContext):
         if setup:
             self.setup()
 
+    @property
+    def current_time(self) -> Time:
+        """Returns the current simulation time."""
+        return self._clock.time
+
     def setup(self):
         super().setup()
         self.initialize_simulants()


### PR DESCRIPTION
## Add current time to interactive sim
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-1562](https://jira.ihme.washington.edu/browse/MIC-1562)

### Testing
Interactive test:
```
>>> from vivarium import InteractiveContext
>>> sim = InteractiveContext("src/vivarium/examples/disease_model/disease_model.yaml")
2022-02-13 13:10:26.941 | DEBUG    | vivarium.framework.values:register_value_modifier:392 - Registering metrics.1.population_manager.metrics as modifier to metrics
...
>>> sim.current_time
Timestamp('2022-01-01 00:00:00')
>>> sim.step()
2022-02-13 13:11:08.715 | DEBUG    | vivarium.framework.engine:step:169 - 2022-01-01 00:00:00
>>> sim.current_time
Timestamp('2022-01-01 12:00:00')
```