### PR TITLE
Rename crn attribute randomness arg

### DIFF
--- a/src/vivarium/examples/disease_model/population.py
+++ b/src/vivarium/examples/disease_model/population.py
@@ -55,7 +55,7 @@ class BasePopulation:
             )
 
         self.age_randomness = builder.randomness.get_stream(
-            "age_initialization", for_initialization=self.with_common_random_numbers
+            "age_initialization", initializes_crn_attributes=self.with_common_random_numbers
         )
         self.sex_randomness = builder.randomness.get_stream("sex_initialization")
 

--- a/src/vivarium/framework/randomness/manager.py
+++ b/src/vivarium/framework/randomness/manager.py
@@ -62,7 +62,7 @@ class RandomnessManager:
         )
 
     def get_randomness_stream(
-        self, decision_point: str, for_initialization: bool = False
+        self, decision_point: str, initializes_crn_attributes: bool = False
     ) -> RandomnessStream:
         """Provides a new source of random numbers for the given decision point.
 
@@ -72,7 +72,7 @@ class RandomnessManager:
             A unique identifier for a stream of random numbers.  Typically
             represents a decision that needs to be made each time step like
             'moves_left' or 'gets_disease'.
-        for_initialization
+        initializes_crn_attributes
             A flag indicating whether this stream is used to generate key
             initialization information that will be used to identify simulants
             in the Common Random Number framework. These streams cannot be
@@ -86,8 +86,8 @@ class RandomnessManager:
             with the same identifier.
 
         """
