### PR TITLE
Implement register_observation

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -19,7 +19,7 @@ class ResultsContext:
     def __init__(self):
         self._default_stratifications: List[str] = []
         self._stratifications: List[Stratification] = []
-        # keys are event names
+        # keys are event names: ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"]
         # values are dicts with key (filter, grouper) value (measure, aggregator, additional_keys)
         self._observations = defaultdict(lambda: defaultdict(list))
 
@@ -83,13 +83,9 @@ class ResultsContext:
         when: str = "collect_metrics",
         **additional_keys: str,
     ):
-        # TODO: _producers doesn't exist, stub code needs bugfix at observation implementation time
+        # TODO: Add check on when being valid, check stratifications existence?
         groupers = self._get_groupers(additional_stratifications, excluded_stratifications)
-        (
-            self._producers[when][(pop_filter, groupers)].append(
-                (name, aggregator, additional_keys)
-            )
-        )
+        self._observations[when][(pop_filter, groupers)].append((name, aggregator, additional_keys))
 
     def gather_results(self, population: pd.DataFrame, event_name: str) -> Dict[str, float]:
         # Optimization: We store all the producers by pop_filter and groupers

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -85,7 +85,9 @@ class ResultsContext:
     ):
         # TODO: Add check on when being valid, check stratifications existence?
         groupers = self._get_groupers(additional_stratifications, excluded_stratifications)
-        self._observations[when][(pop_filter, groupers)].append((name, aggregator, additional_keys))
+        self._observations[when][(pop_filter, groupers)].append(
+            (name, aggregator, additional_keys)
+        )
 
     def gather_results(self, population: pd.DataFrame, event_name: str) -> Dict[str, float]:
         # Optimization: We store all the producers by pop_filter and groupers

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -172,5 +172,13 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_observation(name, pop_filter, aggregator, requires_columns, requires_values,
-                                           additional_stratifications, excluded_stratifications, when)
+        self._manager.register_observation(
+            name,
+            pop_filter,
+            aggregator,
+            requires_columns,
+            requires_values,
+            additional_stratifications,
+            excluded_stratifications,
+            when,
+        )

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -166,7 +166,7 @@ class ResultsInterface:
             names to remove from the observation.
         when
             String name of the phase of a time-step the observation should happen. Valid values are:
-            ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"]
+            `"time_step__prepare"`, `"time_step"`, `"time_step__cleanup"`, `"collect_metrics"`.
 
         Returns
         ------

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -143,4 +143,34 @@ class ResultsInterface:
         excluded_stratifications: List[str] = (),
         when: str = "collect_metrics",
     ) -> None:
-        self._manager.register_observation(...)
+        """Provide the results system all the information it needs to perform the observation.
+
+        Parameters
+        ----------
+        name
+            String name for the observation.
+        pop_filter
+            A Pandas query filter string to filter the population down to the simulants who should
+            be considered for the observation.
+        aggregator
+            A function that computes the quantity for the observation.
+        requires_columns
+            A list of the state table columns that are required by either the pop_filter or the aggregator.
+        requires_values
+            A list of the value pipelines that are required by either the pop_filter or the aggregator.
+        additional_stratifications
+            A list of additional :class:`stratification <vivarium.framework.results.stratification.Stratification>`
+            names by which to stratify.
+        excluded_stratifications
+            A list of default :class:`stratification <vivarium.framework.results.stratification.Stratification>`
+            names to remove from the observation.
+        when
+            String name of the phase of a time-step the observation should happen. Valid values are:
+            ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"]
+
+        Returns
+        ------
+        None
+        """
+        self._manager.register_observation(name, pop_filter, aggregator, requires_columns, requires_values,
+                                           additional_stratifications, excluded_stratifications, when)

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -80,6 +80,7 @@ class ResultsManager:
         #     self._metrics.update(results_group)
 
     def set_default_stratifications(self, default_stratifications: List[str]):
