### PR TITLE
Implement register_stratification, underlying functionality, and add tests

### DIFF
--- a/src/vivarium/framework/results/__init__.py
+++ b/src/vivarium/framework/results/__init__.py
@@ -1,2 +1,2 @@
 from vivarium.framework.results.interface import ResultsInterface
-
+from vivarium.framework.results.manager import ResultsManager

--- a/src/vivarium/framework/results/__init__.py
+++ b/src/vivarium/framework/results/__init__.py
@@ -1,1 +1,2 @@
-from vivarium.framework.results.manager import ResultsInterface, ResultsManager
+from vivarium.framework.results.interface import ResultsInterface
+

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -4,9 +4,9 @@ from typing import Callable, Dict, List, Tuple
 import pandas as pd
 
 from vivarium.framework.results.exceptions import ResultsConfigurationError
+from vivarium.framework.results.stratification import Stratification
 
 
-# TODO: ResultsContext needs tests added to test_engine or elsewhere...
 class ResultsContext:
     """
     Object contained within the ResultsManager organizing observations and the stratifications they require.
@@ -21,6 +21,7 @@ class ResultsContext:
         # values are dicts with key (filter, grouper) value (measure, aggregator, additional_keys)
         self._observations = defaultdict(lambda: defaultdict(list))
 
+    # noinspection PyAttributeOutsideInit
     def set_default_stratifications(self, default_grouping_columns: List[str]):
         if self._default_stratifications:
             raise ResultsConfigurationError(
@@ -42,11 +43,10 @@ class ResultsContext:
         mapper: Callable,
         is_vectorized: bool,
     ):
-        # TODO: implement this with stratifications
-        # self._stratifications.append(
-        #     Stratification(name, sources, categories, mapper, is_vectorized)
-        # )
-        ...
+        stratification = Stratification(name, sources, categories, mapper, is_vectorized)
+        self._stratifications.append(
+            stratification
+        )
 
     def add_observation(
         self,
@@ -58,6 +58,7 @@ class ResultsContext:
         when: str = "collect_metrics",
         **additional_keys: str,
     ):
+        # XXX WTF IS THIS
         groupers = self._get_groupers(additional_stratifications, excluded_stratifications)
         (
             self._producers[when][(pop_filter, groupers)].append(

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -9,9 +9,11 @@ from vivarium.framework.results.stratification import Stratification
 
 class ResultsContext:
     """
-    Object contained within the ResultsManager organizing observations and the stratifications they require.
+    Manager context for organizing observations and the stratifications they require.
 
-    TODO: add more details when implementing
+    This context object is wholly contained by the manager :class:`vivarium.framework.results.manager.ResultsManger`.
+    Stratifications can be added to the context through the manager via the
+    :meth:`vivarium.framework.results.context.ResultsContext.add_observation` method.
     """
 
     def __init__(self):
@@ -43,10 +45,31 @@ class ResultsContext:
         mapper: Callable,
         is_vectorized: bool,
     ):
+        """Add a stratification to the context.
+
+        Parameters
+        ----------
+        name
+            Name of the of the column created by the stratification.
+        sources
+            A list of the columns and values needed for the mapper to determinate
+            categorization.
+        categories
+            List of string values that the mapper is allowed to output.
+        mapper
+            A callable that emits values in `categories` given inputs from columns
+            and values in the `requires_columns` and `requires_values`, respectively.
+        is_vectorized
+            `True` if the mapper function expects a `DataFrame`, and `False` if it
+            expects a row of the `DataFrame` and should be used by calling :func:`df.apply`.
+
+
+        Returns
+        ------
+        None
+        """
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
-        self._stratifications.append(
-            stratification
-        )
+        self._stratifications.append(stratification)
 
     def add_observation(
         self,
@@ -58,7 +81,7 @@ class ResultsContext:
         when: str = "collect_metrics",
         **additional_keys: str,
     ):
-        # XXX WTF IS THIS
+        # TODO: _producers doesn't exist, stub code needs bugfix at observation implementation time
         groupers = self._get_groupers(additional_stratifications, excluded_stratifications)
         (
             self._producers[when][(pop_filter, groupers)].append(

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -17,8 +17,8 @@ class ResultsContext:
     """
 
     def __init__(self):