-        stream = self._get_randomness_stream(decision_point, for_initialization)
-        if not for_initialization:
+        stream = self._get_randomness_stream(decision_point, initializes_crn_attributes)
+        if not initializes_crn_attributes:
             # We need the key columns to be created before this stream can be called.
             self.resources.add_resources(
                 "stream",
@@ -112,7 +112,7 @@ class RandomnessManager:
         return stream
 
     def _get_randomness_stream(
-        self, decision_point: str, for_initialization: bool = False
+        self, decision_point: str, initializes_crn_attributes: bool = False
     ) -> RandomnessStream:
         if decision_point in self._decision_points:
             raise RandomnessError(
@@ -124,7 +124,7 @@ class RandomnessManager:
             clock=self._clock,
             seed=self._seed,
             index_map=self._key_mapping,
-            for_initialization=for_initialization,
+            initializes_crn_attributes=initializes_crn_attributes,
         )
         self._decision_points[decision_point] = stream
         return stream
@@ -182,7 +182,7 @@ class RandomnessInterface:
         self._manager = manager
 
     def get_stream(
-        self, decision_point: str, for_initialization: bool = False
+        self, decision_point: str, initializes_crn_attributes: bool = False
     ) -> RandomnessStream:
         """Provides a new source of random numbers for the given decision point.
 
@@ -198,7 +198,7 @@ class RandomnessInterface:
             A unique identifier for a stream of random numbers.  Typically
             represents a decision that needs to be made each time step like
             'moves_left' or 'gets_disease'.
-        for_initialization
+        initializes_crn_attributes
             A flag indicating whether this stream is used to generate key
             initialization information that will be used to identify simulants
             in the Common Random Number framework. These streams cannot be
@@ -213,7 +213,7 @@ class RandomnessInterface:
             other utilities.
 
         """
-        return self._manager.get_randomness_stream(decision_point, for_initialization)
+        return self._manager.get_randomness_stream(decision_point, initializes_crn_attributes)
 
     def get_seed(self, decision_point: str) -> int:
         """Get a randomly generated seed for use with external randomness tools.

--- a/src/vivarium/framework/randomness/stream.py
+++ b/src/vivarium/framework/randomness/stream.py
@@ -89,13 +89,13 @@ class RandomnessStream:
         clock: Callable,
         seed: Any,
         index_map: IndexMap,
-        for_initialization: bool = False,
+        initializes_crn_attributes: bool = False,
     ):
         self.key = key
         self.clock = clock
         self.seed = seed
         self.index_map = index_map
-        self._for_initialization = for_initialization
+        self.initializes_crn_attributes = initializes_crn_attributes
 
     @property
     def name(self):
@@ -133,7 +133,7 @@ class RandomnessStream:
         pandas.Series
             A series of random numbers indexed by the provided `pandas.Index`.
         """
-        if self._for_initialization:
+        if self.initializes_crn_attributes:
             draw = random(
                 self._key(additional_key), pd.Index(range(len(index))), self.index_map
             )

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -12,6 +12,7 @@ import numpy as np
 import pandas as pd
 
 from vivarium.framework import randomness
+from vivarium.framework.randomness.index_map import IndexMap
 
 
 class NonCRNTestPopulation:
@@ -195,10 +196,14 @@ def make_dummy_column(name, initial_value):
 
 
 def get_randomness(
-    key="test", clock=lambda: pd.Timestamp(1990, 7, 2), seed=12345, for_initialization=False
+    key="test", clock=lambda: pd.Timestamp(1990, 7, 2), seed=12345, initializes_crn_attributes=False
 ):
     return randomness.RandomnessStream(
-        key, clock, seed=seed, for_initialization=for_initialization
+        key,
+        clock,
+        seed=seed,
+        index_map=IndexMap(),
+        initializes_crn_attributes=initializes_crn_attributes,
     )
 
 

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -196,7 +196,10 @@ def make_dummy_column(name, initial_value):
 
 
 def get_randomness(
-    key="test", clock=lambda: pd.Timestamp(1990, 7, 2), seed=12345, initializes_crn_attributes=False
+    key="test",
+    clock=lambda: pd.Timestamp(1990, 7, 2),
+    seed=12345,
+    initializes_crn_attributes=False,
 ):
     return randomness.RandomnessStream(
         key,

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -31,7 +31,7 @@ class NonCRNTestPopulation:
     def setup(self, builder):
         self.config = builder.configuration
         self.randomness = builder.randomness.get_stream(
-            "population_age_fuzz", for_initialization=True
+            "population_age_fuzz", initializes_crn_attributes=True
         )
         columns = ["age", "sex", "location", "alive", "entrance_time", "exit_time"]
         self.population_view = builder.population.get_view(columns)
@@ -72,7 +72,7 @@ class TestPopulation(NonCRNTestPopulation):
     def setup(self, builder):
         super().setup(builder)
         self.age_randomness = builder.randomness.get_stream(
-            "age_initialization", for_initialization=True
+            "age_initialization", initializes_crn_attributes=True
         )
         self.register = builder.randomness.register_simulants
 

--- a/tests/framework/randomness/test_crn.py
+++ b/tests/framework/randomness/test_crn.py
@@ -18,8 +18,8 @@ from vivarium.framework.randomness.stream import RandomnessStream
 from vivarium.interface import InteractiveContext
 
 
-@pytest.mark.parametrize("for_initialization", [True, False])
-def test_basic_repeatability(for_initialization):
+@pytest.mark.parametrize("initializes_crn_attributes", [True, False])
+def test_basic_repeatability(initializes_crn_attributes):
     test_idx = pd.Index(range(100))
     index_map = IndexMap()
 
@@ -28,7 +28,7 @@ def test_basic_repeatability(for_initialization):
         "clock": lambda: pd.Timestamp("2020-01-01"),
         "seed": "abc",
         "index_map": index_map,
-        "for_initialization": for_initialization,
+        "initializes_crn_attributes": initializes_crn_attributes,
     }
 
     stream_base = RandomnessStream(**stream_args)
@@ -81,7 +81,7 @@ class BasePopulation:
         self.register = builder.randomness.register_simulants
         self.randomness_init = builder.randomness.get_stream(
             "crn_init",
-            for_initialization=self.with_crn,
+            initializes_crn_attributes=self.with_crn,
         )
         self.randomness_other = builder.randomness.get_stream("other")
 


### PR DESCRIPTION
## Rename crn attribute randomness arg
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: refactor
*JIRA issue*: N/A

Renames the `for_initialization` arg of `builder.randomness.get_stream` to
`initializes_crn_attributes` which clarifies what's going on.

### Testing
CI
