### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default owners
+* @stevebachmeier @rmudambi @mattkappel @albrja @hussain-jafari @beatrixkh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @stevebachmeier @rmudambi @mattkappel @albrja @hussain-jafari @beatrixkh
+* @collijk @stevebachmeier @rmudambi @mattkappel @albrja @hussain-jafari @beatrixkh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @collijk @stevebachmeier @rmudambi @mattkappel @albrja @hussain-jafari @beatrixkh
+* @albrja @beatrixkh @collijk @hussain-jafari @mattkappel @rmudambi @stevebachmeier


### PR DESCRIPTION
## Add default reviewers

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: other
- *JIRA issue*: [MIC-3225](https://jira.ihme.washington.edu/browse/MIC-3225)

Add a /.github/CODEOWNERS file which are the default reviewers for every PR

### Testing
Tested on the new `vivarium_nih_us_cvd` repo

