### PR TITLE
Add unique simulation names

### DIFF
--- a/docs/source/api_reference/framework/logging/index.rst
+++ b/docs/source/api_reference/framework/logging/index.rst
@@ -1,0 +1,7 @@
+.. automodule:: vivarium.framework.logging
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   *

--- a/docs/source/api_reference/framework/logging/manager.rst
+++ b/docs/source/api_reference/framework/logging/manager.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium.framework.logging.manager

--- a/docs/source/api_reference/framework/logging/utilities.rst
+++ b/docs/source/api_reference/framework/logging/utilities.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium.framework.logging.utilities

--- a/docs/source/concepts/logging.rst
+++ b/docs/source/concepts/logging.rst
@@ -1,0 +1,9 @@
+.. _logging_concept:
+
+=================
+Framework Logging
+=================
+
+.. todo::
+
+   Everything here.

--- a/src/vivarium/framework/artifact/manager.py
+++ b/src/vivarium/framework/artifact/manager.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any, Sequence, Union
 
 import pandas as pd
-from loguru import logger
 
 from vivarium.config_tree import ConfigTree
 from vivarium.framework.artifact.artifact import Artifact
@@ -37,6 +36,7 @@ class ArtifactManager:
 
     def setup(self, builder):
         """Performs this component's simulation setup."""
