### PR TITLE
Add lifecycle/initializer introspection to InteractiveContext

### DIFF
--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -234,5 +234,13 @@ class InteractiveContext(SimulationContext):
         """
         return self._component_manager.get_component(name)
 
+    def print_initializer_order(self):
+        """Print the order in which population initializers are called."""
+        print("\n".join([r.name for r in self._resource]))
+
+    def print_lifecycle_order(self):
+        """Print the order of lifecycle events (including user event handlers)."""
+        print(self._lifecycle)
+
     def __repr__(self):
         return "InteractiveContext()"

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -236,7 +236,8 @@ class InteractiveContext(SimulationContext):
 
     def print_initializer_order(self):
         """Print the order in which population initializers are called."""
-        print("\n".join([r.name for r in self._resource]))
+        initializers = [f'{r.__self__}.{r.__name__}' for r in self._resource]
+        print("\n".join(initializers))
 
     def print_lifecycle_order(self):
         """Print the order of lifecycle events (including user event handlers)."""

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -236,7 +236,14 @@ class InteractiveContext(SimulationContext):
 
     def print_initializer_order(self):
         """Print the order in which population initializers are called."""
-        initializers = [f'{r.__self__}.{r.__name__}' for r in self._resource]
+        initializers = []
+        for r in self._resource:
+            name = r.__name__
+            if hasattr(r, "__self__"):
+                obj = r.__self__
+                initializers.append(f"{obj.__class__.__name__}({obj.name}).{name}")
+            else:
+                initializers.append(f"Unbound function {name}")
         print("\n".join(initializers))
 
     def print_lifecycle_order(self):


### PR DESCRIPTION
##  Add lifecycle/initializer introspection to InteractiveContext
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: feature
*JIRA issue*: N/A

Adds `print_lifecycle_order` to the `InteractiveContext` which does:

```
>>> sim.print_lifecycle_order()

initialization
	initialization
setup
	setup
	post_setup
		ValuesManager(values_manager).on_post_setup
		EventManager(event_manager).on_post_setup
		MortalityObserver(mortality_observer).on_post_setup
		DisabilityObserver(disability_observer).on_post_setup
	population_creation
main_loop*
	time_step__prepare
		ResultsStratifier(results_stratifier).on_time_step_prepare
		ResultsManager(results_manager).on_time_step_prepare
		DiseaseObserver(disease_observer.diarrheal_diseases).on_time_step_prepare
		DiseaseObserver(disease_observer.measles).on_time_step_prepare
		DiseaseObserver(disease_observer.lower_respiratory_infections).on_time_step_prepare
		DiseaseObserver(disease_observer.moderate_protein_energy_malnutrition).on_time_step_prepare
		DiseaseObserver(disease_observer.severe_protein_energy_malnutrition).on_time_step_prepare
		CategoricalRiskObserver(categorical_risk_observer.child_stunting).on_time_step_prepare
		CategoricalRiskObserver(categorical_risk_observer.child_wasting).on_time_step_prepare
		DisabilityObserver(disability_observer).on_time_step_prepare
	time_step
		Mortality(mortality).on_time_step
		ResultsManager(results_manager).on_time_step
		DiseaseModel(disease_model.measles).on_time_step
		DiseaseModel(disease_model.lower_respiratory_infections).on_time_step
		RiskAttributableDisease(disease_model.moderate_protein_energy_malnutrition).on_time_step
		RiskAttributableDisease(disease_model.severe_protein_energy_malnutrition).on_time_step
		MortalityObserver(mortality_observer).on_collect_metrics
		FertilityLineList(line_list_fertility).on_time_step
		DiseaseModel(disease_model.diarrheal_diseases).on_time_step
		PopulationLineList(line_list_population).on_time_step
	time_step__cleanup
		ResultsManager(results_manager).on_time_step_cleanup
		DiseaseModel(disease_model.measles).on_time_step_cleanup
		DiseaseModel(disease_model.lower_respiratory_infections).on_time_step_cleanup
		AgeOutSimulants(age_out_simulants).on_time_step_cleanup
		DiseaseModel(disease_model.diarrheal_diseases).on_time_step_cleanup
	collect_metrics
		ResultsManager(results_manager).on_collect_metrics
		DiseaseObserver(disease_observer.diarrheal_diseases).on_collect_metrics
		DiseaseObserver(disease_observer.measles).on_collect_metrics
		DiseaseObserver(disease_observer.lower_respiratory_infections).on_collect_metrics
		DiseaseObserver(disease_observer.moderate_protein_energy_malnutrition).on_collect_metrics
		DiseaseObserver(disease_observer.severe_protein_energy_malnutrition).on_collect_metrics
		BirthObserver(birth_observer).on_collect_metrics
simulation_end
	simulation_end
	report
```
Adds `print_initializer_order` on the `InteractiveContext` which does:

```
>>> sim.print_initializer_order()

PopulationManager(population_manager).on_initialize_simulants
Mortality(mortality).on_initialize_simulants
DiseaseObserver(disease_observer.diarrheal_diseases).on_initialize_simulants
DiseaseObserver(disease_observer.measles).on_initialize_simulants
DiseaseObserver(disease_observer.lower_respiratory_infections).on_initialize_simulants
DiseaseObserver(disease_observer.moderate_protein_energy_malnutrition).on_initialize_simulants
DiseaseObserver(disease_observer.severe_protein_energy_malnutrition).on_initialize_simulants
PopulationLineList(line_list_population).on_initialize_simulants
DisabilityObserver(disability_observer).on_initialize_simulants
MaternalCharacteristics(maternal_characteristics).on_initialize_simulants
DiseaseModel(disease_model.measles).on_initialize_simulants
DiseaseModel(disease_model.lower_respiratory_infections).on_initialize_simulants
Risk(risk.risk_factor.child_wasting).on_initialize_simulants
Risk(risk.risk_factor.child_stunting).on_initialize_simulants
LBWSGLineList(line_list_low_birth_weight_and_short_gestation).on_initialize_simulants
DiseaseModel(disease_model.diarrheal_diseases).on_initialize_simulants
SusceptibleState(susceptiblestate.susceptible_to_measles).on_initialize_simulants
DiseaseState(diseasestate.measles).on_initialize_simulants
SusceptibleState(susceptiblestate.susceptible_to_lower_respiratory_infections).on_initialize_simulants
DiseaseState(diseasestate.lower_respiratory_infections).on_initialize_simulants
LBWSGRiskEffect(risk_effect.risk_factor.low_birth_weight_and_short_gestation.cause.diarrheal_diseases.excess_mortality_rate).on_initialize_simulants
LBWSGRiskEffect(risk_effect.risk_factor.low_birth_weight_and_short_gestation.cause.lower_respiratory_infections.excess_mortality_rate).on_initialize_simulants
LBWSGRiskEffect(risk_effect.risk_factor.low_birth_weight_and_short_gestation.cause.affected_unmodeled.cause_specific_mortality_rate).on_initialize_simulants
SusceptibleState(susceptiblestate.susceptible_to_diarrheal_diseases).on_initialize_simulants
DiseaseState(diseasestate.diarrheal_diseases).on_initialize_simulants
RiskAttributableDisease(disease_model.moderate_protein_energy_malnutrition).on_initialize_simulants
RiskAttributableDisease(disease_model.severe_protein_energy_malnutrition).on_initialize_simulants
ResultsStratifier(results_stratifier).on_initialize_simulants
```

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

