### PR TITLE
Rework index map to add introspectibility and fix outstanding bug

### DIFF
--- a/src/vivarium/framework/randomness/index_map.py
+++ b/src/vivarium/framework/randomness/index_map.py
@@ -49,11 +49,11 @@ class IndexMap:
         if len(final_keys) != len(final_keys.unique()):
             raise RandomnessError("Non-unique keys in index")
 
-        new_map = self._build_new_mapping(new_mapping_index)
+        final_mapping = self._build_final_mapping(new_mapping_index)
 
         # Tack on the simulant index to the front of the map.
-        new_map.index = final_mapping_index
-        self._map = new_map
+        final_mapping.index = final_mapping_index
+        self._map = final_mapping
 
     def _parse_new_keys(self, new_keys: pd.DataFrame) -> Tuple[pd.MultiIndex, pd.MultiIndex]:
         """Parses raw new keys into the mapping index.
@@ -78,15 +78,15 @@ class IndexMap:
         keys.index.name = self.SIM_INDEX_COLUMN
         new_mapping_index = keys.set_index(self._key_columns, append=True).index
 
-        if self._map is not None:
-            final_mapping_index = self._map.index.append(new_mapping_index)
-        else:
+        if self._map is None:
             final_mapping_index = new_mapping_index
+        else:
+            final_mapping_index = self._map.index.append(new_mapping_index)
         return new_mapping_index, final_mapping_index
 
-    def _build_new_mapping(self, new_mapping_index: pd.Index) -> pd.Series:
+    def _build_final_mapping(self, new_mapping_index: pd.Index) -> pd.Series:
         """Builds a new mapping between key columns and the randomness index from the
-        new mapping index.
+        new mapping index and the existing map.
 
         Parameters
         ----------

--- a/src/vivarium/framework/randomness/manager.py
+++ b/src/vivarium/framework/randomness/manager.py
@@ -40,11 +40,10 @@ class RandomnessManager:
         self._clock = builder.time.clock()
         self._key_columns = builder.configuration.randomness.key_columns
 
-        use_crn = bool(self._key_columns)
         map_size = builder.configuration.randomness.map_size
         pop_size = builder.configuration.population.population_size
         map_size = max(map_size, 10 * pop_size)
-        self._key_mapping = IndexMap(use_crn, map_size)
+        self._key_mapping = IndexMap(self._key_columns, map_size)
 
         self.resources = builder.resources
         self._add_constraint = builder.lifecycle.add_constraint
@@ -168,7 +167,7 @@ class RandomnessManager:
             raise RandomnessError(
                 "The simulants dataframe does not have all specified key_columns."
             )
-        self._key_mapping.update(simulants.set_index(self._key_columns).index)
+        self._key_mapping.update(simulants.loc[:, self._key_columns])
 
     def __str__(self):
         return "RandomnessManager()"