+        self.logger = builder.logging.get_logger(self.name)
         # because not all columns are accessible via artifact filter terms, apply config filters separately
         self.config_filter_term = validate_filter_term(
             builder.configuration.input_data.artifact_filter_term
@@ -63,9 +63,9 @@ class ArtifactManager:
             return None
         artifact_path = parse_artifact_path_config(configuration)
         base_filter_terms = get_base_filter_terms(configuration)
-        logger.debug(f"Running simulation from artifact located at {artifact_path}.")
-        logger.debug(f"Artifact base filter terms are {base_filter_terms}.")
-        logger.debug(f"Artifact additional filter terms are {self.config_filter_term}.")
+        self.logger.info(f"Running simulation from artifact located at {artifact_path}.")
+        self.logger.info(f"Artifact base filter terms are {base_filter_terms}.")
+        self.logger.info(f"Artifact additional filter terms are {self.config_filter_term}.")
         return Artifact(artifact_path, base_filter_terms)
 
     def load(self, entity_key: str, **column_filters: _Filter) -> Any:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -18,16 +18,16 @@ Finally, there are a handful of wrapper methods that allow a user or user
 tools to easily setup and run a simulation.
 
 """
-import time
 from pathlib import Path
 from pprint import pformat
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Set, Union
 
 import numpy as np
 import pandas as pd
 from loguru import logger
 
 from vivarium.config_tree import ConfigTree
+from vivarium.exceptions import VivariumError
 from vivarium.framework.configuration import build_model_specification
 
 from .artifact import ArtifactInterface
@@ -46,13 +46,39 @@ from .values import ValuesInterface
 
 
 class SimulationContext:
+
+    _created_simulation_contexts: Set[str] = set()
+
+    @staticmethod
+    def _get_context_name(sim_name: Union[str, None]) -> str:
+        # Not threadsafe, but I don't see why we'd need to be.
+        if sim_name:
+            if sim_name in SimulationContext._created_simulation_contexts:
+                msg = (
+                    "Attempting to create two SimulationContexts "
+                    f"with the same name {sim_name}"
+                )
+                raise VivariumError(msg)
+
+        if sim_name is None:
+            sim_number = len(SimulationContext._created_simulation_contexts) + 1
+            sim_name = f"simulation_{sim_number}"
+        SimulationContext._created_simulation_contexts.add(sim_name)
+        return sim_name
+
+    @staticmethod
+    def _clear_context_cache():
+        SimulationContext._created_simulation_contexts = set()
+
     def __init__(
         self,
         model_specification: Union[str, Path, ConfigTree] = None,
         components: Union[List, Dict, ConfigTree] = None,
         configuration: Union[Dict, ConfigTree] = None,
         plugin_configuration: Union[Dict, ConfigTree] = None,
+        sim_name: str = None,
     ):
+        self._name = self._get_context_name(sim_name)
         # Bootstrap phase: Parse arguments, make private managers
         component_configuration = (
             components if isinstance(components, (dict, ConfigTree)) else None
@@ -138,7 +164,7 @@ class SimulationContext:
 
     @property
     def name(self):
-        return "simulation_context"
+        return self._name
 
     def setup(self):
         self._lifecycle.set_state("setup")
@@ -230,10 +256,7 @@ class SimulationContext:
         return self._population.get_population(untracked)
 
     def __repr__(self):
-        return "SimulationContext()"
-
-    def __str__(self):
-        return str(self._lifecycle)
+        return f"SimulationContext({self.name})"
 
 
 class Builder:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -51,23 +51,46 @@ class SimulationContext:
 
     @staticmethod
     def _get_context_name(sim_name: Union[str, None]) -> str:
-        # Not threadsafe, but I don't see why we'd need to be.
-        if sim_name:
-            if sim_name in SimulationContext._created_simulation_contexts:
-                msg = (
-                    "Attempting to create two SimulationContexts "
-                    f"with the same name {sim_name}"
-                )
-                raise VivariumError(msg)
+        """Get a unique name for a simulation context.
 
+        Parameters
+        ----------
+        sim_name
+            The name of the simulation context.  If None, a unique name will be generated.
+
+        Returns
+        -------
+        str
+            A unique name for the simulation context.
+
+        Note
+        ----
+        This method mutates process global state (the class attribute
+        ``_created_simulation_contexts``) in order to keep track contexts that have been
+        generated. This functionality makes generating simulation contexts in parallel
+        a non-threadsafe operation.
+
+        """
         if sim_name is None:
             sim_number = len(SimulationContext._created_simulation_contexts) + 1
             sim_name = f"simulation_{sim_number}"
+
+        if sim_name in SimulationContext._created_simulation_contexts:
+            msg = (
+                "Attempting to create two SimulationContexts "
+                f"with the same name {sim_name}"
+            )
+            raise VivariumError(msg)
+
         SimulationContext._created_simulation_contexts.add(sim_name)
         return sim_name
 
     @staticmethod
     def _clear_context_cache():
+        """Clear the cache of simulation context names.
+
+        This is primarily useful for testing purposes.
+        """
         SimulationContext._created_simulation_contexts = set()
 
     def __init__(

--- a/src/vivarium/framework/logging/__init__.py
+++ b/src/vivarium/framework/logging/__init__.py
@@ -1,0 +1,12 @@
+"""
+=======
+Logging
+=======
+
+"""
+from vivarium.framework.logging.manager import LoggingInterface, LoggingManager
+from vivarium.framework.logging.utilities import (
+    configure_logging_to_file,
+    configure_logging_to_terminal,
+    list_loggers,
+)

--- a/src/vivarium/framework/logging/manager.py
+++ b/src/vivarium/framework/logging/manager.py
@@ -1,0 +1,49 @@
+"""
+=====================
+The Logging Susbystem
+=====================
+
+"""
+from loguru import logger
+from loguru._logger import Logger
+
+from vivarium.framework.logging.utilities import configure_logging_to_terminal
+
+
+class LoggingManager:
+    def __init__(self):
+        self._simulation_name = None
+
+    def configure_logging(
+        self,
+        simulation_name: str,
+        verbosity: int = 0,
+        long_format: bool = True,
+    ) -> None:
+        self._simulation_name = simulation_name
+        if self._terminal_logging_not_configured():
+            configure_logging_to_terminal(verbosity=verbosity, long_format=long_format)
+
+    @staticmethod
+    def _terminal_logging_not_configured() -> bool:
+        # This hacks into the internals of loguru to see if we've already configured a
+        # terminal sink. This is a bit fragile since it depends on a libraries internals,
+        # but loguru is a very stable library at this point, so I think it's pretty low risk.
+        return 1 not in logger._core.handlers
+
+    @property
+    def name(self):
+        return "logging_manager"
+
+    def get_logger(self, component_name: str = None) -> Logger:
+        if component_name:
+            return logger.bind(simulation=self._simulation_name, component=component_name)
+        return logger.bind(simulation=self._simulation_name)
+
+
+class LoggingInterface:
+    def __init__(self, manager: LoggingManager):
+        self._manager = manager
+
+    def get_logger(self, component_name: str = None) -> Logger:
+        return self._manager.get_logger(component_name)

--- a/src/vivarium/framework/logging/utilities.py
+++ b/src/vivarium/framework/logging/utilities.py
@@ -1,0 +1,159 @@
+"""
+=================
+Logging Utilities
+=================
+
+This module contains utilities for configuring logging.
+
+"""
+import logging
+import sys
+from pathlib import Path
+
+from loguru import logger
+
+
+def configure_logging_to_terminal(verbosity: int, long_format: bool = True) -> None:
+    """Configure logging to print to the sys.stdout.
+
+    Parameters
+    ----------
+    verbosity
+        The verbosity level of the logging. 0 logs at the WARNING level, 1 logs
+        at the INFO level, and 2 logs at the DEBUG level.
+    long_format
+        Whether to use the long format for logging messages, which includes explicit
+        information about the simulation context and component in the log messages.
+
+    """
+    _clear_default_configuration()
+    _add_logging_sink(
+        sink=sys.stdout,
+        verbosity=verbosity,
+        long_format=long_format,
+        colorize=True,
+        serialize=False,
+    )
+
+
+def configure_logging_to_file(output_directory: Path) -> None:
+    """Configure logging to write to a file in the provided output directory.
+
+    Parameters
+    ----------
+    output_directory
+        The directory to write the log file to.
+
+    """
+    log_file = output_directory / "simulation.log"
+    _add_logging_sink(
+        log_file,
+        verbosity=2,
+        long_format=True,
+        colorize=False,
+        serialize=False,
+    )
+
+
+def _clear_default_configuration():
+    try:
+        logger.remove(0)  # Clear default configuration
+    except ValueError:
+        pass
+
+
+def _add_logging_sink(
+    sink,
+    verbosity: int,
+    long_format: bool,
+    colorize: bool,
+    serialize: bool,
+) -> int:
+    """Add a logging sink to the logger.
+
+    Parameters
+    ----------
+    sink
+        The sink to add.  Can be a file path, a file object, or a callable.
+    verbosity
+        The verbosity level.  0 is the default and will only log warnings and errors.
+        1 will log info messages.  2 will log debug messages.
+    long_format
+        Whether to use the long format for logging messages.  The long format includes
+        the simulation name and component name.  The short format only includes the
+        file name and line number.
+    colorize
+        Whether to colorize the log messages.
+    serialize
+        Whether to serialize log messages.  This is useful when logging to
+        a file or a database.
+
+    """
+    log_formatter = _LogFormatter(long_format)
+    logging_level = _get_log_level(verbosity)
+    return logger.add(
+        sink,
+        colorize=colorize,
+        level=logging_level,
+        format=log_formatter.format,
+        serialize=serialize,
+    )
+
+
+class _LogFormatter:
+    time = "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green>"
+    level = "<level>{level: <8}</level>"
+    simulation = "<cyan>{extra[simulation]}</cyan> - <cyan>{name}</cyan>:<cyan>{line}</cyan>"
+    simulation_and_component = (
+        "<cyan>{extra[simulation]}</cyan>-<cyan>{extra[component]}</cyan>:<cyan>{line}</cyan>"
+    )
+    short_name_and_line = "<cyan>{name}</cyan>:<cyan>{line}</cyan>"
+    message = "<level>{message}</level>"
+
+    def __init__(self, long_format: bool = False):
+        self.long_format = long_format
+
+    def format(self, record):
+        fmt = self.time + " | "
+
+        if self.long_format:
+            fmt += self.level + " | "
+
+        if self.long_format and "simulation" in record["extra"]:
+            if "component" in record["extra"]:
+                fmt += self.simulation_and_component + " - "
+            else:
+                fmt += self.simulation + " - "
+        else:
+            fmt += self.short_name_and_line + " - "
+
+        fmt += self.message + "\n{exception}"
+        return fmt
+
+
+def _get_log_level(verbosity: int):
+    if verbosity == 0:
+        return "WARNING"
+    elif verbosity == 1:
+        return "INFO"
+    elif verbosity >= 2:
+        return "DEBUG"
+
+
+def list_loggers():
+    """Utility function for analyzing the logging environment."""
+    root_logger = logging.getLogger()
+    print("Root logger: ", root_logger)
+    for h in root_logger.handlers:
+        print(f"     %s" % h)
+
+    print("Other loggers")
+    print("=============")
+    for name, logger_ in logging.Logger.manager.loggerDict.items():
+        print("+ [%-20s] %s " % (name, logger_))
+        if not isinstance(logger_, logging.PlaceHolder):
+            handlers = list(logger_.handlers)
+            if not handlers:
+                print("     No handlers")
+            for h in logger_.handlers:
+                print("     %s" % h)

--- a/src/vivarium/framework/plugins.py
+++ b/src/vivarium/framework/plugins.py
@@ -14,6 +14,10 @@ from vivarium.exceptions import VivariumError
 from .utilities import import_by_path
 
 _MANAGERS = {
+    "logging": {
+        "controller": "vivarium.framework.logging.LoggingManager",
+        "builder_interface": "vivarium.framework.logging.LoggingInterface",
+    },
     "lookup": {
         "controller": "vivarium.framework.lookup.LookupTableManager",
         "builder_interface": "vivarium.framework.lookup.LookupTableInterface",

--- a/src/vivarium/framework/resource.py
+++ b/src/vivarium/framework/resource.py
@@ -20,7 +20,6 @@ from types import MethodType
 from typing import Any, Callable, Iterable, List
 
 import networkx as nx
-from loguru import logger
 
 from vivarium.exceptions import VivariumError
 
@@ -152,6 +151,9 @@ class ResourceManager:
                 )
         return self._sorted_nodes
 
+    def setup(self, builder):
+        self.logger = builder.logging.get_logger(self.name)
+
     def add_resources(
         self,
         resource_type: str,
@@ -250,7 +252,7 @@ class ResourceManager:
                 if dependency not in self._resource_group_map:
                     # Warn here because this sometimes happens naturally
                     # if observer components are missing from a simulation.
-                    logger.warning(
+                    self.logger.warning(
                         f"Resource {dependency} is not provided by any component but is needed to "
                         f"compute {resource_group}."
                     )

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from typing import Callable, Dict, List, Tuple
 
 import pandas as pd
-from loguru import logger
 
 from vivarium.framework.results.exceptions import ResultsConfigurationError
 from vivarium.framework.results.stratification import Stratification
@@ -24,6 +23,13 @@ class ResultsContext:
         # keys are event names: ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"]
         # values are dicts with key (filter, grouper) value (measure, aggregator_sources, aggregator, additional_keys)
         self._observations = defaultdict(lambda: defaultdict(list))
+
+    @property
+    def name(self):
+        return "results_context"
+
+    def setup(self, builder):
+        self.logger = builder.logging.get_logger(self.name)
 
     # noinspection PyAttributeOutsideInit
     def set_default_stratifications(self, default_grouping_columns: List[str]):
@@ -69,6 +75,7 @@ class ResultsContext:
         Returns
         ------
         None
+
         """
         if len([s.name for s in self._stratifications if s.name == name]):
             raise ValueError(f"Name `{name}` is already used")
@@ -207,4 +214,4 @@ class ResultsContext:
                 UserWarning,
             )
         if len(nop_additional) or len(nop_exclude):
