### PR TITLE
Add stubs for next gen Results Manager 

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -7,6 +7,11 @@ from vivarium.framework.results.exceptions import ResultsConfigurationError
 
 
 class ResultsContext:
+    """
+    Object contained within the ResultsManager organizing observations and the stratifications they require.
+
+    TODO: add more details when implementing
+    """
 
     def __init__(self):
         self._default_stratifications = []  # type: List[str]
@@ -32,6 +37,7 @@ class ResultsContext:
         mapper: Callable,
         is_vectorized: bool
     ):
+        # TODO: implement this with stratifications
         # self._stratifications.append(
         #     Stratification(name, sources, categories, mapper, is_vectorized)
         # )

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+from typing import Callable, Dict, List, Tuple
+
+import pandas as pd
+
+from vivarium.framework.results.exceptions import ResultsConfigurationError
+
+
+class ResultsContext:
+
+    def __init__(self):
+        self._default_stratifications = []  # type: List[str]
+        self._stratifications = []        # type: List[Stratification]
+        # keys are event names
+        # values are dicts with key (filter, grouper) value (measure, aggregator, additional_keys)
+        self._observations = defaultdict(lambda: defaultdict(list))
+
+    def set_default_stratifications(self, default_grouping_columns: List[str]):
+        if self._default_stratifications:
+            raise ResultsConfigurationError('Multiple calls are being made to set default grouping columns '
+                                            'for results production.')
+        if not default_grouping_columns:
+            raise ResultsConfigurationError('Attempting to set an empty list as the default grouping columns '
+                                            'for results production.')
+        self._default_grouping_columns = default_grouping_columns
+
+    def add_stratification(
+        self,
+        name: str,
+        sources: List[str],
+        categories: List[str],
+        mapper: Callable,
+        is_vectorized: bool
+    ):
+        # self._stratifications.append(
+        #     Stratification(name, sources, categories, mapper, is_vectorized)
+        # )
+        ...
+
+    def add_observation(
+        self,
+        name: str,
+        pop_filter: str,
+        aggregator: Callable[[pd.DataFrame], float],
+        additional_stratifications: List[str] = (),
+        excluded_stratifications: List[str] = (),
+        when: str = "collect_metrics",
+        **additional_keys: str,
+    ):
+        groupers = self._get_groupers(additional_stratifications, excluded_stratifications)
+        (
+            self._producers[when][(pop_filter, groupers)]
+            .append((name, aggregator, additional_keys))
+        )
+
+    def gather_results(self, population: pd.DataFrame, event_name: str) -> Dict[str, float]:
+        # Optimization: We store all the producers by pop_filter and groupers
+        # so that we only have to apply them once each time we compute results.
+        # TODO: uncomment and debug...
+        # for stratification in self._stratifications:
+        #     population = stratification(population)
+        #
+        # for (pop_filter, groupers), observations in self._observations[event_name].items():
+        #     # Results production can be simplified to
+        #     # filter -> groupby -> aggregate in all situations we've seen.
+        #     pop_groups = self.population.query(pop_filter).groupby(list(groupers))
+        #     for measure, aggregator, additional_keys in observers:
+        #         aggregates = pop_groups.apply(aggregator)
+        #         # Keep formatting all in one place.
+        #         yield self._format_results(measure, aggregates, **additional_keys)
+        ...
+
+    def _get_groupers(
+        self,
+        additional_stratifications: List[str] = (),
+        excluded_stratifications: List[str] = ()
+    ) -> Tuple[str, ...]:
+        groupers = list(
+            set(self._default_stratifications) - set(excluded_stratifications)
+            | set(additional_stratifications)
+        )
+        # Makes sure measure identifiers have fields in the same relative order.
+        return tuple(sorted(groupers))
+
+    @staticmethod
+    def _format_results(measure: str, aggregates: pd.DataFrame, **additional_keys: str) -> Dict[str, float]:
+        results = {}
+        # First we expand the categorical index over unobserved pairs.
+        # This ensures that the produced results are always the same length.
+        idx = pd.MultiIndex.from_product(aggregates.index.levels, names=aggregates.index.names)
+        data = pd.Series(data=0, index=idx)
+        data.loc[aggregates.index] = aggregates
+
+        def _format(field, param):
+            """Format of the measure identifier tokens into FIELD_param."""
+            return f'{str(field).upper()}_{param}'
+
+        for params, val in data.iteritems():
+            key = '_'.join(
+                [_format('measure', measure)]
+                + [_format(field, measure) for field, param in zip(data.index.names, params)]
+                # Sorts additional_keys by the field name.
+                + [_format(field, measure) for field, param in sorted(additional_keys.items())]
+            )
+            results[key] = val
+        return results

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -15,18 +15,22 @@ class ResultsContext:
 
     def __init__(self):
         self._default_stratifications = []  # type: List[str]
