### PR TITLE
Collijk/feature/performance reporting

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -207,15 +207,18 @@ class SimulationContext:
     def get_performance_metrics(self) -> pd.DataFrame:
         timing_dict = self._lifecycle.timings
         total_time = np.sum([np.sum(v) for v in timing_dict.values()])
-        timing_dict['total'] = [total_time]
-        records = [{
-            "Event": label,
-            "Count": len(ts),
-            "Mean time (s)": np.mean(ts),
-            "Std. dev. time (s)": np.std(ts),
-            "Total time (s)": sum(ts),
-            "% Total time": 100 * sum(ts) / total_time
-        } for label, ts in timing_dict.items()]
+        timing_dict["total"] = [total_time]
+        records = [
+            {
+                "Event": label,
+                "Count": len(ts),
+                "Mean time (s)": np.mean(ts),
+                "Std. dev. time (s)": np.std(ts),
+                "Total time (s)": sum(ts),
+                "% Total time": 100 * sum(ts) / total_time,
+            }
+            for label, ts in timing_dict.items()
+        ]
         performance_metrics = pd.DataFrame(records)
         return performance_metrics
 

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -18,9 +18,9 @@ Finally, there are a handful of wrapper methods that allow a user or user
 tools to easily setup and run a simulation.
 
 """
+import time
 from pathlib import Path
 from pprint import pformat
-import time
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
@@ -213,10 +213,18 @@ class SimulationContext:
             [label, len(ts), np.mean(ts), np.std(ts), sum(ts), 100 * sum(ts) / total_time]
             for label, ts in timing_dict.items()
         ]
-        records.append(['total', 1, total_time, 0., total_time, 100.])
-        performance_metrics = pd.DataFrame(records, columns=[
-            'Event', 'Count', 'Mean time (s)', 'Std. dev. time (s)', 'Total time (s)', '%'
-        ])
+        records.append(["total", 1, total_time, 0.0, total_time, 100.0])
+        performance_metrics = pd.DataFrame(
+            records,
+            columns=[
+                "Event",
+                "Count",
+                "Mean time (s)",
+                "Std. dev. time (s)",
+                "Total time (s)",
+                "%",
+            ],
+        )
         return performance_metrics
 
     def add_components(self, component_list):

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -53,7 +53,6 @@ class SimulationContext:
         configuration: Union[Dict, ConfigTree] = None,
         plugin_configuration: Union[Dict, ConfigTree] = None,
     ):
-        bootstrap_time_start = time.time()
         # Bootstrap phase: Parse arguments, make private managers
         component_configuration = (
             components if isinstance(components, (dict, ConfigTree)) else None

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -206,24 +206,17 @@ class SimulationContext:
 
     def get_performance_metrics(self) -> pd.DataFrame:
         timing_dict = self._lifecycle.timings
-
         total_time = np.sum([np.sum(v) for v in timing_dict.values()])
-        records = [
-            [label, len(ts), np.mean(ts), np.std(ts), sum(ts), 100 * sum(ts) / total_time]
-            for label, ts in timing_dict.items()
-        ]
-        records.append(["total", 1, total_time, 0.0, total_time, 100.0])
-        performance_metrics = pd.DataFrame(
-            records,
-            columns=[
-                "Event",
-                "Count",
-                "Mean time (s)",
-                "Std. dev. time (s)",
-                "Total time (s)",
-                "%",
-            ],
-        )
+        timing_dict['total'] = [total_time]
+        records = [{
+            "Event": label,
+            "Count": len(ts),
+            "Mean time (s)": np.mean(ts),
+            "Std. dev. time (s)": np.std(ts),
+            "Total time (s)": sum(ts),
+            "% Total time": 100 * sum(ts) / total_time
+        } for label, ts in timing_dict.items()]
+        performance_metrics = pd.DataFrame(records)
         return performance_metrics
 
     def add_components(self, component_list):

--- a/src/vivarium/framework/lifecycle.py
+++ b/src/vivarium/framework/lifecycle.py
@@ -30,9 +30,13 @@ There are two flavors of contracts that this system enforces:
 The tools here also allow for introspection of the simulation life cycle.
 
 """
+from collections import defaultdict
 import functools
 import textwrap
-from typing import Callable, List, Optional, Tuple
+import time
+from typing import Callable, Dict, List, Optional, Tuple
+
+import numpy as np
 
 from vivarium.exceptions import VivariumError
 
@@ -449,6 +453,8 @@ class LifeCycleManager:
     def __init__(self):
         self.lifecycle = LifeCycle()
         self._current_state = self.lifecycle.get_state("initialization")
+        self._current_state_start_time = time.time()
+        self._timings = defaultdict(list)
         self._make_constraint = ConstraintMaker(self)
 
     @property
@@ -460,6 +466,10 @@ class LifeCycleManager:
     def current_state(self) -> str:
         """The name of the current life cycle state."""
         return self._current_state.name
+
+    @property
+    def timings(self) -> Dict[str, List[float]]:
+        return self._timings
 
     def add_phase(self, phase_name: str, states: List[str], loop: bool = False):
         """Add a new phase to the lifecycle.
@@ -504,8 +514,12 @@ class LifeCycleManager:
         """
         new_state = self.lifecycle.get_state(state)
         if self._current_state.valid_next_state(new_state):
+            self._timings[self._current_state.name].append(
+                time.time() - self._current_state_start_time
+            )
             new_state.enter()
             self._current_state = new_state
+            self._current_state_start_time = time.time()
         else:
             raise InvalidTransitionError(
                 f"Invalid transition from {self.current_state} "

--- a/src/vivarium/framework/lifecycle.py
+++ b/src/vivarium/framework/lifecycle.py
@@ -30,10 +30,10 @@ There are two flavors of contracts that this system enforces:
 The tools here also allow for introspection of the simulation life cycle.
 
 """
-from collections import defaultdict
 import functools
 import textwrap
 import time
+from collections import defaultdict
 from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -25,12 +25,7 @@ from .utilities import log_progress, run_from_ipython
 
 
 class InteractiveContext(SimulationContext):
-    """A simulation context with helper methods for running simulations
-    interactively.
-
-    This class should not be instantiated directly. It should be created with a
-    call to one of the helper methods provided in this module.
-    """
+    """A simulation context with helper methods for running simulations interactively."""
 
     def __init__(self, *args, setup=True, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Add performance reporting
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-3093](https://jira.ihme.washington.edu/browse/MIC-3093)

Vivarium will now log a report that looks like 
```
              Event  Count  Mean time (s)  Std. dev. time (s)  Total time (s)      %
     initialization      1           0.32                0.00            0.32   0.07
              setup      1           6.82                0.00            6.82   1.49
         post_setup      1           0.00                0.00            0.00   0.00
population_creation      1           8.03                0.00            8.03   1.75
 time_step__prepare    105           3.06                0.34          321.22  70.09
          time_step    105           0.79                0.11           82.48  18.00
 time_step__cleanup    105           0.11                0.02           11.56   2.52
    collect_metrics    105           0.27                0.04           27.84   6.07
     simulation_end      1           0.03                0.00            0.03   0.01
              total      1         458.30                0.00          458.30 100.00
```
at the end of every run.
### Testing
CI plus integration test with MNCH model.