### PR TITLE
update github CI 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @aflaxman @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier
+* @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 #   - invoked on push, pull_request, or manual trigger
-#   - test under 3 versions of python
+#   - test under at least 3 versions of python
 # -----------------------------------------------------------------------------
 name: build
 on: [push, pull_request, workflow_dispatch]
@@ -12,13 +12,14 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Print environment values
         run: |
+          python --version
           cat $GITHUB_ENV
       - name: Update pip
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,13 +8,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install dependencies
         run: |
+          python --versions
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
       - name: Build and publish

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Vivarium
 Vivarium is a simulation framework written using standard scientific Python
 tools.
 
-**Vivarium requires Python 3.6 to run**
+**Vivarium requires Python 3.7-3.10 to run**
 
 You can install ``vivarium`` from PyPI with pip:
 


### PR DESCRIPTION
## Update CI

### Description
- *Category*: other
- *JIRA issue*: [MIC-3690](https://jira.ihme.washington.edu/browse/MIC-3690)

This addresses a few issues with the github actions:
* Updates the python builds 3.7-3.10 (remove 3.6 and add 3.9-10)
* Update actions to stop future warnings (The `set-output` command
    is deprecated and will be disabled soon. Please upgrade to using
    Environment Files. For more information see: 
    https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* Update CODEOWNERS
* Update README install 3.10
* Update setup to use min 3.7

### Testing
All tests passed and warnings are gone