+        # TODO: ought there be default default_stratifications? There is no interface for them in interface.py
         self._results_context.set_default_stratifications(default_stratifications)
 
     def register_stratification(
@@ -180,8 +181,6 @@ class ResultsManager:
         excluded_stratifications: List[str] = (),
         when: str = "collect_metrics",
     ) -> None:
-        self._add_resources(requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
         self._results_context.add_observation(
             name,
             pop_filter,
@@ -190,6 +189,8 @@ class ResultsManager:
             excluded_stratifications,
             when,
         )
+        self._add_resources(requires_columns, SourceType.COLUMN)
+        self._add_resources(requires_values, SourceType.VALUE)
 
     def _add_resources(self, target: List[str], target_type: SourceType):
         if not len(target):

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -80,7 +80,6 @@ class ResultsManager:
         #     self._metrics.update(results_group)
 
     def set_default_stratifications(self, default_stratifications: List[str]):
-        # TODO: ought there be default default_stratifications? There is no interface for them in interface.py
         self._results_context.set_default_stratifications(default_stratifications)
 
     def register_stratification(

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -1,15 +1,12 @@
-import numpy as np
 import pandas as pd
 import pytest
 
 from vivarium.framework.results.context import ResultsContext
-from vivarium.framework.results.stratification import Stratification
 
 from .mocks import (
     CATEGORIES,
     NAME,
     SOURCES,
-    sorting_hat_bad_mapping,
     sorting_hat_serial,
     sorting_hat_vector,
     verify_stratification_added,

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -80,34 +80,80 @@ def _aggregate_state_person_time(self, x: pd.DataFrame) -> float:
 @pytest.mark.parametrize(
     "name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when",
     [
-        ("living_person_time", 'alive == "alive" and undead == False', _aggregate_state_person_time, [], [], "collect_metrics"),
-        ("undead_person_time", "undead == True", _aggregate_state_person_time, [], [], "time_step__prepare"),
+        (
+            "living_person_time",
+            'alive == "alive" and undead == False',
+            _aggregate_state_person_time,
+            [],
+            [],
+            "collect_metrics",
+        ),
+        (
+            "undead_person_time",
+            "undead == True",
+            _aggregate_state_person_time,
+            [],
+            [],
+            "time_step__prepare",
+        ),
     ],
     ids=["valid_on_collect_metrics", "valid_on_time_step__prepare"],
 )
-def test_add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when):
+def test_add_observation(
+    name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when
+):
     ctx = ResultsContext()
     ctx._default_stratifications = ["age", "sex"]
     assert len(ctx._observations) == 0
-    ctx.add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when)
+    ctx.add_observation(
+        name,
+        pop_filter,
+        aggregator,
+        additional_stratifications,
+        excluded_stratifications,
+        when,
+    )
     assert len(ctx._observations) == 1
 
 
 @pytest.mark.parametrize(
     "name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when",
     [
-        ("living_person_time", 'alive == "alive" and undead == False', _aggregate_state_person_time, [], [], "collect_metrics"),
+        (
+            "living_person_time",
+            'alive == "alive" and undead == False',
+            _aggregate_state_person_time,
+            [],
+            [],
+            "collect_metrics",
+        ),
     ],
     ids=["valid_on_collect_metrics"],
 )
-def test_double_add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when):
+def test_double_add_observation(
+    name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when
+):
     """Tests a double add of the same stratification, this should result in one additional observation being added to
     the context."""
     ctx = ResultsContext()
     ctx._default_stratifications = ["age", "sex"]
     assert len(ctx._observations) == 0
-    ctx.add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when)
-    ctx.add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when)
+    ctx.add_observation(
+        name,
+        pop_filter,
+        aggregator,
+        additional_stratifications,
+        excluded_stratifications,
+        when,
+    )
+    ctx.add_observation(
+        name,
+        pop_filter,
+        aggregator,
+        additional_stratifications,
+        excluded_stratifications,
+        when,
+    )
     assert len(ctx._observations) == 1
 
 
