### PR TITLE
Implement pipeline caching

### DIFF
--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -287,13 +287,13 @@ class ValuesManager:
     def setup(self, builder):
         self.step_size = builder.time.step_size()
         builder.event.register_listener("post_setup", self.on_post_setup)
+        builder.event.register_listener("time_step__cleanup", self.on_timestep_cleanup, priority=9)
 
         self.resources = builder.resources
         self.add_constraint = builder.lifecycle.add_constraint
 
         builder.lifecycle.add_constraint(self.register_value_producer, allow_during=["setup"])
         builder.lifecycle.add_constraint(self.register_value_modifier, allow_during=["setup"])
-        builder.event.register_listener("time_step__cleanup", self.on_timestep_cleanup, priority=9)
 
     def on_post_setup(self, _):
         """Finalizes dependency structure for the pipelines."""
@@ -305,6 +305,7 @@ class ValuesManager:
 
         # register_value_producer and register_value_modifier record the
         # dependency structure for the pipeline source and pipeline modifiers,
+        # respectively.  We don't have enough information to record the
         # respectively.  We don't have enough information to record the
         # dependency structure for the pipeline itself until now, where
         # we say the pipeline value depends on its source and all its

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -235,7 +235,7 @@ class Pipeline:
             )
 
         # if only one kwarg was passed in and it's an index, treat it as the arg
-        if (len(args) == 0) and (len(kwargs) == 1) and (isinstance(kwargs["index"], pd.Index)):
+        if (len(args) == 0) and (len(kwargs) == 1) and ("index" in kwargs) and (isinstance(kwargs["index"], pd.Index)):
             args = [kwargs["index"]]
             kwargs = {}
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -250,6 +250,7 @@ class Pipeline:
                 self.manager.call_history[self.name] = pd.DataFrame()
                 newly_requested = args[0]
             if newly_requested.any():
+                newly_requested = newly_requested.unique()
                 value = self.source(newly_requested)
                 for mutator in self.mutators:
                     value = self.combiner(value, mutator, newly_requested)

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -237,7 +237,7 @@ class Pipeline:
         # if only one kwarg was passed in and it's an index, treat it as the arg
         if (len(args) == 0) and (len(kwargs) == 1) and (isinstance(kwargs["index"], pd.Index)):
             args = [kwargs["index"]]
-            kwargs = None
+            kwargs = {}
 
         # if we only have one arg and it's an index
         if (len(args) == 1) and (isinstance(args[0], pd.Index)) and (kwargs == {}) and use_cache:

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -293,6 +293,7 @@ class ValuesManager:
 
         builder.lifecycle.add_constraint(self.register_value_producer, allow_during=["setup"])
         builder.lifecycle.add_constraint(self.register_value_modifier, allow_during=["setup"])
+        builder.event.register_listener("time_step__cleanup", self.on_timestep_cleanup, priority=9)
 
     def on_post_setup(self, _):
         """Finalizes dependency structure for the pipelines."""
@@ -318,6 +319,9 @@ class ValuesManager:
                 mutator_name = self._get_modifier_name(m)
                 dependencies.append(f"value_modifier.{name}.{i+1}.{mutator_name}")
             self.resources.add_resources("value", [name], pipe._call, dependencies)
+
+    def on_timestep_cleanup(self):
+        self.call_history = {}
 
     def register_value_producer(
         self,

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -235,7 +235,7 @@ class Pipeline:
             )
 
         # if only one kwarg was passed in and it's an index, treat it as the arg
-        if (args is None) and (len(kwargs) == 1) and (isinstance(kwargs["index"], pd.Index)):
+        if (len(args) == 0) and (len(kwargs) == 1) and (isinstance(kwargs["index"], pd.Index)):
             args = [kwargs["index"]]
             kwargs = None
 


### PR DESCRIPTION
## Implement pipeline caching
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
Adding caching functionality to pipeline calls within a timestep
- *Category*: feature
- *JIRA issue*: [MIC-3616](https://jira.ihme.washington.edu/browse/MIC-3616)
- [design propsal](https://github.com/ihmeuw/vivarium_development/blob/main/docs/source/design/2022_11_28_pipeline_caching.rst)

Added pipeline caching functionality:

- if passed in exactly one arg and no kwargs; or
- if passed in exactly one kwarg with key "index" and no kwargs:
- pipeline caches call in a pd.DataFrame stored in ValuesManager.call_history['pipeline_name']

- if any other combinations are passed in, doesn't cache, just calls pipeline as usual.
- empties out cache on timestep cleanup.

### Testing
stepped through code in a number of different scenarios and edge cases. will include pytests in a separate PR.

