### PR TITLE
Add aggregator_sources arg for context tests, resolve FutureWarning

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -160,7 +160,7 @@ class ResultsContext:
             """Format of the measure identifier tokens into FIELD_param."""
             return f"{str(field).upper()}_{param}"
 
-        for categories, val in data.iteritems():
+        for categories, val in data.items():
             if isinstance(categories, str):  # handle single stratification case
                 categories = [categories]
             key = "_".join(

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -110,6 +110,7 @@ def test_add_observation(
     ctx.add_observation(
         name,
         pop_filter,
+        [],
         aggregator,
         additional_stratifications,
         excluded_stratifications,
@@ -143,6 +144,7 @@ def test_double_add_observation(
     ctx.add_observation(
         name,
         pop_filter,
+        [],
         aggregator,
         additional_stratifications,
         excluded_stratifications,
@@ -151,6 +153,7 @@ def test_double_add_observation(
     ctx.add_observation(
         name,
         pop_filter,
+        [],
         aggregator,
         additional_stratifications,
         excluded_stratifications,


### PR DESCRIPTION
## Add aggregator_sources arg for context tests, resolve FutureWarning

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-2375](https://jira.ihme.washington.edu/browse/MIC-2375)

#### Changes
- Resolve FutureWarning on items() replacing iteritems()
- Mend context tests to use the `aggregator_sources` argument

### Testing
Pytests run successfully without warnings.

