### PR TITLE
Add get_output_model_name_string()

### DIFF
--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -106,7 +106,7 @@ def run(
     configure_logging_to_terminal(verbose)
 
     start = time()
-    results_root = get_output_root(results_directory, model_specification)
+    results_root = get_output_root(results_directory, model_specification, artifact_path)
     results_root.mkdir(parents=True, exist_ok=False)
 
     configure_logging_to_file(results_root)

--- a/src/vivarium/interface/utilities.py
+++ b/src/vivarium/interface/utilities.py
@@ -107,11 +107,11 @@ def raise_if_not_setup(system_type):
     return method_wrapper
 
 
-def get_output_location_like_string(
+def get_output_model_name_string(
     artifact_path: Union[str, Path],
     model_spec_path: Union[str, Path],
 ) -> str:
-    """Find a good string to use as model_name or location in output path creation.
+    """Find a good string to use as model name in output path creation.
 
     Parameters
     ----------
@@ -123,18 +123,18 @@ def get_output_location_like_string(
     Returns
     -------
     str
-        A location-like string for use in output labeling.
+        A model name string for use in output labeling.
     """
     if artifact_path:
-        location = Path(artifact_path).stem
+        model_name = Path(artifact_path).stem
     else:
         with open(model_spec_path) as model_spec_file:
             model_spec = yaml.safe_load(model_spec_file)
         try:
-            location = Path(model_spec["configuration"]["input_data"]["artifact_path"]).stem
+            model_name = Path(model_spec["configuration"]["input_data"]["artifact_path"]).stem
         except KeyError:
-            location = Path(model_spec_path).stem
-    return location
+            model_name = Path(model_spec_path).stem
+    return model_name
 
 
 def get_output_root(
@@ -143,7 +143,7 @@ def get_output_root(
     artifact_path: Union[str, Path],
 ):
     launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
-    model_name = get_output_location_like_string(artifact_path, model_specification_file)
+    model_name = get_output_model_name_string(artifact_path, model_specification_file)
     output_root = Path(results_directory + f"/{model_name}/{launch_time}")
     return output_root
 

--- a/src/vivarium/interface/utilities.py
+++ b/src/vivarium/interface/utilities.py
@@ -11,6 +11,7 @@ import functools
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Union
 
 import yaml
 from loguru import logger
@@ -107,8 +108,8 @@ def raise_if_not_setup(system_type):
 
 
 def get_output_location_like_string(
-    artifact_path: Path,
-    model_spec_path: Path,
+    artifact_path: Union[str, Path],
+    model_spec_path: Union[str, Path],
 ) -> str:
     """Find a good string to use as model_name or location in output path creation.
 
@@ -125,7 +126,7 @@ def get_output_location_like_string(
         A location-like string for use in output labeling.
     """
     if artifact_path:
-        location = artifact_path.stem
+        location = Path(artifact_path).stem
     else:
         with open(model_spec_path) as model_spec_file:
             model_spec = yaml.safe_load(model_spec_file)
@@ -137,9 +138,9 @@ def get_output_location_like_string(
 
 
 def get_output_root(
-    results_directory: Path,
-    model_specification_file: Path,
-    artifact_path: Path,
+    results_directory: Union[str, Path],
+    model_specification_file: Union[str, Path],
+    artifact_path: Union[str, Path],
 ):
     launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
     model_name = get_output_location_like_string(artifact_path, model_specification_file)

--- a/src/vivarium/interface/utilities.py
+++ b/src/vivarium/interface/utilities.py
@@ -132,7 +132,7 @@ def get_output_location_like_string(
         try:
             location = Path(model_spec["configuration"]["input_data"]["artifact_path"]).stem
         except KeyError:
-            location = model_spec_path.stem
+            location = Path(model_spec_path).stem
     return location
 
 


### PR DESCRIPTION
## Add get_output_model_name_string()

### Description
- *Category*: feature
- *JIRA issue*:  [MIC-3229](https://jira.ihme.washington.edu/browse/MIC-3229) and [MIC-3091](https://jira.ihme.washington.edu/browse/MIC-3091)

Changes:
- Add `get_output_model_name_string()` to be a standard way for both `psimulate run` and `simulate run` to create the same results paths.
- If an artifact is provided at the CLI, use the location there, if not, check the model specification YAML for an artifact and use its location. If there is no artifact (valid use case!), use the stem of the model specification filename.

### Testing
Ran this VCT and Vivarium against IV Iron with an artifact provided only in the YAML and only at the command and @aflaxman's WA DOH staffing repo, which does not have an artifact and motivated one of these JIRA tickets. In each case, the correct artifact (if any) and results path location were as expected (`"south_asia"` in the former case and `"staffing"` in the latter, from `staffing.yaml`