-            logger.debug(f"Default stratifications are: {self._default_stratifications}")
+            self.logger.debug(f"Default stratifications are: {self._default_stratifications}")

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -18,7 +18,6 @@ from typing import Any, Callable, Iterable, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from loguru import logger
 
 from vivarium.exceptions import VivariumError
 from vivarium.framework.utilities import from_yearly
@@ -258,6 +257,7 @@ class ValuesManager:
         return "values_manager"
 
     def setup(self, builder):
+        self.logger = builder.logging.get_logger(self.name)
         self.step_size = builder.time.step_size()
         builder.event.register_listener("post_setup", self.on_post_setup)
 
@@ -273,7 +273,7 @@ class ValuesManager:
         # modifiers to values that aren't required in a simulation.
         unsourced_pipelines = [p for p, v in self._pipelines.items() if not v.source]
         if unsourced_pipelines:
-            logger.warning(f"Unsourced pipelines: {unsourced_pipelines}")
+            self.logger.warning(f"Unsourced pipelines: {unsourced_pipelines}")
 
         # register_value_producer and register_value_modifier record the
         # dependency structure for the pipeline source and pipeline modifiers,
@@ -335,7 +335,7 @@ class ValuesManager:
         preferred_post_processor: Callable,
     ):
         """Configure the named value pipeline with a source, combiner, and post-processor."""
