### PR TITLE
Squash pandas future warning

### DIFF
--- a/src/vivarium/framework/randomness.py
+++ b/src/vivarium/framework/randomness.py
@@ -88,13 +88,13 @@ class IndexMap:
         if self._map.empty:
             self._map = mapping_update.drop_duplicates()
         else:
-            self._map = self._map.append(mapping_update).drop_duplicates()
+            self._map = pd.concat([self._map, mapping_update]).drop_duplicates()
 
         collisions = mapping_update.index.difference(self._map.index)
         salt = 1
         while not collisions.empty:
             mapping_update = self.hash_(collisions, salt)
-            self._map = self._map.append(mapping_update).drop_duplicates()
+            self._map = pd.concat([self._map, mapping_update]).drop_duplicates()
             collisions = mapping_update.index.difference(self._map.index)
             salt += 1
 


### PR DESCRIPTION
## Squash pandas future warning
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-2877](https://jira.ihme.washington.edu/browse/MIC-2877)

Using python version 3.8.12 and pandas version 1.4.0 produces a
FutureWarning that `pandas.Series.append` is being deprecated
from it's usage in our randomness system.  This PR swaps 
the append implementation in favor of `pandas.concat`.

### Testing
Before the fix, the warning was producible with
```
>>> from vivarium import InteractiveContext
>>> sim = InteractiveContext("src/vivarium/examples/disease_model/disease_model.yaml")
2022-02-13 13:20:38.387 | DEBUG    | vivarium.framework.values:register_value_modifier:392 - Registering metrics.1.population_manager.metrics as modifier to metrics
...
2022-02-13 13:20:38.391 | DEBUG    | vivarium.framework.values:_register_value_producer:338 - Registering value pipeline metrics
/home/collijk/code/vivarium/vivarium/src/vivarium/framework/randomness.py:97: FutureWarning: The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  self._map = self._map.append(mapping_update).drop_duplicates()
...
/home/collijk/code/vivarium/vivarium/src/vivarium/framework/randomness.py:97: FutureWarning: The series.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.
  self._map = self._map.append(mapping_update).drop_duplicates()
```
After the patch, the same code no longer produces an error.  All standard CI checks pass.

