### PR TITLE
Fix bug in gather_results, fix typing notation

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -105,10 +105,11 @@ class ResultsContext:
         ].items():
             # Results production can be simplified to
             # filter -> groupby -> aggregate in all situations we've seen.
-            stratified_pop = population.copy()
             if pop_filter:
-                stratified_pop = stratified_pop.query(pop_filter)
-            pop_groups = stratified_pop.groupby(list(stratifications))
+                filtered_pop = population.query(pop_filter)
+            else:
+                filtered_pop = population
+            pop_groups = filtered_pop.groupby(list(stratifications))
             for measure, aggregator_sources, aggregator, additional_keys in observations:
                 if aggregator_sources:
                     aggregates = pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -105,9 +105,10 @@ class ResultsContext:
         ].items():
             # Results production can be simplified to
             # filter -> groupby -> aggregate in all situations we've seen.
+            stratified_pop = population.copy()
             if pop_filter:
-                population = population.query(pop_filter)
-            pop_groups = population.groupby(list(stratifications))
+                stratified_pop = stratified_pop.query(pop_filter)
+            pop_groups = stratified_pop.groupby(list(stratifications))
             for measure, aggregator_sources, aggregator, additional_keys in observations:
                 if aggregator_sources:
                     aggregates = pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -37,7 +37,7 @@ class ResultsContext:
                 "Attempting to set an empty list as the default grouping columns "
                 "for results production."
             )
-        self._default_grouping_columns = default_grouping_columns
+        self._default_stratifications = default_grouping_columns
 
     def add_stratification(
         self,

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -66,5 +66,5 @@ class Stratification:
         return population
 
     @staticmethod
-    def _default_mapper(pop: pd.DataFrame) -> str:
+    def _default_mapper(pop: pd.DataFrame) -> Union[pd.Series, str]:
         return pop.squeeze(axis=1)

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -66,5 +66,5 @@ class Stratification:
         return population
 
     @staticmethod
-    def _default_mapper(pop: pd.DataFrame) -> Union[pd.Series, str]:
+    def _default_mapper(pop: pd.DataFrame) -> pd.Series:
         return pop.squeeze(axis=1)


### PR DESCRIPTION
## Fix bug in gather_results, fix typing notation

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3684](https://jira.ihme.washington.edu/browse/MIC-3684)

Mends two bugs found in the development of the `DiseaseObserver` where the population was being improperly refined during `gather_results` and the `ResultsContext` default stratifications were improperly set when used by `ResultsStratifier`. Also updates return type annotation that was incomplete for the Stratification default mapper.

### Testing
`DiseaseObserver` works with this code.