--- a/src/vivarium/framework/randomness/stream.py
+++ b/src/vivarium/framework/randomness/stream.py
@@ -133,13 +133,12 @@ class RandomnessStream:
         pandas.Series
             A series of random numbers indexed by the provided `pandas.Index`.
         """
+        key = self._key(additional_key)
         if self.initializes_crn_attributes:
-            draw = random(
-                self._key(additional_key), pd.Index(range(len(index))), self.index_map
-            )
+            draw = random(key, pd.Index(range(len(index))))
             draw.index = index
         else:
-            draw = random(self._key(additional_key), index, self.index_map)
+            draw = random(key, index, self.index_map)
 
         return draw
 

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -215,5 +215,5 @@ def reset_mocks(mocks):
         mock.reset_mock()
 
 
-def metadata(file_path):
-    return {"layer": "override", "source": str(Path(file_path).resolve())}
+def metadata(file_path, layer="override"):
+    return {"layer": layer, "source": str(Path(file_path).resolve())}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def base_config():
             },
             "randomness": {"key_columns": ["entrance_time", "age"]},
         },
-        **metadata(__file__),
+        **metadata(__file__, layer="model_override"),
     )
     return config
 

--- a/tests/framework/randomness/test_crn.py
+++ b/tests/framework/randomness/test_crn.py
@@ -255,8 +255,12 @@ def test_multi_sim_reproducibility_with_different_pop_growth(with_crn, pop_class
         assert_frame_equal(pop1.loc[overlap], pop2.loc[overlap])
 
 
-class BrokenPopulation(BasePopulation):
-    """CRN system falls over if the first CRN attribute is an int or float."""
+class UnBrokenPopulation(BasePopulation):
+    """CRN system used to fall over if the first CRN attribute is an int or float.
+
+    This is now a regression testing class.
+
+    """
 
     def on_initialize_simulants(self, pop_data: SimulantData):
         crn_attr = (1_000_000 * self.randomness_init.get_draw(index=pop_data.index)).astype(
@@ -286,14 +290,14 @@ class BrokenPopulation(BasePopulation):
         pytest.param(False, cycle([1])),
     ],
 )
-def test_failure_path_when_first_crn_attribute_not_datelike(with_crn, sims_to_add):
+def test_prior_failure_path_when_first_crn_attribute_not_datelike(with_crn, sims_to_add):
     if with_crn:
         configuration = {"randomness": {"key_columns": ["crn_attr1", "crn_attr2"]}}
     else:
         configuration = {}
 
     sim = InteractiveContext(
-        components=[BrokenPopulation(with_crn=with_crn, sims_to_add=sims_to_add)],
+        components=[UnBrokenPopulation(with_crn=with_crn, sims_to_add=sims_to_add)],
         configuration=configuration,
     )
 

--- a/tests/framework/randomness/test_crn.py
+++ b/tests/framework/randomness/test_crn.py
@@ -280,8 +280,8 @@ class BrokenPopulation(BasePopulation):
 @pytest.mark.parametrize(
     "with_crn, sims_to_add",
     [
-        pytest.param(True, cycle([0]), marks=pytest.mark.xfail),
-        pytest.param(True, cycle([1]), marks=pytest.mark.xfail),
+        pytest.param(True, cycle([0])),
+        pytest.param(True, cycle([1])),
         pytest.param(False, cycle([0])),
         pytest.param(False, cycle([1])),
     ],

--- a/tests/framework/randomness/test_manager.py
+++ b/tests/framework/randomness/test_manager.py
@@ -35,7 +35,7 @@ def test_RandomnessManager_register_simulants():
     rm._seed = seed
     rm._clock = mock_clock
     rm._key_columns = ["age", "sex"]
-    rm._key_mapping = IndexMap()
+    rm._key_mapping = IndexMap(["age", "sex"])
 
     bad_df = pd.DataFrame({"age": range(10), "not_sex": [1] * 5 + [2] * 5})
     with pytest.raises(RandomnessError):
@@ -44,9 +44,9 @@ def test_RandomnessManager_register_simulants():
     good_df = pd.DataFrame({"age": range(10), "sex": [1] * 5 + [2] * 5})
 
     rm.register_simulants(good_df)
-    assert rm._key_mapping._map.index.difference(
-        good_df.set_index(good_df.columns.tolist()).index
-    ).empty
+    map_index = rm._key_mapping._map.droplevel(rm._key_mapping.SIM_INDEX_COLUMN).index
+    good_index = good_df.set_index(good_df.columns.tolist()).index
+    assert map_index.difference(good_index).empty
 
 
 def test_get_random_seed():

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -53,7 +53,9 @@ def test_transition():
 
 
 def test_choice(base_config):
-    base_config.update({"population": {"population_size": 10000}})
+    base_config.update(
+        {"population": {"population_size": 10000}, "randomness": {"key_columns": []}}
+    )
     a_state = State("a")
     b_state = State("b")
     start_state = State("start")
@@ -75,7 +77,9 @@ def test_choice(base_config):
 
 
 def test_null_transition(base_config):
-    base_config.update({"population": {"population_size": 10000}})
+    base_config.update(
+        {"population": {"population_size": 10000}, "randomness": {"key_columns": []}}
+    )
     a_state = State("a")
     start_state = State("start")
     start_state.add_transition(
@@ -95,7 +99,9 @@ def test_null_transition(base_config):
 
 
 def test_no_null_transition(base_config):
-    base_config.update({"population": {"population_size": 10000}})
+    base_config.update(
+        {"population": {"population_size": 10000}, "randomness": {"key_columns": []}}
+    )
     a_state = State("a")
     b_state = State("b")
     start_state = State("start")


### PR DESCRIPTION
## Rework index map to add introspectibility and fix outstanding bug
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: bugfix
*JIRA issue*: 

**Main Changes**:
The index map used to keep a series whose index was the key columns and values were the index into the randomness system.  E.g.
```
crn_attr1   crn_attr2
2005-07-01  626880       650898
2005-07-01  383226       156931
2005-07-01  608111       893377
2005-07-01  993457       883587
2005-07-01  57456        800131
                                          ...  
2005-07-01  756277       946883
2005-07-01  871183       967051
2005-07-01  675501       395625
2005-07-01  377531       897957
2005-07-01  590229       915907
```
This has been updated to also keep a hold of the population index.  E.g.:
```
simulant_index  crn_attr1   crn_attr2
0               2005-07-01  626880       650898
1               2005-07-01  383226       156931
2               2005-07-01  608111       893377
3               2005-07-01  993457       883587
4               2005-07-01  57456        800131
                                          ...  
95              2005-07-01  756277       946883
96              2005-07-01  871183       967051
97              2005-07-01  675501       395625
98              2005-07-01  377531       897957
99              2005-07-01  590229       915907
```

This is done for two reasons:
1. It's much easier to introspect and compare fore debugging
2. It helps fix an outstanding bug in `IndexMap.__getitem__` (see https://github.com/ihmeuw/vivarium/pull/268 for more description) by allowing us to explicitly use `.loc` in the map indexer rather than relying on the inconsistent behavior of `pd.Series.__getitem__` depending on the underlying dtypes of the index.  The corresponding tests (`tests/framework/randomness/test_crn.py::test_failure_path_when_first_crn_attribute_not_datelike`) are no longer marked `xfail`.

**Other Changes**
1. The IndexMap has had it's methods and docstrings refactored for more clarity.
2. Randomness `key_columns` are now passed directly to the IndexMap and `use_crn` is inferred in the `__init__`
3. `RandomnessStream.get_draw` no longer passes the index map to the underlying `random` function when being used to initialize CRN variables.  This is a workaround for some bad error handling and anticipates some additional changes coming in the next PR to address these more directly.
4. The `metadata` function in `testing_utilities` has been expanded to take a layer argument (in a backwards compatible way as it's used in other libraries). 
5. The layer argument is then used in the main vivarium `conftest.py` to lower the priority of the fixture config so it can be overridden in other tests.
6. This override behavior is used to turn off crn in the state machine tests.  It wasn't being used before but was relying on bad error handling (see 3.) rather than properly declaring it didn't need CRN.
7. Various tests have been updated to reflect updates to the `IndexMap` public and private interfaces.

### Testing
CI and fixed regression test