@@ -117,11 +163,21 @@ def test_double_add_observation(name, pop_filter, aggregator, additional_stratif
         ([], [], [], ()),
         (["age", "sex"], ["handedness"], ["age"], ("sex", "handedness")),
         (["age", "sex"], [], ["age", "sex"], ()),
-        (["age"], [], ["bogus_exclude_column"], ("age",))
+        (["age"], [], ["bogus_exclude_column"], ("age",)),
     ],
-    ids=["empty_add_empty_exclude", "one_add_one_exclude", "all_defaults_excluded", "bogus_exclude"],
+    ids=[
+        "empty_add_empty_exclude",
+        "one_add_one_exclude",
+        "all_defaults_excluded",
+        "bogus_exclude",
+    ],
 )
-def test__get_groupers(default_stratifications, additional_stratifications, excluded_stratifications, expected_groupers):
+def test__get_groupers(
+    default_stratifications,
+    additional_stratifications,
+    excluded_stratifications,
+    expected_groupers,
+):
     ctx = ResultsContext()
     # default_stratifications would normally be set via ResultsInterface.set_default_stratifications()
     ctx._default_stratifications = default_stratifications

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -155,6 +155,33 @@ def test_double_add_observation(
 
 
 @pytest.mark.parametrize(
+    "default, additional, excluded, match",
+    [
+        (["age", "sex"], ["age"], [], "age"),
+        (["age", "sex"], [], ["eye_color"], "eye_color"),
+        (["age", "sex"], ["age"], ["eye_color"], "age|eye_color"),
+    ],
+    ids=[
+        "additional_no_operation",
+        "exclude_no_operation",
+        "additional_and_exclude_no_operation",
+    ],
+)
+def test_add_observation_nop_stratifications(default, additional, excluded, match):
+    ctx = ResultsContext()
+    ctx._default_stratifications = default
+    with pytest.warns(UserWarning, match=match):
+        ctx.add_observation(
+            "name",
+            'alive == "alive"',
+            _aggregate_state_person_time,
+            additional,
+            excluded,
+            "collect_metrics",
+        )
+
+
+@pytest.mark.parametrize(
     "default_stratifications, additional_stratifications, excluded_stratifications, expected_groupers",
     [
         ([], [], [], ()),

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -70,3 +70,60 @@ def test_add_stratification_raises(
     ctx = ResultsContext()
     with pytest.raises(expected_exception):
         raise ctx.add_stratification(name, sources, categories, mapper, is_vectorized)
+
+
+def _aggregate_state_person_time(self, x: pd.DataFrame) -> float:
+    """Helper aggregator function for observation testing"""
+    return len(x) * (28 / 365.35)
+
+
+@pytest.mark.parametrize(
+    "name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when",
+    [
+        ("living_person_time", 'alive == "alive" and undead == False', _aggregate_state_person_time, [], [], "collect_metrics"),
+        ("undead_person_time", "undead == True", _aggregate_state_person_time, [], [], "time_step__prepare"),
+    ],
+    ids=["valid_on_collect_metrics", "valid_on_time_step__prepare"],
+)
+def test_add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when):
+    ctx = ResultsContext()
+    ctx._default_stratifications = ["age", "sex"]
+    assert len(ctx._observations) == 0
+    ctx.add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when)
+    assert len(ctx._observations) == 1
+
+
+@pytest.mark.parametrize(
+    "name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when",
+    [
+        ("living_person_time", 'alive == "alive" and undead == False', _aggregate_state_person_time, [], [], "collect_metrics"),
+    ],
+    ids=["valid_on_collect_metrics"],
+)
+def test_double_add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when):
+    """Tests a double add of the same stratification, this should result in one additional observation being added to
+    the context."""
+    ctx = ResultsContext()
+    ctx._default_stratifications = ["age", "sex"]
+    assert len(ctx._observations) == 0
+    ctx.add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when)
+    ctx.add_observation(name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when)
+    assert len(ctx._observations) == 1
+
+
+@pytest.mark.parametrize(
+    "default_stratifications, additional_stratifications, excluded_stratifications, expected_groupers",
+    [
+        ([], [], [], ()),
+        (["age", "sex"], ["handedness"], ["age"], ("sex", "handedness")),
+        (["age", "sex"], [], ["age", "sex"], ()),
+        (["age"], [], ["bogus_exclude_column"], ("age",))
+    ],
+    ids=["empty_add_empty_exclude", "one_add_one_exclude", "all_defaults_excluded", "bogus_exclude"],
+)
+def test__get_groupers(default_stratifications, additional_stratifications, excluded_stratifications, expected_groupers):
+    ctx = ResultsContext()
+    # default_stratifications would normally be set via ResultsInterface.set_default_stratifications()
+    ctx._default_stratifications = default_stratifications
+    groupers = ctx._get_groupers(additional_stratifications, excluded_stratifications)
+    assert sorted(groupers) == sorted(expected_groupers)

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -59,3 +59,32 @@ def test_register_observation(
         excluded_stratifications,
     )
     assert len(interface._manager._results_context._observations) == 1
