### PR TITLE
Refactor type coercion into a method

### DIFF
--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -161,9 +161,8 @@ def test_population_view_get_fail(population_manager):
 
 
 @pytest.mark.parametrize(
-    'test_df',
-    (pd.DataFrame(data=RECORDS, columns=COL_NAMES),
-     pd.DataFrame(columns=COL_NAMES))
+    "test_df",
+    (pd.DataFrame(data=RECORDS, columns=COL_NAMES), pd.DataFrame(columns=COL_NAMES)),
 )
 def test_multicolumn_population_view__coerce_to_dataframe(population_manager, test_df):
     pv = population_manager.get_view(COL_NAMES)
@@ -189,11 +188,11 @@ def test_multicolumn_population_view__coerce_to_dataframe(population_manager, te
 
     # All bad columns
     with pytest.raises(PopulationError):
-        pv._coerce_to_dataframe(test_df.rename(columns=lambda x: f'bad_{x}'))
+        pv._coerce_to_dataframe(test_df.rename(columns=lambda x: f"bad_{x}"))
 
     # One bad column
     with pytest.raises(PopulationError):
-        pv._coerce_to_dataframe(test_df.rename(columns={COL_NAMES[0]: f'bad_{COL_NAMES[0]}'}))
+        pv._coerce_to_dataframe(test_df.rename(columns={COL_NAMES[0]: f"bad_{COL_NAMES[0]}"}))
 
     # Unnamed series in view with multiple cols
     cols = COL_NAMES[0]
@@ -202,9 +201,8 @@ def test_multicolumn_population_view__coerce_to_dataframe(population_manager, te
 
 
 @pytest.mark.parametrize(
-    'test_df',
-    (pd.DataFrame(data=RECORDS, columns=COL_NAMES),
-     pd.DataFrame(columns=COL_NAMES))
+    "test_df",
+    (pd.DataFrame(data=RECORDS, columns=COL_NAMES), pd.DataFrame(columns=COL_NAMES)),
 )
 def test_single_column_population_view__coerce_to_dataframe(population_manager, test_df):
     # Content doesn't matter, only format.
@@ -229,11 +227,11 @@ def test_single_column_population_view__coerce_to_dataframe(population_manager, 
 
     # Badly named df
     with pytest.raises(PopulationError):
-        pv._coerce_to_dataframe(test_df[column].rename(f'bad_{column}').to_frame())
+        pv._coerce_to_dataframe(test_df[column].rename(f"bad_{column}").to_frame())
 
     # Badly named series
     with pytest.raises(PopulationError):
-        pv._coerce_to_dataframe(test_df[column].rename(f'bad_{column}'))
+        pv._coerce_to_dataframe(test_df[column].rename(f"bad_{column}"))
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/test_population.py
+++ b/tests/framework/test_population.py
@@ -161,6 +161,82 @@ def test_population_view_get_fail(population_manager):
 
 
 @pytest.mark.parametrize(
+    'test_df',
+    (pd.DataFrame(data=RECORDS, columns=COL_NAMES),
+     pd.DataFrame(columns=COL_NAMES))
+)
+def test_multicolumn_population_view__coerce_to_dataframe(population_manager, test_df):
+    pv = population_manager.get_view(COL_NAMES)
+
+    # No-op
+    coerced_df = pv._coerce_to_dataframe(test_df)
+    assert test_df.equals(coerced_df)
+
+    # Subset
+    cols = COL_NAMES[:2]
+    coerced_df = pv._coerce_to_dataframe(test_df[cols])
+    assert test_df[cols].equals(coerced_df)
+
+    # Single col df
+    cols = [COL_NAMES[0]]
+    coerced_df = pv._coerce_to_dataframe(test_df[cols])
+    assert test_df[cols].equals(coerced_df)
+
+    # Series
+    cols = COL_NAMES[0]
+    coerced_df = pv._coerce_to_dataframe(test_df[cols])
+    assert test_df[[cols]].equals(coerced_df)
+
+    # All bad columns
+    with pytest.raises(PopulationError):
+        pv._coerce_to_dataframe(test_df.rename(columns=lambda x: f'bad_{x}'))
+
+    # One bad column
+    with pytest.raises(PopulationError):
+        pv._coerce_to_dataframe(test_df.rename(columns={COL_NAMES[0]: f'bad_{COL_NAMES[0]}'}))
+
+    # Unnamed series in view with multiple cols
+    cols = COL_NAMES[0]
+    with pytest.raises(PopulationError):
+        pv._coerce_to_dataframe(test_df[cols].rename(None))
+
+
+@pytest.mark.parametrize(
+    'test_df',
+    (pd.DataFrame(data=RECORDS, columns=COL_NAMES),
+     pd.DataFrame(columns=COL_NAMES))
+)
+def test_single_column_population_view__coerce_to_dataframe(population_manager, test_df):
+    # Content doesn't matter, only format.
+    column = COL_NAMES[0]
+    pv = population_manager.get_view([column])
+
+    # Good single col df
+    coerced_df = pv._coerce_to_dataframe(test_df[[column]])
+    assert test_df[[column]].equals(coerced_df)
+
+    # Good named series
+    coerced_df = pv._coerce_to_dataframe(test_df[column])
+    assert test_df[[column]].equals(coerced_df)
+
+    # Nameless series
+    coerced_df = pv._coerce_to_dataframe(test_df[column].rename(None))
+    assert test_df[[column]].equals(coerced_df)
+
+    # Too many columns
+    with pytest.raises(PopulationError):
+        pv._coerce_to_dataframe(test_df)
+
+    # Badly named df
+    with pytest.raises(PopulationError):
+        pv._coerce_to_dataframe(test_df[column].rename(f'bad_{column}').to_frame())
+
+    # Badly named series
+    with pytest.raises(PopulationError):
+        pv._coerce_to_dataframe(test_df[column].rename(f'bad_{column}'))
+
+
+@pytest.mark.parametrize(
     "update_with",
     [
         pd.DataFrame(


### PR DESCRIPTION
## Refactor type coercion into a method
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-3090](https://jira.ihme.washington.edu/browse/MIC-3090)

Split off coercion of population updates into a dataframe into a separate 
method.  Add a bunch of unit tests.

### Testing
New unit tests

