### PR TITLE
Handle deprecation warning for default series dtype

### DIFF
--- a/src/vivarium/framework/randomness.py
+++ b/src/vivarium/framework/randomness.py
@@ -250,7 +250,7 @@ def random(key: str, index: Index, index_map: IndexMap = None) -> pd.Series:
         raw_draws = random_state.random_sample(sample_size)
         return pd.Series(raw_draws[draw_index], index=index)
 
-    return pd.Series(index=index)  # Structured null value
+    return pd.Series(index=index, dtype=float)  # Structured null value
 
 
 def get_hash(key: str) -> int:


### PR DESCRIPTION
## Fix pandas deprecation warning
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
- *Category*: bugfix
- *JIRA issue*: N/A

Squash a FutureWarning

### Testing
CI