-        self._stratifications = []        # type: List[Stratification]
+        self._stratifications = []  # type: List[Stratification]
         # keys are event names
         # values are dicts with key (filter, grouper) value (measure, aggregator, additional_keys)
         self._observations = defaultdict(lambda: defaultdict(list))
 
     def set_default_stratifications(self, default_grouping_columns: List[str]):
         if self._default_stratifications:
-            raise ResultsConfigurationError('Multiple calls are being made to set default grouping columns '
-                                            'for results production.')
+            raise ResultsConfigurationError(
+                "Multiple calls are being made to set default grouping columns "
+                "for results production."
+            )
         if not default_grouping_columns:
-            raise ResultsConfigurationError('Attempting to set an empty list as the default grouping columns '
-                                            'for results production.')
+            raise ResultsConfigurationError(
+                "Attempting to set an empty list as the default grouping columns "
+                "for results production."
+            )
         self._default_grouping_columns = default_grouping_columns
 
     def add_stratification(
@@ -35,7 +39,7 @@ class ResultsContext:
         sources: List[str],
         categories: List[str],
         mapper: Callable,
-        is_vectorized: bool
+        is_vectorized: bool,
     ):
         # TODO: implement this with stratifications
         # self._stratifications.append(
@@ -55,8 +59,9 @@ class ResultsContext:
     ):
         groupers = self._get_groupers(additional_stratifications, excluded_stratifications)
         (
-            self._producers[when][(pop_filter, groupers)]
-            .append((name, aggregator, additional_keys))
+            self._producers[when][(pop_filter, groupers)].append(
+                (name, aggregator, additional_keys)
+            )
         )
 
     def gather_results(self, population: pd.DataFrame, event_name: str) -> Dict[str, float]:
