### PR TITLE
fix mismatched indices

### DIFF
--- a/src/vivarium/framework/population/population_view.py
+++ b/src/vivarium/framework/population/population_view.py
@@ -329,11 +329,12 @@ class PopulationView:
                 )
 
             if adding_simulants:
+                state_table_new_simulants = state_table.loc[population_update.index, :]
                 conflicting_columns = [
                     column
                     for column in population_update
-                    if state_table.loc[population_update.index, column].notnull().any()
-                    and not population_update[column].equals(state_table[column])
+                    if state_table_new_simulants[column].notnull().any()
+                    and not population_update[column].equals(state_table_new_simulants[column])
                 ]
                 if conflicting_columns:
                     raise PopulationError(


### PR DESCRIPTION
## Fix mismatched indices when updating existing data
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3223](https://jira.ihme.washington.edu/browse/MIC-3223)

Fixed a bug with mismatched indices when creating new simulants with a dataframe that has data that is equal to data created by another component

### Testing
Ran test suite in vivarium and vph