### PR TITLE
Add functionality for binned stratifications

### DIFF
--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -106,7 +106,30 @@ class ResultsInterface:
         target_type: str = "column",
         **cut_kwargs,
     ) -> None:
-        self._manager.register_binned_stratification(...)
+        """Register a continuous `target` quantity to observe into bins in a `binned_column`.
+
+        Parameters
+        ----------
+        target
+            String name of the state table column or value pipeline used to stratify.
+        binned_column
+            String name of the column for the binned quantities.
+        bins
+            List of scalars defining the bin edges, passed to :meth: pandas.cut. Lists
+            `bins` and `labels` must be of equal length.
+        labels
+            List of string labels for bins. Lists `bins` and `labels` must be of equal length.
+        target_type
+            "column" or "value"
+        **cut_kwargs
+            Keyword arguments for :meth: pandas.cut.
+
+        Returns
+        ------
+        None
+        """
+        self._manager.register_binned_stratification(target, target_type, binned_column, bins, labels, **cut_kwargs)
+
 
     def register_observation(
         self,

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -128,8 +128,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_binned_stratification(target, target_type, binned_column, bins, labels, **cut_kwargs)
-
+        self._manager.register_binned_stratification(
+            target, target_type, binned_column, bins, labels, **cut_kwargs
+        )
 
     def register_observation(
         self,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -133,9 +133,33 @@ class ResultsManager:
         labels: List[str],
         **cut_kwargs,
     ) -> None:
+        """Manager-level registration of a continuous `target` quantity to observe into bins in a `binned_column`.
+
+        Parameters
+        ----------
+        target
+            String name of the state table column or value pipeline used to stratify.
+        target_type
+            "column" or "value"
+        binned_column
+            String name of the column for the binned quantities.
+        bins
+            List of scalars defining the bin edges, passed to :meth: pandas.cut. Lists
+            `bins` and `labels` must be of equal length.
+        labels
+            List of string labels for bins. Lists `bins` and `labels` must be of equal length.
+        **cut_kwargs
+            Keyword arguments for :meth: pandas.cut.
+
+        Returns
+        ------
+        None
+        """
         def _bin_data(data: pd.Series) -> pd.Series:
             return pd.cut(data, bins, labels=labels, **cut_kwargs)
 
+        if len(bins) != len(labels):
+            raise ValueError(f"Bin length ({len(bins)}) does not match labels length ({len(labels)})")
         target_arg = "required_columns" if target_type == "column" else "required_values"
         target_kwargs = {target_arg: [target]}
         self.register_stratification(

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -155,11 +155,14 @@ class ResultsManager:
         ------
         None
         """
+
         def _bin_data(data: pd.Series) -> pd.Series:
             return pd.cut(data, bins, labels=labels, **cut_kwargs)
 
         if len(bins) != len(labels):
-            raise ValueError(f"Bin length ({len(bins)}) does not match labels length ({len(labels)})")
+            raise ValueError(
+                f"Bin length ({len(bins)}) does not match labels length ({len(labels)})"
+            )
         target_arg = "required_columns" if target_type == "column" else "required_values"
         target_kwargs = {target_arg: [target]}
         self.register_stratification(

--- a/tests/framework/results/mocks.py
+++ b/tests/framework/results/mocks.py
@@ -13,6 +13,11 @@ STUDENT_TABLE = pd.DataFrame(
 )
 STUDENT_HOUSES = pd.Series(["gryffindor", "slytherin", "ravenclaw"])
 
+BIN_BINNED_COLUMN = "silly_bin"
+BIN_SOURCE = "silly_level"
+BIN_LABELS = ["not", "meh", "somewhat", "very", "extra"]
+BIN_SILLY_BINS = [0, 20, 40, 60, 90]
+
 
 ##################
 # Helper methods #

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -8,6 +8,10 @@ from .mocks import (
     CATEGORIES,
     NAME,
     SOURCES,
+    BIN_BINNED_COLUMN,
+    BIN_SOURCE,
+    BIN_LABELS,
+    BIN_SILLY_BINS,
     sorting_hat_serial,
     sorting_hat_vector,
     verify_stratification_added,
@@ -18,6 +22,10 @@ from .mocks import (
 def mock_get_value(self, name: str):
     return name
 
+
+#######################################
+# Tests for `register_stratification` #
+#######################################
 
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized",
@@ -155,3 +163,25 @@ def test_duplicate_name_register_stratification(mocker):
     mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
     with pytest.raises(ValueError, match=f"Name `{NAME}` is already used"):
         mgr.register_stratification(NAME, CATEGORIES, sorting_hat_vector, True, SOURCES, [])
+
+
+##############################################
+# Tests for `register_binned_stratification` #
+##############################################
+
+def test_register_binned_stratification(mocker):
+    mgr = ResultsManager()
+    mock_register_stratification = mocker.patch("vivarium.framework.results.manager.ResultsManager.register_stratification")
+    mgr.register_binned_stratification(BIN_SOURCE, "column", BIN_BINNED_COLUMN, BIN_SILLY_BINS, BIN_LABELS)
+    mock_register_stratification.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "bins, labels",
+    [(BIN_SILLY_BINS, BIN_LABELS[2:]), (BIN_SILLY_BINS[2:], BIN_LABELS)],
+    ids=["more_bins_than_labels", "more_labels_than_bins"],
+)
+def test_register_binned_stratification_raises(bins, labels):
+    mgr = ResultsManager()
+    with pytest.raises(ValueError):
+        raise mgr.register_binned_stratification(BIN_SOURCE, "column", BIN_BINNED_COLUMN, bins, labels)

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -5,13 +5,13 @@ import pytest
 from vivarium.framework.results.manager import ResultsManager
 
 from .mocks import (
+    BIN_BINNED_COLUMN,
+    BIN_LABELS,
+    BIN_SILLY_BINS,
+    BIN_SOURCE,
     CATEGORIES,
     NAME,
     SOURCES,
-    BIN_BINNED_COLUMN,
-    BIN_SOURCE,
-    BIN_LABELS,
-    BIN_SILLY_BINS,
     sorting_hat_serial,
     sorting_hat_vector,
     verify_stratification_added,
@@ -26,6 +26,7 @@ def mock_get_value(self, name: str):
 #######################################
 # Tests for `register_stratification` #
 #######################################
+
 
 @pytest.mark.parametrize(
     "name, sources, categories, mapper, is_vectorized",
@@ -169,10 +170,15 @@ def test_duplicate_name_register_stratification(mocker):
 # Tests for `register_binned_stratification` #
 ##############################################
 
+
 def test_register_binned_stratification(mocker):
     mgr = ResultsManager()
-    mock_register_stratification = mocker.patch("vivarium.framework.results.manager.ResultsManager.register_stratification")
-    mgr.register_binned_stratification(BIN_SOURCE, "column", BIN_BINNED_COLUMN, BIN_SILLY_BINS, BIN_LABELS)
+    mock_register_stratification = mocker.patch(
+        "vivarium.framework.results.manager.ResultsManager.register_stratification"
+    )
+    mgr.register_binned_stratification(
+        BIN_SOURCE, "column", BIN_BINNED_COLUMN, BIN_SILLY_BINS, BIN_LABELS
+    )
     mock_register_stratification.assert_called_once()
 
 
@@ -184,4 +190,6 @@ def test_register_binned_stratification(mocker):
 def test_register_binned_stratification_raises(bins, labels):
     mgr = ResultsManager()
     with pytest.raises(ValueError):
-        raise mgr.register_binned_stratification(BIN_SOURCE, "column", BIN_BINNED_COLUMN, bins, labels)
+        raise mgr.register_binned_stratification(
+            BIN_SOURCE, "column", BIN_BINNED_COLUMN, bins, labels
+        )


### PR DESCRIPTION
## Add functionality for binned stratifications

### Description
- *Category*: POC
- *JIRA issue*: [MIC-3134](https://jira.ihme.washington.edu/browse/MIC-3134)

#### Changes
- Adds implementation of interface and manager methods for binned stratifications and docstrings
- Adds test for registration (using `assert_called_once` as `assert_called_with` isn't available, as the mapper is defined at runtime)

### Testing
My new tests work.