+
+
+def test_register_observations():
+    mgr = ResultsManager()
+    interface = ResultsInterface(mgr)
+    # interface.set_default_stratifications(["age", "sex"])
+    assert len(interface._manager._results_context._observations) == 0
+    interface.register_observation(
+        "living_person_time",
+        'alive == "alive" and undead == False',
+        _silly_aggregator,
+        [],
+        [],
+        [],
+        [],
+        "collect_metrics",
+    )
+    assert len(interface._manager._results_context._observations) == 1
+    interface.register_observation(
+        "undead_person_time",
+        "undead == True",
+        _silly_aggregator,
+        [],
+        [],
+        [],
+        [],
+        "time_step__prepare",
+    )
+    assert len(interface._manager._results_context._observations) == 2

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import pytest
+
+from vivarium.framework.results import ResultsInterface, ResultsManager
+
+
+def _silly_aggregator(_: pd.DataFrame) -> float:
+    return 1.0
+
+
+@pytest.mark.parametrize(
+    (
+        "name, pop_filter, aggregator, requires_columns, requires_values,"
+        " additional_stratifications, excluded_stratifications, when"
+    ),
+    [
+        (
+            "living_person_time",
+            'alive == "alive" and undead == False',
+            _silly_aggregator,
+            None,
+            None,
+            [],
+            [],
+            "collect_metrics",
+        ),
+        (
+            "undead_person_time",
+            "undead == True",
+            _silly_aggregator,
+            None,
+            None,
+            [],
+            [],
+            "time_step__prepare",
+        ),
+    ],
+    ids=["valid_on_collect_metrics", "valid_on_time_step__prepare"],
+)
+def test_register_observation(
+    name,
+    pop_filter,
+    aggregator,
+    requires_columns,
+    requires_values,
+    additional_stratifications,
+    excluded_stratifications,
+    when,
+):
+    mgr = ResultsManager()
+    interface = ResultsInterface(mgr)
+    # interface.set_default_stratifications(["age", "sex"])
+    assert len(interface._manager._results_context._observations) == 0
+    interface.register_observation(
+        name,
+        pop_filter,
+        aggregator,
+        additional_stratifications,
+        excluded_stratifications,
+    )
+    assert len(interface._manager._results_context._observations) == 1


### PR DESCRIPTION
## Implement register_observation

### Description
- *Category*: POC
- *JIRA issue*: [MIC-3341](https://jira.ihme.washington.edu/browse/MIC-3341)

#### Changes
- Adds docstring to `interface.register_observation`
- Implements `ResultsManager.register_observation` and `ResultsContext.add_observation`
- Integration test added for `ResultsManager.register_observation` and unit test added for `ResultsContext.add_observation`
- Implements and tests `ResultsContext._get_groupers`

### Testing
All tests pass.

