### PR TITLE
Add method to get sim state

### DIFF
--- a/src/vivarium/framework/lifecycle.py
+++ b/src/vivarium/framework/lifecycle.py
@@ -670,3 +670,14 @@ class LifeCycleInterface:
 
         """
         self._manager.add_constraint(method, allow_during, restrict_during)
+
+    def current_state(self) -> Callable[[], str]:
+        """Returns a callable that gets the current simulation lifecycle state.
+
+        Returns
+        -------
+        Callable[[], str]
+            A callable that returns the current simulation lifecycle state.
+
+        """
+        return lambda: self._manager.current_state


### PR DESCRIPTION
## Add method to get sim state
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: N/A

Adds a method on the simulation lifecycle interface to provide other components 
and simulation managers a way to access the current simulation state.  In particular,
I'm planning on using this to clean up the way initial population creation vs new births
and migration are handeled.

### Testing
N/A, just an expansion of the interface, but no functionality.