@@ -79,7 +84,7 @@ class ResultsContext:
     def _get_groupers(
         self,
         additional_stratifications: List[str] = (),
-        excluded_stratifications: List[str] = ()
+        excluded_stratifications: List[str] = (),
     ) -> Tuple[str, ...]:
         groupers = list(
             set(self._default_stratifications) - set(excluded_stratifications)
@@ -89,24 +94,31 @@ class ResultsContext:
         return tuple(sorted(groupers))
 
     @staticmethod
-    def _format_results(measure: str, aggregates: pd.DataFrame, **additional_keys: str) -> Dict[str, float]:
+    def _format_results(
+        measure: str, aggregates: pd.DataFrame, **additional_keys: str
+    ) -> Dict[str, float]:
         results = {}
         # First we expand the categorical index over unobserved pairs.
         # This ensures that the produced results are always the same length.
-        idx = pd.MultiIndex.from_product(aggregates.index.levels, names=aggregates.index.names)
+        idx = pd.MultiIndex.from_product(
+            aggregates.index.levels, names=aggregates.index.names
+        )
         data = pd.Series(data=0, index=idx)
         data.loc[aggregates.index] = aggregates
 
         def _format(field, param):
             """Format of the measure identifier tokens into FIELD_param."""
-            return f'{str(field).upper()}_{param}'
+            return f"{str(field).upper()}_{param}"
 
         for params, val in data.iteritems():
-            key = '_'.join(
-                [_format('measure', measure)]
+            key = "_".join(
+                [_format("measure", measure)]
                 + [_format(field, measure) for field, param in zip(data.index.names, params)]
                 # Sorts additional_keys by the field name.
-                + [_format(field, measure) for field, param in sorted(additional_keys.items())]
+                + [
+                    _format(field, measure)
+                    for field, param in sorted(additional_keys.items())
+                ]
             )
             results[key] = val
         return results

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -6,6 +6,7 @@ import pandas as pd
 from vivarium.framework.results.exceptions import ResultsConfigurationError
 
 
+# TODO: ResultsContext needs tests added to test_engine or elsewhere...
 class ResultsContext:
     """
     Object contained within the ResultsManager organizing observations and the stratifications they require.

--- a/src/vivarium/framework/results/exceptions.py
+++ b/src/vivarium/framework/results/exceptions.py
@@ -1,9 +1,9 @@
 """
-================================
-Population Management Exceptions
-================================
+==========================
+Results System Exceptions
+==========================
 
-Errors related to the results manager
+Errors related to the results system
 """
 
 from vivarium.exceptions import VivariumError

--- a/src/vivarium/framework/results/exceptions.py
+++ b/src/vivarium/framework/results/exceptions.py
@@ -1,0 +1,15 @@
+"""
+================================
+Population Management Exceptions
+================================
+
+Errors related to the results manager
+"""
+
+from vivarium.exceptions import VivariumError
+
+
+class ResultsConfigurationError(VivariumError):
+    """Error raised when the results stratifications are improperly configured."""
+
+    pass

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -16,11 +16,9 @@ class ResultsManager:
     stratify and observe results. It contains the public methods used by the
     :class:`ResultsInterface` to register stratifications and observations,
     which provide it with lists of methods to apply in their respective areas.
-    This Manager takes the place of the ResultsStratifier and all the
-    previous Observer components, leaving only the need to register
-    stratifications and observations. It is able to record observations at
-    any of the time-step sub-steps (`time_step__prepare`, `time_step`,
-    `time_step__cleanup`, and `collect_metrics`).
+    It is able to record observations at any of the time-step sub-steps
+    (`time_step__prepare`, `time_step`, `time_step__cleanup`, and
+    `collect_metrics`).
     """
 
     def __init__(self):

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -1,182 +1,183 @@
-from typing import Callable, List
+from collections import Counter
+from typing import Callable, List, Union
 
 import pandas as pd
 
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.results.context import ResultsContext
+
 
 class ResultsManager:
+
+    def __init__(self):
+        self._metrics = Counter()
+        self._results_context = ResultsContext()
+        self._required_columns = {'tracked'}
+        self._required_values = set()
+
     @property
-    def name(self):
-        return "results_manager"
+    def metrics(self):
+        return self._metrics.copy()
 
-    def add_mapping_strategy(self, *args, **kwargs):
-        ...
+    def setup(self, builder: 'Builder'):
+        self.population_view = builder.population.get_view([])
+        self.clock = builder.time.clock()
+        self.step_size = builder.time.step_size()
 
-    def add_default_grouping_columns(self, *args, **kwargs):
-        ...
+        builder.event.register_listener('time_step__prepare', self.on_time_step_prepare)
+        builder.event.register_listener('time_step', self.on_time_step)
+        builder.event.register_listener('time_step__cleanup', self.on_time_step_cleanup)
+        builder.event.register_listener('collect_metrics', self.on_collect_metrics)
 
-    def register_results_producer(self, *args, **kwargs):
-        ...
+        self.get_value = builder.value.get_value
+
+        builder.value.register_value_modifier('metrics', self.get_results)
+
+    def on_time_step_prepare(self, event: Event):
+        self.gather_results('time_step__prepare', event)
+
+    def on_time_step(self, event: Event):
+        self.gather_results('time_step', event)
+
+    def on_time_step_cleanup(self, event: Event):
+        self.gather_results('time_step__cleanup', event)
+
+    def on_collect_metrics(self, event: Event):
+        self.gather_results('collect_metrics', event)
+
+    def gather_results(self, event_name: str, event: Event):
+        population = self._prepare_population(event)
+        for results_group in self._results_context.gather_results(population, event_name):
+            self._metrics.update(results_group)
+
+    def set_default_stratifications(self, default_stratifications: List[str]):
+        self._results_context.set_default_stratifications(default_stratifications)
+
+    def register_stratification(
+        self,
+        name: str,
+        categories: List[str],
+        mapper: Callable,
+        is_vectorized: bool,
+        requires_columns: List[str] = (),
+        requires_values: List[str] = (),
+    ) -> None:
+        self._add_resources(requires_columns, 'column')
+        self._add_resources(requires_values, 'value')
+        target_columns = list(requires_columns) + list(requires_values)
+        self._results_context.add_stratification(
+            name, target_columns, categories, mapper, is_vectorized
+        )
+
+    def register_binned_stratification(
+        self,
+        target: str,
+        target_type: str,
+        binned_column: str,
+        bins: List[Union[int, float]],
+        labels: List[str],
+        **cut_kwargs,
+    ) -> None:
+        def _bin_data(data: pd.Series) -> pd.Series:
+            return pd.cut(data, bins, labels=labels, **cut_kwargs)
+
+        target_arg = "required_columns" if target_type == "column" else "required_values"
+        target_kwargs = {target_arg : [target]}
+        self.register_stratification(binned_column, bins, _bin_data, is_vectorized=True, **target_kwargs)
+
+    def register_observation(
+        self,
+        name: str,
+        pop_filter: str,
+        aggregator: Callable,
+        requires_columns: List[str] = None,
+        requires_values: List[str] = None,
+        additional_stratifications: List[str] = (),
+        excluded_stratifications: List[str] = (),
+        when: str = 'collect_metrics',
+    ) -> None:
+        self._add_resources(requires_columns, 'column')
+        self._add_resources(requires_values, 'value')
+        self._results_context.add_observation(
+            name,
+            pop_filter,
+            aggregator,
+            additional_stratifications,
+            excluded_stratifications,
+            when
+        )
+
+    def _add_resources(self, target: List[str], target_type: str):
+        target = set(target) - {'event_time', 'current_time', 'step_size'}
+        if target_type == 'column':
+            self._required_columns.update(target)
+        elif target_type == 'value':
+            self._required_values.update(self.get_value(target))
+
+    def _prepare_population(self, event: Event):
+
+        population = self.population_view.subview(list(self._required_columns)).get(event.index)
+        population['current_time'] = self.clock()
+        population['step_size'] = event.step_size
+        population['event_time'] = self.clock() + event.step_size
+        for k, v in event.user_data.items():
+            population[k] = v
+        for pipeline in self._required_values:
+            population[pipeline.name] = pipeline(event.index)
+        return population
+
+    def get_results(self, index, metrics):
+        # Shim for now to allow incremental transition to new results system.
+        metrics.update(self.metrics)
+        return metrics
 
 
 class ResultsInterface:
     """Builder interface for the results management system.
 
-    The results management system allows users to delegate results production
-    to the simulation framework. This process attempts to roughly mimic the
-    groupby-apply logic commonly done when manipulating :mod:`pandas`
-    DataFrames. The representation of state in the simulation is complex,
-    however, as it includes information both in the population state table
-    as well as dynamically generated information available from the
-    :class:`value pipelines <vivarium.framework.values.Pipeline>`.
-    Additionally, good encapsulation of simulation logic typically has
-    results production separated from the modeling code into specialized
-    `Observer` components. This often highlights the need for transformations
-    of the simulation state into representations that aren't needed for
-    modeling, but are required for the stratification of produced results.
-
-    To support these complexities, we first allow the user to supplement the
-    simulation state with transformations of the underlying state table and
-    pipeline values using :meth:`add_mapping_strategy`. For example, a public
-    health simulation may want to group its summary results by 5-year age
-    bins. A user could add a mapping strategy to transform the continuous
-    "age" property of each of the simulants into a discrete set of age
-    categories. This expanded version of the state can then be used to
-    stratify the population into groups of interest for producing aggregate
-    statistics.
-
-    In general, most of this grouping is for all results being produced.  E.g.
-    if we're going to stratify results in a public health simulation by age
-    group and/or sex, we likely want to do it for all results and not just a
-    few. These global stratifications can be registered with a call to
-    :meth:`add_default_grouping_columns` where the columns in question are part
-    of the expanded state table generated by the previously discussed mapping
-    strategies.
-
-    The suggested pattern for adding mapping strategies and default
-    grouping columns is to centralize them in the `setup` method of a general
-    `Metrics` or `Results` component. From this component you can expose
-    configuration for the global stratification of results. This component
-    should be fairly easy to reuse across entire categories of models.
-
-    Individual `Observer` components (or model components if modeling and
-    results production are mixed in the same component) can then declare
-    strategies to produce result measures using
-    :meth:`register_results_producer`. This method is intended to closely
-    mirror the `apply` step of a :mod:`pandas` groupby-apply, taking a generic
-    callable that operates on dataframes with the understanding that it
-    will be called on data subsets generated by groupings defined by
-    :meth:`add_default_grouping_columns`. For flexibility, a user can
-    elect to add additional stratification or exclude some of the default
-    stratification levels when registering a results producer.
-
-    Results producers registered by users should only produce results about
-    the current time step. The results system automatically accumulates the
-    results across the whole lifetime of the simulation. The combination of the
-    'measure' used when registering a results producer and the levels of
-    the stratification groupings form a unique key for a particular result
-    and calls to produce results every time step will accumulate values
-    for a particular result if it is generated multiple times.  For example,
-    we may want to track all the heart attacks that occur for 50-55 year old
-    men in a several year simulation of cardiovascular health. Each time step,
-    the results system will call the producer the user has registered to count
-    heart attacks by age group and that producer will count all the heart
-    attacks in that particular time step. The results system will then add
-    that time step's worth of heart attacks for 50-55 year old men to its
-    running total.
-
+    TODO: add details
     """
 
     def __init__(self, manager: ResultsManager) -> None:
         self._manager = manager
 
-    def add_mapping_strategy(
-        self, new_column: str, mapper: Callable[[pd.Index], pd.Series]
-    ) -> None:
-        """Adds a specification to map simulation state into a new column.
+    def set_default_stratifications(self, default_stratifications: List[str]):
+        self._manager.set_default_stratifications(default_stratifications)
 
-        This allows a user to specify an arbitrary function to generate
-        new columns in the expanded state table for use in results production.
-
-        For instance, suppose you have a column `time_of_death` that records
-        the time a simulant dies as a time stamp.  In order to stratify
-        results, you might map that column to a `year_of_death` column to
-        group deaths by the year in which they occurred.
-
-        Parameters
-        ----------
-        new_column
-            The name of the new column in the expanded state table.
-        mapper
-            A callable that takes an index representing the entire
-            population and returning a series of values indexed by
-            the population index.
-
-        """
-        self._manager.add_mapping_strategy(new_column, mapper)
-
-    def add_default_grouping_columns(self, grouping_columns: List[str]) -> None:
-        """Add a list of expanded state table columns to group by for all measures.
-
-        Generally, we want to be able to globally define the stratification for all
-        results produced by a simulation. This method allows a user to provide
-        a set of expanded state table columns that will be used to group the population
-        for all results production strategies. These defaults can be
-        overridden by individual results production strategies for special cases.
-
-        Parameters
-        ----------
-            grouping_columns
-                A list of names of columns in the expanded state table to use
-                when grouping the population for results production.
-
-        """
-        self._manager.add_default_grouping_columns(grouping_columns)
-
-    def add_results_production_strategy(
+    def register_stratification(
         self,
-        measure: str,
-        pop_filter: str = "",
-        aggregator: Callable[[pd.DataFrame], float] = len,
-        additional_grouping_columns: List[str] = (),
-        excluded_grouping_columns: List[str] = (),
-        when: str = "collect_metrics",
+        name: str,
+        categories: List[str],
+        mapper: Callable = None,
+        is_vectorized: bool = False,
+        requires_columns: List[str] = (),
+        requires_values: List[str] = (),
     ) -> None:
-        """Provide the framework with a strategy for producing a results 'measure'.
 
-        Results production strategies operate like functions used in the
-        `apply` step of a :mod:`pandas` groupby-apply.
+        self._manager.register_stratification(...)
 
-        Parameters
-        ----------
-        measure
-            The name of the measure to be produced by the strategy.
-        pop_filter
-            A filter to apply to the population before grouping and
-            aggregation. Filters should be formatted so that they are
-            consistent with arguments to :func:`pandas.DataFrame.query`.
-        aggregator
-            A callable operating on a :obj:`pandas.DataFrame` and producing
-            a float value. Defaults to the length of the data, producing
-            a group count.
-        additional_grouping_columns
-            Columns in the expanded state table to group the population
-            by before applying any aggregation. These columns are added
-            to any default grouping columns registered with
-            :func:`ResultsInterface.add_default_grouping_columns`.
-        excluded_grouping_columns
-            Columns in the default grouping columns registered with
-            :func:`ResultsInterface.add_default_grouping_columns` that should
-            not be used in the production of this measure.
-        when
-            The name of the time step event when this measure should be
-            produced.
+    def register_binned_stratification(
+        self,
+        target: str,
+        binned_column: str,
+        bins: List = (),
+        labels: List[str] = (),
+        target_type: str = 'column',
+        **cut_kwargs
+    ) -> None:
 
-        """
-        self._manager.register_results_producer(
-            measure,
-            pop_filter,
-            aggregator,
-            list(additional_grouping_columns),
-            list(excluded_grouping_columns),
-            when,
-        )
+        self._manager.register_binned_stratification(...)
+
+    def register_observation(
+        self,
+        name: str,
+        pop_filter: str = '',
+        aggregator: Callable[[pd.DataFrame], float] = len,
+        requires_columns: List[str] = None,
+        requires_values: List[str] = None,
+        additional_stratifications: List[str] = (),
+        excluded_stratifications: List[str] = (),
+        when: str = 'collect_metrics'
+    ) -> None:
+        self._manager.register_observation(...)

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -9,6 +9,19 @@ from vivarium.framework.results.context import ResultsContext
 
 
 class ResultsManager:
+    """Backend manager object for the results management system.
+
+    The :class:`ResultManager` actually performs the actions needed to
+    stratify and observe results. It contains the public methods used by the
+    :class:`ResultsInterface` to register stratifications and observations,
+    which provide it with lists of methods to apply in their respective areas.
+    This Manager takes the place of the ResultsStratifier and all the
+    previous Observer components, leaving only the need to register
+    stratifications and observations. It is able to record observations at
+    any of the time-step sub-steps (`time_step__prepare`, `time_step`,
+    `time_step__cleanup`, and `collect_metrics`).
+
+    """
 
     def __init__(self):
         self._metrics = Counter()
@@ -136,7 +149,34 @@ class ResultsManager:
 class ResultsInterface:
     """Builder interface for the results management system.
 
-    TODO: add details
+    The results management system allows users to delegate results production
+    to the simulation framework. This process attempts to roughly mimic the
+    groupby-apply logic commonly done when manipulating :mod:`pandas`
+    DataFrames. The representation of state in the simulation is complex,
+    however, as it includes information both in the population state table
+    and dynamically generated information available from the
+    :class:`value pipelines <vivarium.framework.values.Pipeline>`.
+    Additionally, good encapsulation of simulation logic typically has
+    results production separated from the modeling code into specialized
+    `Observer` components. This often highlights the need for transformations
+    of the simulation state into representations that aren't needed for
+    modeling, but are required for the stratification of produced results.
+
+
+    The purpose of this interface is to provide controlled access to a results
+    backend by means of the builder object. It exposes methods
+    to register stratifications, set default stratifications, and register
+    results producers. There is a special case for stratifications generated
+    by binning continuous data into categories.
+
+    The expected use pattern would be for a single component to register all
+    stratifications required by the model using :func:`register_default_stratifications`,
+    :func:`register_stratification`, and :func:`register_binned_stratification`
+    as necessary. A “binned stratification” is a stratification special case for
+    the very common situation when a continuous value needs to be binned into
+    categorical bins. The is_vectorized argument should be True if the mapper
+    function expects a DataFrame, and False if it expects a row of the DataFrame
+    and should be used by calling df.apply.
     """
 
     def __init__(self, manager: ResultsManager) -> None:
@@ -145,6 +185,8 @@ class ResultsInterface:
     def set_default_stratifications(self, default_stratifications: List[str]):
         self._manager.set_default_stratifications(default_stratifications)
 
+    # TODO: It is not reflected in the sample code here, but the “when” parameter should be added
+    #  to the stratification registration calls, probably as a List.
     def register_stratification(
         self,
         name: str,
@@ -154,8 +196,30 @@ class ResultsInterface:
         requires_columns: List[str] = (),
         requires_values: List[str] = (),
     ) -> None:
+        # TODO: Fill in the XXX below!
+        """Register quantities to observe.
 
-        self._manager.register_stratification(...)
+        Parameters
+        ----------
+        name
+            XXX
+        categories
+            XXX
+        mapper
+            XXX
+        is_vectorized
+            XXX
+        requires_columns
+            XXX
+        requires_values
+            XXX
+
+        Returns
+        ------
+        None
+        """
+        ...
+        # self._manager.register_stratification(...)
 
     def register_binned_stratification(
         self,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -37,6 +37,7 @@ class ResultsManager:
     def metrics(self):
         return self._metrics.copy()
 
+    # noinspection PyAttributeOutsideInit
     def setup(self, builder):
         self.population_view = builder.population.get_view([])
         self.clock = builder.time.clock()
@@ -182,7 +183,7 @@ class ResultsInterface:
     :func:`register_stratification`, and :func:`register_binned_stratification`
     as necessary. A “binned stratification” is a stratification special case for
     the very common situation when a continuous value needs to be binned into
-    categorical bins. The is_vectorized argument should be True if the mapper
+    categorical bins. The `is_vectorized` argument should be True if the mapper
     function expects a DataFrame, and False if it expects a row of the DataFrame
     and should be used by calling df.apply.
     """
@@ -210,23 +211,27 @@ class ResultsInterface:
         requires_columns: List[str] = (),
         requires_values: List[str] = (),
     ) -> None:
-        # TODO: Fill in the XXX below!
         """Register quantities to observe.
 
         Parameters
         ----------
         name
-            XXX
+            Name of the of the column created by the stratification.
         categories
-            XXX
+            List of string values that the mapper is allowed to output.
         mapper
-            XXX
+            A callable that emits values in `categories` given inputs from columns
+            and values in the `requires_columns` and `requires_values`, respectively.
         is_vectorized
-            XXX
+            `True` if the mapper function expects a `DataFrame`, and `False` if it
+            expects a row of the `DataFrame` and should be used by calling :func:`df.apply`.
         requires_columns
-            XXX
+            A list of the state table columns that already need to be present
+            and populated in the state table before the pipeline modifier
+            is called.
         requires_values
-            XXX
+            A list of the value pipelines that need to be properly sourced
+            before the pipeline modifier is called.
 
         Returns
         ------

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -3,7 +3,8 @@ from typing import Callable, List, Union
 
 import pandas as pd
 
-from vivarium.framework.engine import Builder
+# TODO: importing Builder causes circular import, fix that in implementation
+# from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.results.context import ResultsContext
 
@@ -20,49 +21,55 @@ class ResultsManager:
     stratifications and observations. It is able to record observations at
     any of the time-step sub-steps (`time_step__prepare`, `time_step`,
     `time_step__cleanup`, and `collect_metrics`).
-
     """
 
     def __init__(self):
         self._metrics = Counter()
         self._results_context = ResultsContext()
-        self._required_columns = {'tracked'}
+        self._required_columns = {"tracked"}
         self._required_values = set()
+        self._name = "results_manager"
+
+    @property
+    def name(self) -> str:
+        """The name of this ResultsManager."""
+        return self._name
 
     @property
     def metrics(self):
         return self._metrics.copy()
 
-    def setup(self, builder: 'Builder'):
+    def setup(self, builder):
         self.population_view = builder.population.get_view([])
         self.clock = builder.time.clock()
         self.step_size = builder.time.step_size()
 
-        builder.event.register_listener('time_step__prepare', self.on_time_step_prepare)
-        builder.event.register_listener('time_step', self.on_time_step)
-        builder.event.register_listener('time_step__cleanup', self.on_time_step_cleanup)
-        builder.event.register_listener('collect_metrics', self.on_collect_metrics)
+        builder.event.register_listener("time_step__prepare", self.on_time_step_prepare)
+        builder.event.register_listener("time_step", self.on_time_step)
+        builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
+        builder.event.register_listener("collect_metrics", self.on_collect_metrics)
 
         self.get_value = builder.value.get_value
 
-        builder.value.register_value_modifier('metrics', self.get_results)
+        builder.value.register_value_modifier("metrics", self.get_results)
 
     def on_time_step_prepare(self, event: Event):
-        self.gather_results('time_step__prepare', event)
+        self.gather_results("time_step__prepare", event)
 
     def on_time_step(self, event: Event):
-        self.gather_results('time_step', event)
+        self.gather_results("time_step", event)
 
     def on_time_step_cleanup(self, event: Event):
-        self.gather_results('time_step__cleanup', event)
+        self.gather_results("time_step__cleanup", event)
 
     def on_collect_metrics(self, event: Event):
-        self.gather_results('collect_metrics', event)
+        self.gather_results("collect_metrics", event)
 
     def gather_results(self, event_name: str, event: Event):
-        population = self._prepare_population(event)
-        for results_group in self._results_context.gather_results(population, event_name):
-            self._metrics.update(results_group)
+        ...
+        # population = self._prepare_population(event)
+        # for results_group in self._results_context.gather_results(population, event_name):
+        #     self._metrics.update(results_group)
 
     def set_default_stratifications(self, default_stratifications: List[str]):
         self._results_context.set_default_stratifications(default_stratifications)
@@ -76,8 +83,8 @@ class ResultsManager:
         requires_columns: List[str] = (),
         requires_values: List[str] = (),
     ) -> None:
-        self._add_resources(requires_columns, 'column')
-        self._add_resources(requires_values, 'value')
+        self._add_resources(requires_columns, "column")
+        self._add_resources(requires_values, "value")
         target_columns = list(requires_columns) + list(requires_values)
         self._results_context.add_stratification(
             name, target_columns, categories, mapper, is_vectorized
@@ -96,8 +103,10 @@ class ResultsManager:
             return pd.cut(data, bins, labels=labels, **cut_kwargs)
 
         target_arg = "required_columns" if target_type == "column" else "required_values"
-        target_kwargs = {target_arg : [target]}
-        self.register_stratification(binned_column, bins, _bin_data, is_vectorized=True, **target_kwargs)
+        target_kwargs = {target_arg: [target]}
+        self.register_stratification(
+            binned_column, bins, _bin_data, is_vectorized=True, **target_kwargs
+        )
 
     def register_observation(
         self,
@@ -108,32 +117,34 @@ class ResultsManager:
         requires_values: List[str] = None,
         additional_stratifications: List[str] = (),
         excluded_stratifications: List[str] = (),
-        when: str = 'collect_metrics',
+        when: str = "collect_metrics",
     ) -> None:
-        self._add_resources(requires_columns, 'column')
-        self._add_resources(requires_values, 'value')
+        self._add_resources(requires_columns, "column")
+        self._add_resources(requires_values, "value")
         self._results_context.add_observation(
             name,
             pop_filter,
             aggregator,
             additional_stratifications,
             excluded_stratifications,
-            when
+            when,
         )
 
     def _add_resources(self, target: List[str], target_type: str):
-        target = set(target) - {'event_time', 'current_time', 'step_size'}
-        if target_type == 'column':
+        target = set(target) - {"event_time", "current_time", "step_size"}
+        if target_type == "column":
             self._required_columns.update(target)
-        elif target_type == 'value':
+        elif target_type == "value":
             self._required_values.update(self.get_value(target))
 
     def _prepare_population(self, event: Event):
 
-        population = self.population_view.subview(list(self._required_columns)).get(event.index)
-        population['current_time'] = self.clock()
-        population['step_size'] = event.step_size
-        population['event_time'] = self.clock() + event.step_size
+        population = self.population_view.subview(list(self._required_columns)).get(
+            event.index
+        )
+        population["current_time"] = self.clock()
+        population["step_size"] = event.step_size
+        population["event_time"] = self.clock() + event.step_size
         for k, v in event.user_data.items():
             population[k] = v
         for pipeline in self._required_values:
@@ -162,7 +173,6 @@ class ResultsInterface:
     of the simulation state into representations that aren't needed for
     modeling, but are required for the stratification of produced results.
 
-
     The purpose of this interface is to provide controlled access to a results
     backend by means of the builder object. It exposes methods
     to register stratifications, set default stratifications, and register
@@ -181,6 +191,12 @@ class ResultsInterface:
 
     def __init__(self, manager: ResultsManager) -> None:
         self._manager = manager
+        self._name = "results_interface"
+
+    @property
+    def name(self) -> str:
+        """The name of this ResultsInterface."""
+        return self._name
 
     def set_default_stratifications(self, default_stratifications: List[str]):
         self._manager.set_default_stratifications(default_stratifications)
@@ -227,8 +243,8 @@ class ResultsInterface:
         binned_column: str,
         bins: List = (),
         labels: List[str] = (),
-        target_type: str = 'column',
-        **cut_kwargs
+        target_type: str = "column",
+        **cut_kwargs,
     ) -> None:
 
         self._manager.register_binned_stratification(...)
@@ -236,12 +252,12 @@ class ResultsInterface:
     def register_observation(
         self,
         name: str,
-        pop_filter: str = '',
+        pop_filter: str = "",
         aggregator: Callable[[pd.DataFrame], float] = len,
         requires_columns: List[str] = None,
         requires_values: List[str] = None,
         additional_stratifications: List[str] = (),
         excluded_stratifications: List[str] = (),
-        when: str = 'collect_metrics'
+        when: str = "collect_metrics",
     ) -> None:
         self._manager.register_observation(...)


### PR DESCRIPTION
## Add stubs for next gen Results Manager 

### Description
- *Category*: feature
- *JIRA issue*: [MIC-3130](https://jira.ihme.washington.edu/browse/MIC-3130)

#### Changes
- Adds stubs for classes `ResultsManger`, `ResultsInterface`, and `ResultsContext` based on the [published design](https://ihmeuw.github.io/vivarium_development/docs/build/html/design/2022_05_25_results_writer.html)
- Several changes make the code functional based on the snippets from the design
- Updates/adds docstrings for `ResultsManger` and `ResultsInterface`

### Testing
Ran pytest on `test_engine.py`. Passed.

