### PR TITLE
Be clearer about the index map interface

### DIFF
--- a/src/vivarium/framework/randomness/manager.py
+++ b/src/vivarium/framework/randomness/manager.py
@@ -26,7 +26,7 @@ class RandomnessManager:
         self._seed = None
         self._clock = None
         self._key_columns = None
-        self._key_mapping = IndexMap()
+        self._key_mapping = None
         self._decision_points = dict()
 
     @property
@@ -39,9 +39,12 @@ class RandomnessManager:
             self._seed += str(builder.configuration.randomness.additional_seed)
         self._clock = builder.time.clock()
         self._key_columns = builder.configuration.randomness.key_columns
+
+        use_crn = bool(self._key_columns)
         map_size = builder.configuration.randomness.map_size
         pop_size = builder.configuration.population.population_size
-        self._key_mapping.map_size = max(map_size, 10 * pop_size)
+        map_size = max(map_size, 10 * pop_size)
+        self._key_mapping = IndexMap(use_crn, map_size)
 
         self.resources = builder.resources
         self._add_constraint = builder.lifecycle.add_constraint

--- a/tests/framework/randomness/test_index_map.py
+++ b/tests/framework/randomness/test_index_map.py
@@ -57,28 +57,28 @@ def id_fun(param):
 def map_size_and_hashed_values(request):
     keys = generate_keys(*request.param)
     m = IndexMap()
-    return m.map_size, m.hash_(keys)
+    return len(m), m._hash(keys)
 
 
 def test_digit_scalar():
     m = IndexMap()
     k = 123456789
     for i in range(10):
-        assert m.digit(k, i) == 10 - (i + 1)
+        assert m._digit(k, i) == 10 - (i + 1)
 
 
 def test_digit_series():
     m = IndexMap()
     k = pd.Series(123456789, index=range(10000))
     for i in range(10):
-        assert len(m.digit(k, i).unique()) == 1
-        assert m.digit(k, i)[0] == 10 - (i + 1)
+        assert len(m._digit(k, i).unique()) == 1
+        assert m._digit(k, i)[0] == 10 - (i + 1)
 
 
 def test_clip_to_seconds_scalar():
     m = IndexMap()
     k = pd.to_datetime("2010-01-25 06:25:31.123456789")
-    assert m.clip_to_seconds(k.value) == int(str(k.value)[:10])
+    assert m._clip_to_seconds(k.value) == int(str(k.value)[:10])
 
 
 def test_clip_to_seconds_series():
@@ -89,32 +89,32 @@ def test_clip_to_seconds_series():
         .to_series()
         .view(np.int64)
     )
-    assert len(m.clip_to_seconds(k).unique()) == 1
-    assert m.clip_to_seconds(k).unique()[0] == stamp
+    assert len(m._clip_to_seconds(k).unique()) == 1
+    assert m._clip_to_seconds(k).unique()[0] == stamp
 
 
 def test_spread_scalar():
     m = IndexMap()
-    assert m.spread(1234567890) == 4072825790
+    assert m._spread(1234567890) == 4072825790
 
 
 def test_spread_series():
     m = IndexMap()
     s = pd.Series(1234567890, index=range(10000))
-    assert len(m.spread(s).unique()) == 1
-    assert m.spread(s).unique()[0] == 4072825790
+    assert len(m._spread(s).unique()) == 1
+    assert m._spread(s).unique()[0] == 4072825790
 
 
 def test_shift_scalar():
     m = IndexMap()
-    assert m.shift(1.1234567890) == 1234567890
+    assert m._shift(1.1234567890) == 1234567890
 
 
 def test_shift_series():
     m = IndexMap()
     s = pd.Series(1.1234567890, index=range(10000))
-    assert len(m.shift(s).unique()) == 1
-    assert m.shift(s).unique()[0] == 1234567890
+    assert len(m._shift(s).unique()) == 1
+    assert m._shift(s).unique()[0] == 1234567890
 
 
 def test_convert_to_ten_digit_int():
@@ -127,11 +127,11 @@ def test_convert_to_ten_digit_int():
     float_col = pd.Series(1.1234567890, index=range(10000))
     bad_col = pd.Series("a", index=range(10000))
 
-    assert m.convert_to_ten_digit_int(datetime_col).unique()[0] == v
-    assert m.convert_to_ten_digit_int(int_col).unique()[0] == 4072825790
-    assert m.convert_to_ten_digit_int(float_col).unique()[0] == v
+    assert m._convert_to_ten_digit_int(datetime_col).unique()[0] == v
+    assert m._convert_to_ten_digit_int(int_col).unique()[0] == 4072825790
+    assert m._convert_to_ten_digit_int(float_col).unique()[0] == v
     with pytest.raises(RandomnessError):
-        m.convert_to_ten_digit_int(bad_col)
+        m._convert_to_ten_digit_int(bad_col)
 
 
 @pytest.mark.skip("This fails because the hash needs work")
@@ -173,9 +173,9 @@ def test_update(mocker):
         rs = np.random.RandomState(seed=seed + salt)
         return pd.Series(rs.randint(0, len(k) * 10, size=len(k)), index=k)
 
-    mocker.patch.object(m, "hash_", side_effect=hash_mock)
+    mocker.patch.object(m, "_hash", side_effect=hash_mock)
     m.update(keys)
-    assert len(m) == len(keys), "All keys not in mapping"
+    assert len(m._map) == len(keys), "All keys not in mapping"
     assert m._map.index.difference(keys).empty, "All keys not in mapping"
     assert len(m._map.unique()) == len(keys), "Duplicate values in mapping"
 
@@ -185,7 +185,7 @@ def test_update(mocker):
 
     new_unique_keys = generate_keys(1000).difference(keys)
     m.update(new_unique_keys)
-    assert len(m) == len(keys) + len(new_unique_keys), "All keys not in mapping"
+    assert len(m._map) == len(keys) + len(new_unique_keys), "All keys not in mapping"
     assert m._map.index.difference(
         keys.union(new_unique_keys)
     ).empty, "All keys not in mapping"

--- a/tests/framework/randomness/test_manager.py
+++ b/tests/framework/randomness/test_manager.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from vivarium.framework.randomness.index_map import IndexMap
 from vivarium.framework.randomness.manager import RandomnessError, RandomnessManager
 from vivarium.framework.randomness.stream import get_hash
 
@@ -34,6 +35,7 @@ def test_RandomnessManager_register_simulants():
     rm._seed = seed
     rm._clock = mock_clock
     rm._key_columns = ["age", "sex"]
+    rm._key_mapping = IndexMap()
 
     bad_df = pd.DataFrame({"age": range(10), "not_sex": [1] * 5 + [2] * 5})
     with pytest.raises(RandomnessError):


### PR DESCRIPTION
## Be clearer about the index map interface
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: refactor
*JIRA issue*: N/A

- Privatize most of the index map functions
- Redefine the length of the index map to be the actual length of the mapping, not the number of used keys.
- Be explicit in the randomness manager that we are using crn whenever there are provided `key_columns` rather than hiding that detail in the implementation
- move some old error messages to use fstrings
- extract a randomness stream test fixture
- update test usage to match new interface methods.

### Testing
CI