-        logger.debug(f"Registering value pipeline {value_name}")
+        self.logger.debug(f"Registering value pipeline {value_name}")
         pipeline = self._pipelines[value_name]
         if pipeline.source:
             raise DynamicValueError(
@@ -389,7 +389,7 @@ class ValuesManager:
         pipeline.mutators.append(modifier)
 
         name = f"{value_name}.{len(pipeline.mutators)}.{modifier_name}"
-        logger.debug(f"Registering {name} as modifier to {value_name}")
+        self.logger.debug(f"Registering {name} as modifier to {value_name}")
         dependencies = self._convert_dependencies(
             modifier, requires_columns, requires_values, requires_streams
         )

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -233,6 +233,3 @@ class InteractiveContext(SimulationContext):
 
         """
         return self._component_manager.get_component(name)
-
-    def __repr__(self):
-        return "InteractiveContext()"

--- a/src/vivarium/interface/utilities.py
+++ b/src/vivarium/interface/utilities.py
@@ -8,13 +8,11 @@ interfaces for ``vivarium``.
 
 """
 import functools
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Union
 
 import yaml
-from loguru import logger
 
 from vivarium.exceptions import VivariumError
 
@@ -124,6 +122,7 @@ def get_output_model_name_string(
     -------
     str
         A model name string for use in output labeling.
+
     """
     if artifact_path:
         model_name = Path(artifact_path).stem
@@ -146,29 +145,3 @@ def get_output_root(
     model_name = get_output_model_name_string(artifact_path, model_specification_file)
     output_root = Path(results_directory + f"/{model_name}/{launch_time}")
     return output_root
-
-
-def add_logging_sink(sink, verbose, colorize=False, serialize=False):
-    message_format = (
-        "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
-        "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> "
-        "- <level>{message}</level>"
-    )
-    if verbose:
-        logger.add(
-            sink, colorize=colorize, level="DEBUG", format=message_format, serialize=serialize
-        )
-    else:
-        logger.add(
-            sink, colorize=colorize, level="ERROR", format=message_format, serialize=serialize
-        )
-
-
-def configure_logging_to_terminal(verbose):
-    logger.remove(0)  # Clear default configuration
-    add_logging_sink(sys.stdout, verbose, colorize=True)
-
-
-def configure_logging_to_file(output_directory):
-    master_log = output_directory / "simulation.log"
-    add_logging_sink(master_log, verbose=True)

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -6,7 +6,8 @@ from vivarium.framework.components import (
     ComponentManager,
     OrderedComponentSet,
 )
-from vivarium.framework.engine import Builder, SimulationContext
+from vivarium.framework.engine import Builder
+from vivarium.framework.engine import SimulationContext as SimulationContext_
 from vivarium.framework.event import EventInterface, EventManager
 from vivarium.framework.lifecycle import LifeCycleInterface, LifeCycleManager
 from vivarium.framework.lookup import LookupTableInterface, LookupTableManager
@@ -25,6 +26,12 @@ def is_same_object_method(m1, m2):
     return m1.__func__ is m2.__func__ and m1.__self__ is m2.__self__
 
 
+@pytest.fixture()
+def SimulationContext():
+    yield SimulationContext_
+    SimulationContext_._clear_context_cache()
+
+
 @pytest.fixture
 def components():
     return [
@@ -39,7 +46,16 @@ def log(mocker):
     return mocker.patch("vivarium.framework.engine.logger")
 
 
-def test_SimulationContext_init_default(components):
+def test_SimulationContext_get_sim_name(SimulationContext):
+    assert SimulationContext._created_simulation_contexts == set()
+
+    assert SimulationContext._get_context_name(None) == "simulation_1"
+    assert SimulationContext._get_context_name("foo") == "foo"
+
+    assert SimulationContext._created_simulation_contexts == {"simulation_1", "foo"}
+
+
+def test_SimulationContext_init_default(SimulationContext, components):
     sim = SimulationContext(components=components)
 
     assert isinstance(sim._lifecycle, LifeCycleManager)
@@ -103,7 +119,27 @@ def test_SimulationContext_init_default(components):
     assert isinstance(list(sim._component_manager._components)[-1], Metrics)
 
 
-def test_SimulationContext_setup_default(base_config, components):
+def test_SimulationContext_name_management(SimulationContext):
+    assert SimulationContext._created_simulation_contexts == set()
+
+    sim1 = SimulationContext()
+    assert sim1._name == "simulation_1"
+    assert SimulationContext._created_simulation_contexts == {"simulation_1"}
+
+    sim2 = SimulationContext(sim_name="foo")
+    assert sim2._name == "foo"
+    assert SimulationContext._created_simulation_contexts == {"simulation_1", "foo"}
+
+    sim3 = SimulationContext()
+    assert sim3._name == "simulation_3"
+    assert SimulationContext._created_simulation_contexts == {
+        "simulation_1",
+        "foo",
+        "simulation_3",
+    }
+
+
+def test_SimulationContext_setup_default(SimulationContext, base_config, components):
     sim = SimulationContext(base_config, components)
     listener = [c for c in components if "listener" in c.args][0]
     assert not listener.post_setup_called
@@ -140,7 +176,7 @@ def test_SimulationContext_setup_default(base_config, components):
     assert listener.post_setup_called
 
 
-def test_SimulationContext_initialize_simulants(base_config, components):
+def test_SimulationContext_initialize_simulants(SimulationContext, base_config, components):
     sim = SimulationContext(base_config, components)
     sim.setup()
     pop_size = sim.configuration.population.population_size
@@ -151,7 +187,7 @@ def test_SimulationContext_initialize_simulants(base_config, components):
     assert sim._clock.time == current_time
 
 
-def test_SimulationContext_step(log, base_config, components):
+def test_SimulationContext_step(SimulationContext, log, base_config, components):
     sim = SimulationContext(base_config, components)
     sim.setup()
     sim.initialize_simulants()
@@ -177,7 +213,7 @@ def test_SimulationContext_step(log, base_config, components):
     assert sim._clock.time == current_time + step_size
 
 
-def test_SimulationContext_finalize(base_config, components):
+def test_SimulationContext_finalize(SimulationContext, base_config, components):
     sim = SimulationContext(base_config, components)
     listener = [c for c in components if "listener" in c.args][0]
     sim.setup()
@@ -188,7 +224,7 @@ def test_SimulationContext_finalize(base_config, components):
     assert listener.simulation_end_called
 
 
-def test_SimulationContext_report(base_config, components):
+def test_SimulationContext_report(SimulationContext, base_config, components):
     sim = SimulationContext(base_config, components)
     sim.setup()
     sim.initialize_simulants()


### PR DESCRIPTION
## Add unique simulation names
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: feature
*JIRA issue*: N/A

This is the first step to fixing a couple issues with simulation logging described here: https://github.com/ihmeuw/vivarium/issues/282 and here: https://github.com/ihmeuw/vivarium/issues/283.
It adds an attribute to th simulation context to track all created contexts within a python process which
allows us to uniquely name simulation contexts.  

This implementation requires that SimulationContexts
are created in serial to ensure thread safety, which I think is a reasonable constraint given all historical 
use cases (in which we never do multiprocessing or multithreading to begin with).  


### Testing
CI + new unit tests

