### PR TITLE
Clean up population system logic

### DIFF
--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -325,7 +325,6 @@ class PopulationManager:
         new_population = self._population.reindex(new_index)
         index = new_population.index.difference(self._population.index)
         self._population = new_population
-
         self.adding_simulants = True
         for initializer in self.resources:
             initializer(

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -354,7 +354,7 @@ class PopulationManager:
 
         """
         pop = self._population.copy() if self._population is not None else pd.DataFrame()
-        if not untracked:
+        if not untracked and 'tracked' in pop.columns:
             pop = pop[pop.tracked]
         return pop
 

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -179,9 +179,7 @@ class PopulationManager:
 
     @property
     def columns(self) -> List[str]:
-        """The columns that currently exist in the population manager's
-        representation of state.
-        """
+        """The columns that currently exist in the state table."""
         return list(self._population.columns)
 
     def __repr__(self):
@@ -195,13 +193,16 @@ class PopulationManager:
         self, columns: Union[List[str], Tuple[str]], query: str = None
     ) -> PopulationView:
         """Get a time-varying view of the population state table.
+
         The requested population view can be used to view the current state or
         to update the state with new values.
+
         If the column 'tracked' is not specified in the ``columns`` argument,
         the query string 'tracked == True' will be added to the provided
         query argument. This allows components to ignore untracked simulants
         by default. If the columns argument is empty, the population view will
         have access to the entire state table.
+
         Parameters
         ----------
         columns
@@ -214,11 +215,13 @@ class PopulationManager:
             The query should be provided in a way that is understood by the
             :meth:`pandas.DataFrame.query` method and may reference state
             table columns not requested in the ``columns`` argument.
+
         Returns
         -------
         PopulationView
             A filtered view of the requested columns of the population state
             table.
+
         """
         view = self._get_view(columns, query)
         self._add_constraint(
@@ -254,6 +257,7 @@ class PopulationManager:
         requires_streams: List[str] = (),
     ):
         """Marks a source of initial state information for new simulants.
+
         Parameters
         ----------
         initializer
@@ -272,6 +276,7 @@ class PopulationManager:
         requires_streams
             A list of the randomness streams necessary to initialize the
             simulant attributes.
+
         """
         self._initializer_components.add(initializer, creates_columns)
         dependencies = (
@@ -289,8 +294,10 @@ class PopulationManager:
 
     def get_simulant_creator(self) -> Callable:
         """Gets a function that can generate new simulants.
+
         Returns
         -------
+        Callable
            The simulant creator function. The creator function takes the
            number of simulants to be created as it's first argument and a dict
            population configuration that will be available to simulant
@@ -300,6 +307,7 @@ class PopulationManager:
            object containing the state table index of the new simulants, the
            configuration info passed to the creator, the current simulation
            time, and the size of the next time step.
+
         """
         return self._create_simulants
 
@@ -334,14 +342,17 @@ class PopulationManager:
 
     def get_population(self, untracked: bool) -> pd.DataFrame:
         """Provides a copy of the full population state table.
+
         Parameters
         ----------
         untracked
             Whether to include untracked simulants in the returned population.
+
         Returns
         -------
         pandas.DataFrame
             A copy of the population table.
+
         """
         pop = self._population.copy() if self._population is not None else pd.DataFrame()
         if not untracked:

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -354,7 +354,7 @@ class PopulationManager:
 
         """
         pop = self._population.copy() if self._population is not None else pd.DataFrame()
-        if not untracked and 'tracked' in pop.columns:
+        if not untracked and "tracked" in pop.columns:
             pop = pop[pop.tracked]
         return pop
 

--- a/src/vivarium/framework/population/population_view.py
+++ b/src/vivarium/framework/population/population_view.py
@@ -24,12 +24,10 @@ if TYPE_CHECKING:
 
 class PopulationView:
     """A read/write manager for the simulation state table.
-
     It can be used to both read and update the state of the population. A
     PopulationView can only read and write columns for which it is configured.
     Attempts to update non-existent columns are ignored except during
     simulant creation when new columns are allowed to be created.
-
     Parameters
     ----------
     manager
@@ -40,12 +38,10 @@ class PopulationView:
     query
         A :mod:`pandas`-style filter that will be applied any time this
         view is read from.
-
     Notes
     -----
     By default, this view will filter out ``untracked`` simulants unless
     the ``tracked`` column is specified in the initialization arguments.
-
     """
 
     def __init__(
@@ -67,12 +63,10 @@ class PopulationView:
     @property
     def columns(self) -> List[str]:
         """The columns that the view can read and update.
-
         If the view was created with ``None`` as the columns argument, then
         the view will have access to the full table by default. That case
         should be only be used in situations where the full state table is
         actually needed, like for some metrics collection applications.
-
         """
         if not self._columns:
             return list(self._manager.get_population(True).columns)
@@ -81,33 +75,27 @@ class PopulationView:
     @property
     def query(self) -> Union[str, None]:
         """A :mod:`pandas` style query to filter the rows of this view.
-
         This query will be applied any time the view is read. This query may
         reference columns not in the view's columns.
-
         """
         return self._query
 
     def subview(self, columns: Union[List[str], Tuple[str]]) -> "PopulationView":
         """Retrieves a new view with a subset of this view's columns.
-
         Parameters
         ----------
         columns
             The set of columns to provide access to in the subview. Must be
             a proper subset of this view's columns.
-
         Returns
         -------
         PopulationView
             A new view with access to the requested columns.
-
         Raises
         ------
         PopulationError
             If the requested columns are not a proper subset of this view's
-            columns.
-
+            columns or no columns are requested.
         Notes
         -----
         Subviews are useful during population initialization. The original
@@ -116,24 +104,23 @@ class PopulationView:
         requesting a subview, a component can read the sections it needs
         without running the risk of trying to access uncreated columns
         because the component itself has not created them.
-
         """
-        if set(columns) - set(self.columns):
+
+        if not columns or set(columns) - set(self.columns):
             raise PopulationError(
-                f"Invalid subview requested.  Requested columns must be a subset of this "
-                f"view's columns.  Requested columns: {columns}, Available columns: {self.columns}"
+                f"Invalid subview requested.  Requested columns must be a non-empty "
+                f"subset of this view's columns.  Requested columns: {columns}, "
+                f"Available columns: {self.columns}"
             )
         # Skip constraints for requesting subviews.
         return self._manager._get_view(columns, self.query)
 
     def get(self, index: pd.Index, query: str = "") -> pd.DataFrame:
         """Select the rows represented by the given index from this view.
-
         For the rows in ``index`` get the columns from the simulation's
         state table to which this view has access. The resulting rows may be
         further filtered by the view's query and only return a subset
         of the population represented by the index.
-
         Parameters
         ----------
         index
@@ -142,23 +129,19 @@ class PopulationView:
             Additional conditions used to filter the index. These conditions
             will be unioned with the default query of this view.  The query
             provided may use columns that this view does not have access to.
-
         Returns
         -------
         pandas.DataFrame
             A table with the subset of the population requested.
-
         Raises
         ------
         PopulationError
             If this view has access to columns that have not yet been created
             and this method is called.  If you see this error, you should
             request a subview with the columns you need read access to.
-
         See Also
         --------
         :meth:`subview <PopulationView.subview>`
-
         """
         pop = self._manager.get_population(True).loc[index]
 
@@ -175,20 +158,20 @@ class PopulationView:
             non_existent_columns = set(columns) - set(pop.columns)
             if non_existent_columns:
                 raise PopulationError(
-                    f"Requested column(s) {non_existent_columns} not in population table. This is "
-                    "likely due to a failure to require some columns, randomness streams, or "
-                    "pipelines when registering a simulant initializer, a value producer, or a "
-                    "value modifier. NOTE: It is possible for a run to succeed even if resource "
-                    "requirements were not properly specified in the simulant initializers or "
-                    "pipeline creation/modification calls. This success depends on component "
-                    "initialization order which may change in different run settings."
+                    f"Requested column(s) {non_existent_columns} not in population table. "
+                    "This is likely due to a failure to require some columns, randomness "
+                    "streams, or pipelines when registering a simulant initializer, a value "
+                    "producer, or a value modifier. NOTE: It is possible for a run to "
+                    "succeed even if resource requirements were not properly specified in "
+                    "the simulant initializers or pipeline creation/modification calls. This "
+                    "success depends on component initialization order which may change in "
+                    "different run settings."
                 )
             else:
                 return pop.loc[:, columns]
 
     def update(self, population_update: Union[pd.DataFrame, pd.Series]) -> None:
         """Updates the state table with the provided data.
-
         Parameters
         ----------
         population_update
@@ -199,76 +182,123 @@ class PopulationView:
             this view's columns unless the view only has one column in which
             case the Series will be assumed to refer to that regardless of its
             name.
-
         Raises
         ------
         PopulationError
             If the provided data name or columns do not match columns that
             this view manages or if the view is being updated with a data
             type inconsistent with the original population data.
+        """
+        state_table = self._manager.get_population(True)
+        population_update = self._ensure_preconditions_and_format(population_update)
 
+        if self._manager.creating_initial_population:
+            new_columns = list(set(population_update).intersection(state_table))
+            self._manager._population.loc[:, new_columns] = population_update[new_columns]
+        elif not population_update.empty:
+            update_columns = list(set(population_update).intersection(state_table))
+            for column in update_columns:
+                column_update = self._ensure_update_dtype(
+                    population_update[column],
+                    state_table[column],
+                )
+                self._manager._population.loc[:, column] = column_update
+
+    def _ensure_preconditions_and_format(
+        self,
+        population_update: Union[pd.Series, pd.DataFrame]
+    ) -> pd.DataFrame:
+        """Standardizes the population update format and checks preconditions.
+        Managing how values get written to the underlying population state table is critical
+        to rule out several categories of error in client simulation code. The state table
+        is modified at three different times. In the first, the initial population table
+        is being created and new columns are being added to the state table with their
+        initial values. In the second, the population manager has added new rows with
+        appropriate null values to the state table in response to population creation
+        dictated by client code, and population updates are being provided to fill in
+        initial values for those new rows. In the final case, state table values for
+        existing simulants are being overridden as part of a time step.
+        All of these modification scenarios require that certain preconditions are met.
+        For all scenarios, we require
+            1. The update is a DataFrame or a Series.
+            2. If it is a series, it is nameless and this view manages a single column
+               or it is named and it's name matches a column in this PopulationView.
+            3. The update matches at least one column in this PopulationView.
+            4. The update columns are a subset of the columns managed by this
+               PopulationView.
+        For initial population creation additional preconditions are documented in
+        :meth:`PopulationView._ensure_coherent_initialization`. Outside population
+        initialization, we require that all columns in the update to be present in
+        the existing state table. When new simulants are added in the middle of the
+        simulation, we require that only one component provide updates to a column.
+        Parameters
+        ----------
+        population_update
+            The update to the simulation state table.
+        Returns
+        -------
+        pandas.DataFrame
+            The input data formatted as a DataFrame.
+        Raises
+        ------
+        TypeError
+            If the population update is not a :class:`pandas.Series` or a
+            :class:`pandas.DataFrame`.
+        PopulationError
+            If the update violates any preconditions relevant to the context in which
+            the update is provided (initial population creation, population creation on
+            time steps, or population state changes on time steps).
         """
         population_update = self._coerce_to_dataframe(population_update)
-        affected_columns = set(population_update.columns)
-
-        if population_update.empty and not affected_columns.difference(self._manager.columns):
-            return
-
         state_table = self._manager.get_population(True)
-        if not self._manager.growing:
-            affected_columns = affected_columns.intersection(state_table.columns)
 
-        for affected_column in affected_columns:
-            if affected_column in state_table:
-                if population_update.empty:
-                    continue
+        if self._manager.creating_initial_population:
+            self._ensure_coherent_initialization(population_update, state_table)
+        else:
+            new_columns = list(set(population_update).difference(state_table))
+            if new_columns:
+                raise PopulationError(
+                    f'Attempting to add new columns {new_columns} to the state table '
+                    f'outside the initial population creation phase.'
+                )
 
-                new_state_table_values = state_table[affected_column].values
-                update_values = population_update[affected_column].values
-                new_state_table_values[population_update.index] = update_values
-
-                if new_state_table_values.dtype != update_values.dtype:
-                    # This happens when the population is being grown because extending
-                    # the index forces columns that don't have a natural null type
-                    # to become 'object'
-                    if not self._manager.growing:
+            if self._manager.adding_simulants:
+                for column in population_update:
+                    if state_table.loc[population_update.index, column].notnull().any():
                         raise PopulationError(
-                            "Component corrupting population table. "
-                            f"Column name: {affected_column} "
-                            f"Old column type: {new_state_table_values.dtype} "
-                            f"New column type: {update_values.dtype}"
+                            "Two components are providing conflicting initialization data "
+                            f"for the {column} state table column."
                         )
-                    new_state_table_values = new_state_table_values.astype(
-                        update_values.dtype
-                    )
-            else:
-                new_state_table_values = population_update[affected_column].values
-            self._manager._population[affected_column] = new_state_table_values
 
     def _coerce_to_dataframe(
         self,
         population_update: Union[pd.Series, pd.DataFrame],
     ) -> pd.DataFrame:
         """Coerce all population updates to a :class:`pandas.DataFrame` format.
-
         Parameters
         ----------
         population_update
             The update to the simulation state table.
-
         Returns
         -------
         pandas.DataFrame
             The input data formatted as a DataFrame.
-
         Raises
         ------
+        TypeError
+            If the population update is not a :class:`pandas.Series` or a
+            :class:`pandas.DataFrame`.
         PopulationError
             If the input data is a :class:`pandas.Series` and this :class:`PopulationView`
             manages multiple columns or if the population update contains columns not
             managed by this view.
-
         """
+        if not isinstance(population_update, (pd.Series, pd.DataFrame)):
+            raise TypeError(
+                'The population update must be a pandas Series or DataFrame. '
+                f'A {type(population_update)} was provided.'
+            )
+
         if isinstance(population_update, pd.Series):
             if population_update.name is None:
                 if len(self.columns) == 1:
@@ -288,7 +318,85 @@ class PopulationView:
                 f"{set(population_update.columns).difference(self.columns)}."
             )
 
+        update_columns = list(population_update)
+        if not update_columns:
+            raise PopulationError(
+                "The update method of population view is being called "
+                "on a DataFrame with no columns."
+            )
+
         return population_update
+
+    @staticmethod
+    def _ensure_coherent_initialization(
+        population_update: pd.DataFrame,
+        state_table: pd.DataFrame
+    ) -> None:
+        """Ensure that overlapping population updates have the same information.
+        During population initialization, each state table column should be updated by
+        exactly one component and each component with an initializer should create at
+        least one column. Sometimes components are a little sloppy and provide
+        duplicate column information, which we should continue to allow. We want to ensure
+        that a column is only getting one set of unique values though.
+        Parameters
+        ----------
+        population_update
+            The update to the simulation state table.
+        state_table
+            The existing simulation state table. When this method is called, the table
+            should be in a partially complete state. That is the provided population
+            update should carry some new attributes we need to assign.
+        Raises
+        -----
+        PopulationError
+            If the population update contains no new information or if it contains
+            information in conflict with the existing state table.
+        """
+        extra_pops = len(population_update.index.difference(state_table.index))
+        missing_pops = len(state_table.index.difference(population_update.index))
+        if extra_pops or missing_pops:
+            raise PopulationError(
+                f"Components should initialize the same population at the simulation start. "
+                f"A component is providing updates for {extra_pops} extra simulants and is "
+                f"missing updates for {missing_pops} simulants."
+            )
+        new_columns = set(population_update).difference(state_table)
+        overlapping_columns = set(population_update).intersection(state_table)
+        if not new_columns:
+            raise PopulationError(
+                f"A component is providing a population update for {list(population_update)} "
+                "but all provided columns are initialized by other components."
+            )
+        for column in overlapping_columns:
+            if not population_update[column].equals(state_table[column]):
+                raise PopulationError(
+                    "Two components are providing conflicting initialization data for the "
+                    f"{column} state table column."
+                )
+
+    def _ensure_update_dtype(
+        self,
+        update: pd.Series,
+        existing: pd.Series,
+    ) -> pd.Series:
+        update_values = update.values
+        new_state_table_values = existing.values
+
+        # Assumes the update index labels can be interpreted as an array position.
+        new_state_table_values[update.index] = update_values
+
+        unmatched_dtypes = new_state_table_values.dtype != update_values.dtype
+        if not self._manager.adding_simulants and unmatched_dtypes:
+            # This happens when the population is being grown because extending
+            # the index forces columns that don't have a natural null type
+            # to become 'object'
+            raise PopulationError(
+                "A component is corrupting the population table by modifying the dtype of "
+                f"the {update.name} column from {existing.dtype} to {update.dtype}."
+            )
+
+        new_state_table_values = new_state_table_values.astype(update_values.dtype)
+        return pd.Series(new_state_table_values, index=existing.index, name=existing.name)
 
     def __repr__(self):
         return (

--- a/src/vivarium/framework/population/population_view.py
+++ b/src/vivarium/framework/population/population_view.py
@@ -330,7 +330,8 @@ class PopulationView:
 
             if adding_simulants:
                 conflicting_columns = [
-                    column for column in population_update
+                    column
+                    for column in population_update
                     if state_table.loc[population_update.index, column].notnull().any()
                     and not population_update[column].equals(state_table[column])
                 ]


### PR DESCRIPTION
## Clean up population system logic
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor/test
- *JIRA issue*: [MIC-3135](https://jira.ihme.washington.edu/browse/MIC-3135)

This update tries to clean up logic in the population view to make it more
clear what's going on.  It still kind of sucks.  There's a design flaw in the 
way we do population management that I now have some ideas for, but 
is beyond the scope.  Instead, we try better naming, isolation of 
code into methods, a ton of docstrings/comments, and a boatload of 
new tests.

### Testing
Like a hundred new tests.