### PR TITLE
Update CI build and release versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ venv.bak/
 
 # Pycharm project settings
 .idea/
+
+# Local user jupyter notebooks directory
+notebooks/

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,19 @@
 import sys
 
-if sys.version_info < (3, 6) or sys.version_info >= (3, 9):
+min_version, max_version = ((3, 6), "3.6"), ((3, 10), "3.10")
+
+if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings
     py_version = ".".join([str(v) for v in sys.version_info[:3]])
     error = (
         "\n----------------------------------------\n"
-        "Error: Vivarium runs under python 3.6-3.8.\n"
-        "You are running python {py_version}".format(py_version=py_version)
+        "Error: Vivarium runs under python {min_version}-{max_version}.\n"
+        "You are running python {py_version}".format(
+            min_version=min_version[1], max_version=max_version[1], py_version=py_version
+        )
     )
     print(error, file=sys.stderr)
     sys.exit(1)
-
 
 from pathlib import Path
 


### PR DESCRIPTION
## Fix broken CI builds
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: CI/Infrastructure
*JIRA issue*: N/A

- Added notebooks/ to the .gitignore so notebooks I store for testing in my local copy of the repo don't end up in the remote.
- Updated CI build versions as 3.6 is no longer supported by github actions


### Testing
N/A
