### PR TITLE
Remove copy_with_addtional_key

### DIFF
--- a/src/vivarium/framework/randomness/manager.py
+++ b/src/vivarium/framework/randomness/manager.py
@@ -122,7 +122,6 @@ class RandomnessManager:
             clock=self._clock,
             seed=self._seed,
             index_map=self._key_mapping,
-            manager=self,
             for_initialization=for_initialization,
         )
         self._decision_points[decision_point] = stream

--- a/src/vivarium/framework/randomness/stream.py
+++ b/src/vivarium/framework/randomness/stream.py
@@ -10,12 +10,8 @@ import numpy as np
 import pandas as pd
 
 from vivarium.framework.randomness.core import choice, filter_for_probability, random
-from vivarium.framework.randomness.exceptions import RandomnessError
 from vivarium.framework.randomness.index_map import IndexMap
 from vivarium.framework.utilities import rate_to_probability
-
-if TYPE_CHECKING:
-    from vivarium.framework.randomness.manager import RandomnessManager
 
 
 class RandomnessStream:
@@ -55,37 +51,13 @@ class RandomnessStream:
         clock: Callable,
         seed: Any,
         index_map: IndexMap = None,
-        manager: "RandomnessManager" = None,
         for_initialization: bool = False,
     ):
         self.key = key
         self.clock = clock
         self.seed = seed
         self.index_map = index_map
-        self._manager = manager
         self._for_initialization = for_initialization
-
-    def copy_with_additional_key(self, key: Any) -> "RandomnessStream":
-        """Creates a copy of this stream with a permutation of it's random seed.
-
-        Parameters
-        ----------
-        key
-            The additional key to describe the new stream with.
-
-        Returns
-        -------
-        RandomnessStream
-            A new RandomnessStream with a combined key.
-
-        """
-        copy_key = "_".join([self.key, key])
-        if self._for_initialization:
-            raise RandomnessError("Initialization streams cannot be copied.")
-        elif self._manager:
-            return self._manager.get_randomness_stream(copy_key)
-        else:
-            return RandomnessStream(copy_key, self.clock, self.seed, self.index_map)
 
     @property
     def name(self):


### PR DESCRIPTION
Remove copy_with_addtional_key
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: Refactor
*JIRA issue*: 

Removes the `copy_with_addtional_key` method from the `RandomnessStream`
as it has been supplanted by:
- Getting a randomness stream for every decision point in a model.
- Or, using the additional_key keyword when using a randomness stream method.

As the `Zen of Python` reminds us: "There should be one-- and preferably only one --obvious way to do it."

Also lets us completely decouple the RandomnessManager from the stream, which is
just good design.

### Testing
CI, no additional tests required.
