### PR TITLE
Add a warning when the path passed to Artifact doesn't exist

### DIFF
--- a/src/vivarium/framework/artifact/artifact.py
+++ b/src/vivarium/framework/artifact/artifact.py
@@ -11,6 +11,7 @@ archive file for convenient access and inspection.
 
 """
 import re
+import warnings
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, List, Union
@@ -64,6 +65,7 @@ class Artifact:
     def create_hdf_with_keyspace(self):
         """Creates the artifact HDF file and adds a node to track keys."""
         if not self._path.is_file():
+            warnings.warn(f"No artifact found at {self._path}. Building new artifact.")
             hdf.touch(self._path)
             hdf.write(self._path, "metadata.keyspace", ["metadata.keyspace"])
 


### PR DESCRIPTION
## Warning on new Artifact creation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-784](https://jira.ihme.washington.edu/browse/MIC-784)

No behavior change aside from displaying a warning when a new 
artifact is made.

### Testing
Before:
```
>>> from vivarium import Artifact
>>> art = Artifact('not_a_path.hdf')
```
After:
```
>>> from vivarium import Artifact
>>> art = Artifact('not_a_path.hdf')
/home/collijk/code/vivarium/vivarium/src/vivarium/framework/artifact/artifact.py:68: UserWarning: No artifact found at not_a_path.hdf. Building new artifact.
  warnings.warn(f"No artifact found at {self._path}. Building new artifact.")
```