-        self._default_stratifications = []  # type: List[str]
-        self._stratifications = []  # type: List[Stratification]
+        self._default_stratifications: List[str] = []
+        self._stratifications: List[Stratification] = []
         # keys are event names
         # values are dicts with key (filter, grouper) value (measure, aggregator, additional_keys)
         self._observations = defaultdict(lambda: defaultdict(list))

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -68,6 +68,8 @@ class ResultsContext:
         ------
         None
         """
+        if len([s.name for s in self._stratifications if s.name == name]):
+            raise ValueError(f"Name `{name}` is already used")
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
         self._stratifications.append(stratification)
 

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -33,10 +33,10 @@ class ResultsInterface:
     stratifications required by the model using :func:`register_default_stratifications`,
     :func:`register_stratification`, and :func:`register_binned_stratification`
     as necessary. A “binned stratification” is a stratification special case for
-    the very common situation when a continuous value needs to be binned into
+    the very common situation when a single continuous value needs to be binned into
     categorical bins. The `is_vectorized` argument should be True if the mapper
-    function expects a DataFrame, and False if it expects a row of the DataFrame
-    and should be used by calling df.apply.
+    function expects a DataFrame corresponding to the whole population, and False
+    if it expects a row of the DataFrame corresponding to a single simulant.
     """
 
     def __init__(self, manager: "ResultsManager") -> None:

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -1,0 +1,122 @@
+from typing import TYPE_CHECKING, Callable, List
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    # cyclic import
+    from vivarium.framework.results.manager import ResultsManager
+
+
+class ResultsInterface:
+    """Builder interface for the results management system.
+
+    The results management system allows users to delegate results production
+    to the simulation framework. This process attempts to roughly mimic the
+    groupby-apply logic commonly done when manipulating :mod:`pandas`
+    DataFrames. The representation of state in the simulation is complex,
+    however, as it includes information both in the population state table
+    and dynamically generated information available from the
+    :class:`value pipelines <vivarium.framework.values.Pipeline>`.
+    Additionally, good encapsulation of simulation logic typically has
+    results production separated from the modeling code into specialized
+    `Observer` components. This often highlights the need for transformations
+    of the simulation state into representations that aren't needed for
+    modeling, but are required for the stratification of produced results.
+
+    The purpose of this interface is to provide controlled access to a results
+    backend by means of the builder object. It exposes methods
+    to register stratifications, set default stratifications, and register
+    results producers. There is a special case for stratifications generated
+    by binning continuous data into categories.
+
+    The expected use pattern would be for a single component to register all
+    stratifications required by the model using :func:`register_default_stratifications`,
+    :func:`register_stratification`, and :func:`register_binned_stratification`
+    as necessary. A “binned stratification” is a stratification special case for
+    the very common situation when a continuous value needs to be binned into
+    categorical bins. The `is_vectorized` argument should be True if the mapper
+    function expects a DataFrame, and False if it expects a row of the DataFrame
+    and should be used by calling df.apply.
+    """
+
+    def __init__(self, manager: "ResultsManager") -> None:
+        self._manager: "ResultsManager" = manager
+        self._name = "results_interface"
+
+    @property
+    def name(self) -> str:
+        """The name of this ResultsInterface."""
+        return self._name
+
+    def set_default_stratifications(self, default_stratifications: List[str]):
+        self._manager.set_default_stratifications(default_stratifications)
+
+    # TODO: It is not reflected in the sample code here, but the “when” parameter should be added
+    #  to the stratification registration calls, probably as a List. Consider this after observer implementation
+    def register_stratification(
+        self,
+        name: str,
+        categories: List[str],
+        mapper: Callable = None,
+        is_vectorized: bool = False,
+        requires_columns: List[str] = (),
+        requires_values: List[str] = (),
+    ) -> None:
+        """Register quantities to observe.
+
+        Parameters
+        ----------
+        name
+            Name of the of the column created by the stratification.
+        categories
+            List of string values that the mapper is allowed to output.
+        mapper
+            A callable that emits values in `categories` given inputs from columns
+            and values in the `requires_columns` and `requires_values`, respectively.
+        is_vectorized
+            `True` if the mapper function expects a `DataFrame`, and `False` if it
+            expects a row of the `DataFrame` and should be used by calling :func:`df.apply`.
+        requires_columns
+            A list of the state table columns that already need to be present
+            and populated in the state table before the pipeline modifier
+            is called.
+        requires_values
+            A list of the value pipelines that need to be properly sourced
+            before the pipeline modifier is called.
+
+        Returns
+        ------
+        None
+        """
+        self._manager.register_stratification(
+            name,
+            categories,
+            mapper,
+            is_vectorized,
+            requires_columns,
+            requires_values,
+        )
+
+    def register_binned_stratification(
+        self,
+        target: str,
+        binned_column: str,
+        bins: List = (),
+        labels: List[str] = (),
+        target_type: str = "column",
+        **cut_kwargs,
+    ) -> None:
+        self._manager.register_binned_stratification(...)
+
+    def register_observation(
+        self,
+        name: str,
+        pop_filter: str = "",
+        aggregator: Callable[[pd.DataFrame], float] = len,
+        requires_columns: List[str] = None,
+        requires_values: List[str] = None,
+        additional_stratifications: List[str] = (),
+        excluded_stratifications: List[str] = (),
+        when: str = "collect_metrics",
+    ) -> None:
+        self._manager.register_observation(...)

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -85,6 +85,32 @@ class ResultsManager:
         requires_columns: List[str] = (),
         requires_values: List[str] = (),
     ) -> None:
+        """Manager-level stratification registration, including resources and the stratification itself.
+
+        Parameters
+        ----------
+        name
+            Name of the of the column created by the stratification.
+        categories
+            List of string values that the mapper is allowed to output.
+        mapper
+            A callable that emits values in `categories` given inputs from columns
+            and values in the `requires_columns` and `requires_values`, respectively.
+        is_vectorized
+            `True` if the mapper function expects a `DataFrame`, and `False` if it
+            expects a row of the `DataFrame` and should be used by calling :func:`df.apply`.
+        requires_columns
+            A list of the state table columns that already need to be present
+            and populated in the state table before the pipeline modifier
+            is called.
+        requires_values
+            A list of the value pipelines that need to be properly sourced
+            before the pipeline modifier is called.
+
+        Returns
+        ------
+        None
+        """
         self._add_resources(requires_columns, "column")
         self._add_resources(requires_values, "value")
         target_columns = list(requires_columns) + list(requires_values)

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -111,12 +111,12 @@ class ResultsManager:
         ------
         None
         """
-        self._add_resources(requires_columns, "column")
-        self._add_resources(requires_values, "value")
         target_columns = list(requires_columns) + list(requires_values)
         self._results_context.add_stratification(
             name, target_columns, categories, mapper, is_vectorized
         )
+        self._add_resources(requires_columns, "column")
+        self._add_resources(requires_values, "value")
 
     def register_binned_stratification(
         self,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from enum import Enum
 from typing import TYPE_CHECKING, Callable, List, Union
 
 import pandas as pd
@@ -9,6 +10,11 @@ from vivarium.framework.results.context import ResultsContext
 if TYPE_CHECKING:
     # Cyclic import
     from vivarium.framework.engine import Builder
+
+
+class SourceType(Enum):
+    COLUMN = 0
+    VALUE = 1
 
 
 class ResultsManager:
@@ -115,8 +121,8 @@ class ResultsManager:
         self._results_context.add_stratification(
             name, target_columns, categories, mapper, is_vectorized
         )
-        self._add_resources(requires_columns, "column")
-        self._add_resources(requires_values, "value")
+        self._add_resources(requires_columns, SourceType.COLUMN)
+        self._add_resources(requires_values, SourceType.VALUE)
 
     def register_binned_stratification(
         self,
@@ -147,8 +153,8 @@ class ResultsManager:
         excluded_stratifications: List[str] = (),
         when: str = "collect_metrics",
     ) -> None:
-        self._add_resources(requires_columns, "column")
-        self._add_resources(requires_values, "value")
+        self._add_resources(requires_columns, SourceType.COLUMN)
+        self._add_resources(requires_values, SourceType.VALUE)
         self._results_context.add_observation(
             name,
             pop_filter,
@@ -158,13 +164,13 @@ class ResultsManager:
             when,
         )
 
-    def _add_resources(self, target: List[str], target_type: str):
+    def _add_resources(self, target: List[str], target_type: SourceType):
         if not len(target):
             return  # do nothing on empty lists
         target = set(target) - {"event_time", "current_time", "step_size"}
-        if target_type == "column":
+        if target_type == SourceType.COLUMN:
             self._required_columns.update(target)
-        elif target_type == "value":
+        elif target_type == SourceType.VALUE:
             self._required_values.update(self.get_value(target))
 
     def _prepare_population(self, event: Event):

--- a/tests/framework/results/mocks.py
+++ b/tests/framework/results/mocks.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+##########################
+# Mock data and fixtures #
+##########################
+NAME = "hogwarts_house"
+SOURCES = ["first_name", "last_name"]
+CATEGORIES = ["hufflepuff", "ravenclaw", "slytherin", "gryffindor"]
+STUDENT_TABLE = pd.DataFrame(
+    np.array([["harry", "potter"], ["severus", "snape"], ["luna", "lovegood"]]),
+    columns=SOURCES,
+)
+STUDENT_HOUSES = pd.Series(["gryffindor", "slytherin", "ravenclaw"])
+
+
+##################
+# Helper methods #
+##################
+def sorting_hat_vector(state_table: pd.DataFrame) -> pd.Series:
+    sorted_series = state_table.apply(sorting_hat_serial, axis=1)
+    return sorted_series
+
+
+def sorting_hat_serial(simulant_row: pd.Series) -> str:
+    first_name = simulant_row[0]
+    last_name = simulant_row[1]
+    if first_name == "harry":
+        return "gryffindor"
+    if first_name == "luna":
+        return "ravenclaw"
+    if last_name == "snape":
+        return "slytherin"
+    return "hufflepuff"
+
+
+def sorting_hat_bad_mapping(simulant_row: pd.Series) -> str:
+    # Return something not in CATEGORIES
+    return "pancakes"

--- a/tests/framework/results/mocks.py
+++ b/tests/framework/results/mocks.py
@@ -37,3 +37,22 @@ def sorting_hat_serial(simulant_row: pd.Series) -> str:
 def sorting_hat_bad_mapping(simulant_row: pd.Series) -> str:
     # Return something not in CATEGORIES
     return "pancakes"
+
+
+def verify_stratification_added(
+    stratification_list, name, sources, categories, mapper, is_vectorized
+):
+    """Verify that a :class: `vivarium.framework.results.stratification.Stratification` is in `stratification_list`"""
+    matching_stratification_found = False
+    for stratification in stratification_list:  # noqa
+        # big equality check
+        if (
+            stratification.name == name
+            and sorted(stratification.categories) == sorted(categories)
+            and stratification.mapper == mapper
+            and stratification.is_vectorized == is_vectorized
+            and sorted(stratification.sources) == sorted(sources)
+        ):
+            matching_stratification_found = True
+            break
+    return matching_stratification_found

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -12,46 +12,32 @@ from .mocks import (
     sorting_hat_bad_mapping,
     sorting_hat_serial,
     sorting_hat_vector,
+    verify_stratification_added,
 )
 
 
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized",
     [
-        (  # expected Stratification for vectorized
-            NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_vector,
-            True,
-        ),
-        (  # expected Stratification for non-vectorized
-            NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_serial,
-            False,
-        ),
+        (NAME, SOURCES, CATEGORIES, sorting_hat_vector, True),
+        (NAME, SOURCES, CATEGORIES, sorting_hat_serial, False),
     ],
+    ids=["vectorized_mapper", "non-vectorized_mapper"],
 )
 def test_add_stratification(name, sources, categories, mapper, is_vectorized):
     ctx = ResultsContext()
+    assert not verify_stratification_added(
+        ctx._stratifications, name, sources, categories, mapper, is_vectorized
+    )
     ctx.add_stratification(name, sources, categories, mapper, is_vectorized)
-    expected_object = Stratification(name, sources, categories, mapper, is_vectorized)
-    assert expected_object in ctx._stratifications
+    assert verify_stratification_added(
+        ctx._stratifications, name, sources, categories, mapper, is_vectorized
+    )
 
 
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized, expected_exception",
     [
-        (  # map to a category that isn't in CATEGORIES
-            NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_bad_mapping,
-            False,
-            TypeError,
-        ),
         (  # sources not in population columns
             NAME,
             ["middle_initial"],

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -9,10 +9,11 @@ from .mocks import (
     CATEGORIES,
     NAME,
     SOURCES,
-    sorting_hat_vector,
-    sorting_hat_serial,
     sorting_hat_bad_mapping,
+    sorting_hat_serial,
+    sorting_hat_vector,
 )
+
 
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized",

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from vivarium.framework.results.context import ResultsContext
+from vivarium.framework.results.stratification import Stratification
+
+from .mocks import (
+    CATEGORIES,
+    NAME,
+    SOURCES,
+    sorting_hat_vector,
+    sorting_hat_serial,
+    sorting_hat_bad_mapping,
+)
+
+@pytest.mark.parametrize(
+    "name, sources, categories, mapper, is_vectorized",
+    [
+        (  # expected Stratification for vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_vector,
+            True,
+        ),
+        (  # expected Stratification for non-vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_serial,
+            False,
+        ),
+    ],
+)
+def test_add_stratification(name, sources, categories, mapper, is_vectorized):
+    ctx = ResultsContext()
+    ctx.add_stratification(name, sources, categories, mapper, is_vectorized)
+    expected_object = Stratification(name, sources, categories, mapper, is_vectorized)
+    assert expected_object in ctx._stratifications
+
+
+@pytest.mark.parametrize(
+    "name, sources, categories, mapper, is_vectorized, expected_exception",
+    [
+        (  # map to a category that isn't in CATEGORIES
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_bad_mapping,
+            False,
+            TypeError,
+        ),
+        (  # sources not in population columns
+            NAME,
+            ["middle_initial"],
+            CATEGORIES,
+            sorting_hat_vector,
+            True,
+            TypeError,
+        ),
+        (  # is_vectorized=True with non-vectorized mapper
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_serial,
+            True,
+            Exception,
+        ),
+        (  # is_vectorized=False with vectorized mapper
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_vector,
+            False,
+            Exception,
+        ),
+    ],
+)
+def test_add_stratification_raises(
+    name, sources, categories, mapper, is_vectorized, expected_exception
+):
+    ctx = ResultsContext()
+    with pytest.raises(expected_exception):
+        raise ctx.add_stratification(name, sources, categories, mapper, is_vectorized)

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -4,13 +4,7 @@ import pytest
 
 from vivarium.framework.results.manager import ResultsManager
 
-from .mocks import (
-    CATEGORIES,
-    NAME,
-    SOURCES,
-    sorting_hat_vector,
-    sorting_hat_serial
-)
+from .mocks import CATEGORIES, NAME, SOURCES, sorting_hat_serial, sorting_hat_vector
 
 
 # Mock for get_value call for Pipelines, returns a str instead of a Pipeline
@@ -18,45 +12,16 @@ def mock_get_value(self, name: str):
     return name
 
 
-@pytest.mark.parametrize(
-    "name, sources, categories, mapper, is_vectorized",
-    [
-        (  # expected Stratification for vectorized
-            NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_vector,
-            True,
-        ),
-        (  # expected Stratification for non-vectorized
-            NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_serial,
-            False,
-        ),
-    ],
-)
-def test_register_stratification_no_pipelines(name, sources, categories, mapper, is_vectorized, mocker):
-    mgr = ResultsManager()
-    builder = mocker.Mock()
-    mgr.setup(builder)
-    mgr.register_stratification(name, categories, mapper, is_vectorized, sources, [])
-    for item in sources:
-        assert item in mgr._required_columns
-    verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
-
-
 def verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized):
     matching_stratification_found = False
     for stratification in mgr._results_context._stratifications:  # noqa
         # big equality check
         if (
-                stratification.name == name
-                and stratification.categories == categories
-                and stratification.mapper == mapper
-                and stratification.is_vectorized == is_vectorized
-                and stratification.sources == sources
+            stratification.name == name
+            and stratification.categories == categories
+            and stratification.mapper == mapper
+            and stratification.is_vectorized == is_vectorized
+            and stratification.sources == sources
         ):
             matching_stratification_found = True
         break
@@ -82,7 +47,40 @@ def verify_stratification_added(mgr, name, categories, sources, mapper, is_vecto
         ),
     ],
 )
-def test_register_stratification_with_pipelines(name, sources, categories, mapper, is_vectorized, mocker):
+def test_register_stratification_no_pipelines(
+    name, sources, categories, mapper, is_vectorized, mocker
+):
+    mgr = ResultsManager()
+    builder = mocker.Mock()
+    mgr.setup(builder)
+    mgr.register_stratification(name, categories, mapper, is_vectorized, sources, [])
+    for item in sources:
+        assert item in mgr._required_columns
+    verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
+
+
+@pytest.mark.parametrize(
+    "name, sources, categories, mapper, is_vectorized",
+    [
+        (  # expected Stratification for vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_vector,
+            True,
+        ),
+        (  # expected Stratification for non-vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_serial,
+            False,
+        ),
+    ],
+)
+def test_register_stratification_with_pipelines(
+    name, sources, categories, mapper, is_vectorized, mocker
+):
     mgr = ResultsManager()
     builder = mocker.Mock()
     # Set up mock builder with mocked get_value call for Pipelines
@@ -93,3 +91,13 @@ def test_register_stratification_with_pipelines(name, sources, categories, mappe
     for item in sources:
         assert item in mgr._required_values
     verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
+
+
+# def test_duplicate_register_stratification(mocker):
+#     mgr = ResultsManager()
+#     builder = mocker.Mock()
+#     mgr.setup(builder)
+#     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
+#     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
+# TODO: Decide what should happen on duplicate stratifications:
+#   a) context throws a ValueError, b) overwrite the existing named Stratification, c) keep dupes?

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -136,11 +136,12 @@ def test_register_stratification_with_column_and_pipelines(
     assert mocked_column_name in mgr._required_columns
     for item in sources:
         assert item in mgr._required_values
-    sources.append(mocked_column_name)
+    all_sources = sources.copy()
+    all_sources.append(mocked_column_name)
     assert verify_stratification_added(
         mgr._results_context._stratifications,
         name,
-        sources,
+        all_sources,
         categories,
         mapper,
         is_vectorized,

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -4,7 +4,14 @@ import pytest
 
 from vivarium.framework.results.manager import ResultsManager
 
-from .mocks import CATEGORIES, NAME, SOURCES, sorting_hat_serial, sorting_hat_vector
+from .mocks import (
+    CATEGORIES,
+    NAME,
+    SOURCES,
+    sorting_hat_serial,
+    sorting_hat_vector,
+    verify_stratification_added,
+)
 
 
 # Mock for get_value call for Pipelines, returns a str instead of a Pipeline
@@ -12,33 +19,17 @@ def mock_get_value(self, name: str):
     return name
 
 
-def verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized):
-    matching_stratification_found = False
-    for stratification in mgr._results_context._stratifications:  # noqa
-        # big equality check
-        if (
-            stratification.name == name
-            and stratification.categories == categories
-            and stratification.mapper == mapper
-            and stratification.is_vectorized == is_vectorized
-            and stratification.sources == sources
-        ):
-            matching_stratification_found = True
-        break
-    assert matching_stratification_found
-
-
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized",
     [
-        (  # expected Stratification for vectorized
+        (
             NAME,
             SOURCES,
             CATEGORIES,
             sorting_hat_vector,
             True,
         ),
-        (  # expected Stratification for non-vectorized
+        (
             NAME,
             SOURCES,
             CATEGORIES,
@@ -46,6 +37,7 @@ def verify_stratification_added(mgr, name, categories, sources, mapper, is_vecto
             False,
         ),
     ],
+    ids=["vectorized_mapper", "non-vectorized_mapper"],
 )
 def test_register_stratification_no_pipelines(
     name, sources, categories, mapper, is_vectorized, mocker
@@ -56,20 +48,27 @@ def test_register_stratification_no_pipelines(
     mgr.register_stratification(name, categories, mapper, is_vectorized, sources, [])
     for item in sources:
         assert item in mgr._required_columns
-    verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
+    assert verify_stratification_added(
+        mgr._results_context._stratifications,
+        name,
+        sources,
+        categories,
+        mapper,
+        is_vectorized,
+    )
 
 
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized",
     [
-        (  # expected Stratification for vectorized
+        (
             NAME,
             SOURCES,
             CATEGORIES,
             sorting_hat_vector,
             True,
         ),
-        (  # expected Stratification for non-vectorized
+        (
             NAME,
             SOURCES,
             CATEGORIES,
@@ -77,6 +76,7 @@ def test_register_stratification_no_pipelines(
             False,
         ),
     ],
+    ids=["vectorized_mapper", "non-vectorized_mapper"],
 )
 def test_register_stratification_with_pipelines(
     name, sources, categories, mapper, is_vectorized, mocker
@@ -90,7 +90,61 @@ def test_register_stratification_with_pipelines(
     mgr.register_stratification(name, categories, mapper, is_vectorized, [], sources)
     for item in sources:
         assert item in mgr._required_values
-    verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
+    assert verify_stratification_added(
+        mgr._results_context._stratifications,
+        name,
+        sources,
+        categories,
+        mapper,
+        is_vectorized,
+    )
+
+
+@pytest.mark.parametrize(
+    "name, sources, categories, mapper, is_vectorized",
+    [
+        (  # expected Stratification for vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_vector,
+            True,
+        ),
+        (  # expected Stratification for non-vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_serial,
+            False,
+        ),
+    ],
+    ids=["vectorized_mapper", "non-vectorized_mapper"],
+)
+def test_register_stratification_with_column_and_pipelines(
+    name, sources, categories, mapper, is_vectorized, mocker
+):
+    mgr = ResultsManager()
+    builder = mocker.Mock()
+    # Set up mock builder with mocked get_value call for Pipelines
+    mocker.patch.object(builder, "value.get_value")
+    builder.value.get_value = MethodType(mock_get_value, builder)
+    mgr.setup(builder)
+    mocked_column_name = "silly_column"
+    mgr.register_stratification(
+        name, categories, mapper, is_vectorized, [mocked_column_name], sources
+    )
+    assert mocked_column_name in mgr._required_columns
+    for item in sources:
+        assert item in mgr._required_values
+    sources.append(mocked_column_name)
+    assert verify_stratification_added(
+        mgr._results_context._stratifications,
+        name,
+        sources,
+        categories,
+        mapper,
+        is_vectorized,
+    )
 
 
 def test_duplicate_name_register_stratification(mocker):
@@ -98,5 +152,5 @@ def test_duplicate_name_register_stratification(mocker):
     builder = mocker.Mock()
     mgr.setup(builder)
     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=f"Name `{NAME}` is already used"):
         mgr.register_stratification(NAME, CATEGORIES, sorting_hat_vector, True, SOURCES, [])

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -100,4 +100,3 @@ def test_duplicate_name_register_stratification(mocker):
     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
     with pytest.raises(ValueError):
         mgr.register_stratification(NAME, CATEGORIES, sorting_hat_vector, True, SOURCES, [])
-

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -1,0 +1,95 @@
+from types import MethodType
+
+import pytest
+
+from vivarium.framework.results.manager import ResultsManager
+
+from .mocks import (
+    CATEGORIES,
+    NAME,
+    SOURCES,
+    sorting_hat_vector,
+    sorting_hat_serial
+)
+
+
+# Mock for get_value call for Pipelines, returns a str instead of a Pipeline
+def mock_get_value(self, name: str):
+    return name
+
+
+@pytest.mark.parametrize(
+    "name, sources, categories, mapper, is_vectorized",
+    [
+        (  # expected Stratification for vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_vector,
+            True,
+        ),
+        (  # expected Stratification for non-vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_serial,
+            False,
+        ),
+    ],
+)
+def test_register_stratification_no_pipelines(name, sources, categories, mapper, is_vectorized, mocker):
+    mgr = ResultsManager()
+    builder = mocker.Mock()
+    mgr.setup(builder)
+    mgr.register_stratification(name, categories, mapper, is_vectorized, sources, [])
+    for item in sources:
+        assert item in mgr._required_columns
+    verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
+
+
+def verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized):
+    matching_stratification_found = False
+    for stratification in mgr._results_context._stratifications:  # noqa
+        # big equality check
+        if (
+                stratification.name == name
+                and stratification.categories == categories
+                and stratification.mapper == mapper
+                and stratification.is_vectorized == is_vectorized
+                and stratification.sources == sources
+        ):
+            matching_stratification_found = True
+        break
+    assert matching_stratification_found
+
+
+@pytest.mark.parametrize(
+    "name, sources, categories, mapper, is_vectorized",
+    [
+        (  # expected Stratification for vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_vector,
+            True,
+        ),
+        (  # expected Stratification for non-vectorized
+            NAME,
+            SOURCES,
+            CATEGORIES,
+            sorting_hat_serial,
+            False,
+        ),
+    ],
+)
+def test_register_stratification_with_pipelines(name, sources, categories, mapper, is_vectorized, mocker):
+    mgr = ResultsManager()
+    builder = mocker.Mock()
+    # Set up mock builder with mocked get_value call for Pipelines
+    mocker.patch.object(builder, "value.get_value")
+    builder.value.get_value = MethodType(mock_get_value, builder)
+    mgr.setup(builder)
+    mgr.register_stratification(name, categories, mapper, is_vectorized, [], sources)
+    for item in sources:
+        assert item in mgr._required_values
+    verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -93,11 +93,11 @@ def test_register_stratification_with_pipelines(
     verify_stratification_added(mgr, name, categories, sources, mapper, is_vectorized)
 
 
-# def test_duplicate_register_stratification(mocker):
-#     mgr = ResultsManager()
-#     builder = mocker.Mock()
-#     mgr.setup(builder)
-#     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
-#     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
-# TODO: Decide what should happen on duplicate stratifications:
-#   a) context throws a ValueError, b) overwrite the existing named Stratification, c) keep dupes?
+def test_duplicate_name_register_stratification(mocker):
+    mgr = ResultsManager()
+    builder = mocker.Mock()
+    mgr.setup(builder)
+    mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
+    with pytest.raises(ValueError):
+        mgr.register_stratification(NAME, CATEGORIES, sorting_hat_vector, True, SOURCES, [])
+

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -10,9 +10,9 @@ from .mocks import (
     SOURCES,
     STUDENT_HOUSES,
     STUDENT_TABLE,
-    sorting_hat_vector,
-    sorting_hat_serial,
     sorting_hat_bad_mapping,
+    sorting_hat_serial,
+    sorting_hat_vector,
 )
 
 

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -4,41 +4,16 @@ import pytest
 
 from vivarium.framework.results.stratification import Stratification
 
-##########################
-# Mock data and fixtures #
-##########################
-NAME = "hogwarts_house"
-SOURCES = ["first_name", "last_name"]
-CATEGORIES = ["hufflepuff", "ravenclaw", "slytherin", "gryffindor"]
-STUDENT_TABLE = pd.DataFrame(
-    np.array([["harry", "potter"], ["severus", "snape"], ["luna", "lovegood"]]),
-    columns=SOURCES,
+from .mocks import (
+    CATEGORIES,
+    NAME,
+    SOURCES,
+    STUDENT_HOUSES,
+    STUDENT_TABLE,
+    sorting_hat_vector,
+    sorting_hat_serial,
+    sorting_hat_bad_mapping,
 )
-STUDENT_HOUSES = pd.Series(["gryffindor", "slytherin", "ravenclaw"])
-
-##################
-# Helper methods #
-##################
-def sorting_hat_vector(state_table: pd.DataFrame) -> pd.Series:
-    sorted_series = state_table.apply(sorting_hat_serial, axis=1)
-    return sorted_series
-
-
-def sorting_hat_serial(simulant_row: pd.Series) -> str:
-    first_name = simulant_row[0]
-    last_name = simulant_row[1]
-    if first_name == "harry":
-        return "gryffindor"
-    if first_name == "luna":
-        return "ravenclaw"
-    if last_name == "snape":
-        return "slytherin"
-    return "hufflepuff"
-
-
-def sorting_hat_bad_mapping(simulant_row: pd.Series) -> str:
-    # Return something not in CATEGORIES
-    return "pancakes"
 
 
 #########

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -39,6 +39,7 @@ from .mocks import (
             STUDENT_HOUSES,
         ),
     ],
+    ids=["vectorized_mapper", "non-vectorized_mapper"],
 )
 def test_stratification(name, sources, categories, mapper, is_vectorized, expected_output):
     my_stratification = Stratification(name, sources, categories, mapper, is_vectorized)
@@ -93,7 +94,7 @@ def test_stratification_init_raises(
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized, expected_exception",
     [
-        (  # map to a category that isn't in CATEGORIES
+        (
             NAME,
             SOURCES,
             CATEGORIES,
@@ -101,7 +102,7 @@ def test_stratification_init_raises(
             False,
             ValueError,
         ),
-        (  # sources not in population columns
+        (
             NAME,
             ["middle_initial"],
             CATEGORIES,
@@ -109,7 +110,7 @@ def test_stratification_init_raises(
             True,
             KeyError,
         ),
-        (  # is_vectorized=True with non-vectorized mapper
+        (
             NAME,
             SOURCES,
             CATEGORIES,
@@ -117,7 +118,7 @@ def test_stratification_init_raises(
             True,
             Exception,
         ),
-        (  # is_vectorized=False with vectorized mapper
+        (
             NAME,
             SOURCES,
             CATEGORIES,
@@ -125,6 +126,12 @@ def test_stratification_init_raises(
             False,
             Exception,
         ),
+    ],
+    ids=[
+        "category_not_in_categories",
+        "source_not_in_population_columns",
+        "vectorized_with_serial_mapper",
+        "not_vectorized_with_serial_mapper",
     ],
 )
 def test_stratification_call_raises(


### PR DESCRIPTION
## Implement register_stratification, underlying functionality, and add tests

### Description
- *Category*: POC
- *JIRA issue*: [MIC-3133](https://jira.ihme.washington.edu/browse/MIC-3133)

#### Changes
- Implements ResultsInterface and ResultsManager register_stratification along with ResultsContext functionality
- Refactor ResultsInterface to be separate from ResultsManager, using `TYPE_CHECKING` to handle circular imports
- Refactor often-used mocks to its own file
- Adds tests for register_stratification with columns and pipelines as sources
- TODO added for error case (duplicate stratification) pending feedback

### Testing
Four new tests were added, all pass along with the pre-existing ones for the results system.

