### PR TITLE
gather_results empty data bugfix

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -115,7 +115,9 @@ class ResultsContext:
                 pop_groups = filtered_pop.groupby(list(stratifications))
                 for measure, aggregator_sources, aggregator, additional_keys in observations:
                     if aggregator_sources:
-                        aggregates = pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)
+                        aggregates = (
+                            pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)
+                        )
                     else:
                         aggregates = pop_groups.apply(aggregator)
 

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -109,24 +109,27 @@ class ResultsContext:
                 filtered_pop = population.query(pop_filter)
             else:
                 filtered_pop = population
-            pop_groups = filtered_pop.groupby(list(stratifications))
-            for measure, aggregator_sources, aggregator, additional_keys in observations:
-                if aggregator_sources:
-                    aggregates = pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)
-                else:
-                    aggregates = pop_groups.apply(aggregator)
+            if filtered_pop.empty:
+                yield {}
+            else:
+                pop_groups = filtered_pop.groupby(list(stratifications))
+                for measure, aggregator_sources, aggregator, additional_keys in observations:
+                    if aggregator_sources:
+                        aggregates = pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)
+                    else:
+                        aggregates = pop_groups.apply(aggregator)
 
-                # Ensure we are dealing with a single column of formattable results
-                if isinstance(aggregates, pd.DataFrame):
-                    aggregates = aggregates.squeeze(axis=1)
-                if not isinstance(aggregates, pd.Series):
-                    raise TypeError(
-                        f"The aggregator return value is a {type(aggregates)} and could not be "
-                        "made into a pandas.Series. This is probably not correct."
-                    )
+                    # Ensure we are dealing with a single column of formattable results
+                    if isinstance(aggregates, pd.DataFrame):
+                        aggregates = aggregates.squeeze(axis=1)
+                    if not isinstance(aggregates, pd.Series):
+                        raise TypeError(
+                            f"The aggregator return value is a {type(aggregates)} and could not be "
+                            "made into a pandas.Series. This is probably not correct."
+                        )
 
-                # Keep formatting all in one place.
-                yield self._format_results(measure, aggregates, **additional_keys)
+                    # Keep formatting all in one place.
+                    yield self._format_results(measure, aggregates, **additional_keys)
 
     def _get_stratifications(
         self,

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -259,7 +259,7 @@ def test__get_stratifications(
         "len_aggregator_one_stratification",
         "sum_aggregator_one_stratification",
         "custom_aggregator_one_stratification",
-        "len_aggregator_two_stratifications_empty_filter",
+        "empty_pop_filter",
     ],
 )
 def test_gather_results(

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -250,6 +250,7 @@ def test__get_stratifications(
             ["house"],
             1.53277,
         ),
+        ("wizard_count", "house=='Durmstrang'", None, len, ["house", "familiar"], 4),
     ],
     ids=[
         "len_aggregator_two_stratifications",
@@ -258,6 +259,7 @@ def test__get_stratifications(
         "len_aggregator_one_stratification",
         "sum_aggregator_one_stratification",
         "custom_aggregator_one_stratification",
+        "len_aggregator_two_stratifications_empty_filter",
     ],
 )
 def test_gather_results(

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -250,7 +250,6 @@ def test__get_stratifications(
             ["house"],
             1.53277,
         ),
-        ("wizard_count", "house=='Durmstrang'", None, len, ["house", "familiar"], 4),
     ],
     ids=[
         "len_aggregator_two_stratifications",
@@ -259,7 +258,6 @@ def test__get_stratifications(
         "len_aggregator_one_stratification",
         "sum_aggregator_one_stratification",
         "custom_aggregator_one_stratification",
-        "empty_pop_filter",
     ],
 )
 def test_gather_results(
@@ -374,6 +372,26 @@ def test_gather_results_partial_stratifications_in_results(
         unladen_results = {k: v for (k, v) in r.items() if "unladen_swallow" in k}
         assert len(unladen_results.items()) > 0
         assert all(v == 0 for v in unladen_results.values())
+
+
+def test_gather_results_with_empty_pop_filter():
+    """Test case where pop_filter filters to an empty population. gather_results should return an empty dict"""
+    ctx = ResultsContext()
+
+    # Generate population DataFrame
+    population = BASE_POPULATION.copy()
+
+    event_name = "collect_metrics"
+    ctx.add_observation(
+        name="wizard_count",
+        pop_filter="house == 'durmstrang'",
+        aggregator_sources=None,
+        aggregator=len,
+        event_name=event_name,
+    )
+
+    for result in ctx.gather_results(population, event_name):
+        assert len(result) == 0
 
 
 def test__format_results():


### PR DESCRIPTION
## gather_results empty data bugfix

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3840](https://jira.ihme.washington.edu/browse/MIC-3840)

When we filter to an empty population in gather_results, the output of our groupby -> aggregate is an empty dataframe. Vivarium tries to convert this to a Series using squeeze and errors out if it's not a Series. However, an empty dataframe that is squeezed is still a dataframe.

### Testing
Added test with filter that would lead to an empty dataframe. Checked that previous code failed test and that updated code passed.

