### PR TITLE
Add a CLI progress bar

### DIFF
--- a/docs/source/tutorials/disease_model.rst
+++ b/docs/source/tutorials/disease_model.rst
@@ -734,7 +734,7 @@ to 0.0097 deaths per person-year, very close to the 0.01 rate we provided.
    }
 
    sim = InteractiveContext(components=[BasePopulation(), Mortality()], configuration=config)
-   sim.take_steps(2)
+   sim.take_steps(2, progress_bar=False)
 
 
 Observer

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
         "tables",
         "networkx",
         "loguru",
+        "tqdm",
     ]
 
     interactive_requirements = [

--- a/src/vivarium/examples/disease_model/disease_model.yaml
+++ b/src/vivarium/examples/disease_model/disease_model.yaml
@@ -26,7 +26,7 @@ configuration:
             year: 2026
             month: 12
             day: 31
-        step_size: 0.5  # Days
+        step_size: 30  # Days
     population:
         population_size: 100_000
         age_start: 0

--- a/src/vivarium/examples/disease_model/disease_model.yaml
+++ b/src/vivarium/examples/disease_model/disease_model.yaml
@@ -23,7 +23,7 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2026
+            year: 2023
             month: 12
             day: 31
         step_size: 0.5  # Days

--- a/src/vivarium/examples/disease_model/disease_model.yaml
+++ b/src/vivarium/examples/disease_model/disease_model.yaml
@@ -26,7 +26,7 @@ configuration:
             year: 2026
             month: 12
             day: 31
-        step_size: 30  # Days
+        step_size: 0.5  # Days
     population:
         population_size: 100_000
         age_start: 0

--- a/src/vivarium/examples/disease_model/disease_model.yaml
+++ b/src/vivarium/examples/disease_model/disease_model.yaml
@@ -23,7 +23,7 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2023
+            year: 2026
             month: 12
             day: 31
         step_size: 0.5  # Days

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -214,10 +214,11 @@ class SimulationContext:
         self._clock.step_forward()
 
     def take_steps(self, number_of_steps: int, progress_bar: bool = False) -> None:
+        log_step = not progress_bar
         with tqdm.tqdm(total=number_of_steps, disable=not progress_bar) as pbar:
             for _ in range(number_of_steps):
                 pbar.set_description(f"Time step {self._clock.time}")
-                self.step()
+                self.step(log_step=log_step)
                 pbar.update(1)
 
     def run(self, progress_bar: bool = False) -> int:

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -10,8 +10,8 @@ For more information about time in the simulation, see the associated
 :ref:`concept note <time_concept>`.
 
 """
-from datetime import datetime, timedelta
 import math
+from datetime import datetime, timedelta
 from numbers import Number
 from typing import Callable, Union
 
@@ -63,8 +63,6 @@ class SimulationClock:
     def step_backward(self):
         """Rewinds the clock by the current step size."""
         self._time -= self.step_size
-
-
 
 
 class SimpleClock(SimulationClock):

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -11,6 +11,7 @@ For more information about time in the simulation, see the associated
 
 """
 from datetime import datetime, timedelta
+import math
 from numbers import Number
 from typing import Callable, Union
 
@@ -50,6 +51,11 @@ class SimulationClock:
         assert self._step_size is not None, "No step size provided"
         return self._step_size
 
+    @property
+    def steps_remaining(self) -> int:
+        """Returns the number of steps remaining until the simulation stops."""
+        return math.ceil((self.stop_time - self.time) / self.step_size)
+
     def step_forward(self) -> None:
         """Advances the clock by the current step size."""
         self._time += self.step_size
@@ -57,6 +63,8 @@ class SimulationClock:
     def step_backward(self):
         """Rewinds the clock by the current step size."""
         self._time -= self.step_size
+
+
 
 
 class SimpleClock(SimulationClock):

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -132,8 +132,8 @@ def run(
 
     if verbose and progress_bar:
         logger.warning(
-            "Progress bar may work poorly with verbose logging. "
-            "Consider disabling one of these options."
+            "Progress bar may work poorly with verbose logging if there are user generated"
+            "logs within a time step. Consider disabling one of these options if problematic."
         )
 
     start = time()

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -97,7 +97,7 @@ def simulate():
     "--progress-bar",
     "--pb",
     is_flag=True,
-    help="Show a progress bar for time steps in the simulation."
+    help="Show a progress bar for time steps in the simulation.",
 )
 @click.option(
     "--pdb",

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -41,7 +41,7 @@ class InteractiveContext(SimulationContext):
         super().setup()
         self.initialize_simulants()
 
-    def step(self, step_size: Timedelta = None):
+    def step(self, step_size: Timedelta = None, log_step: bool = True):
         """Advance the simulation one step.
 
         Parameters
@@ -49,10 +49,12 @@ class InteractiveContext(SimulationContext):
         step_size
             An optional size of step to take. Must be the same type as the
             simulation clock's step size (usually a pandas.Timedelta).
+        log_step
+            Whether to log the step taken.
 
         """
         with self._adjust_step_size(step_size) as _:
-            super().step()
+            super().step(log_step=log_step)
 
     def take_steps(
         self,
@@ -135,9 +137,7 @@ class InteractiveContext(SimulationContext):
         step_size = step_size if step_size is not None else self._clock.step_size
         number_of_steps = int(ceil((end_time - self._clock.time) / self._clock.step_size))
         self.take_steps(
-            number_of_steps=number_of_steps,
-            step_size=step_size,
-            progress_bar=progress_bar
+            number_of_steps=number_of_steps, step_size=step_size, progress_bar=progress_bar
         )
         return number_of_steps
 
@@ -270,4 +270,3 @@ class InteractiveContext(SimulationContext):
             self._clock._step_size = step_size
         yield
         self._clock._step_size = old_step_size
-

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -12,6 +12,7 @@ See the associated tutorials for :ref:`running <interactive_tutorial>` and
 :ref:`exploring <exploration_tutorial>` for more information.
 
 """
+from contextlib import contextmanager
 from math import ceil
 from typing import Any, Callable, Dict, List
 
@@ -20,8 +21,6 @@ import pandas as pd
 from vivarium.framework.engine import SimulationContext
 from vivarium.framework.time import Time, Timedelta
 from vivarium.framework.values import Pipeline
-
-from .utilities import log_progress, run_from_ipython
 
 
 class InteractiveContext(SimulationContext):
@@ -50,83 +49,16 @@ class InteractiveContext(SimulationContext):
         step_size
             An optional size of step to take. Must be the same type as the
             simulation clock's step size (usually a pandas.Timedelta).
-        """
-        old_step_size = self._clock.step_size
-        if step_size is not None:
-            if not isinstance(step_size, type(self._clock.step_size)):
-                raise ValueError(
-                    f"Provided time must be an instance of {type(self._clock.step_size)}"
-                )
-            self._clock._step_size = step_size
-        super().step()
-        self._clock._step_size = old_step_size
-
-    def run(self, with_logging: bool = True) -> int:
-        """Run the simulation for the duration specified in the configuration.
-
-        Parameters
-        ----------
-        with_logging
-            Whether or not to log the simulation steps. Only works in an ipython
-            environment.
-
-        Returns
-        -------
-        int
-            The number of steps the simulation took.
 
         """
-        return self.run_until(self._clock.stop_time, with_logging=with_logging)
-
-    def run_for(self, duration: Timedelta, with_logging: bool = True) -> int:
-        """Run the simulation for the given time duration.
-
-        Parameters
-        ----------
-        duration
-            The length of time to run the simulation for. Should be the same
-            type as the simulation clock's step size (usually a pandas
-            Timedelta).
-        with_logging
-            Whether or not to log the simulation steps. Only works in an ipython
-            environment.
-
-        Returns
-        -------
-        int
-            The number of steps the simulation took.
-
-        """
-        return self.run_until(self._clock.time + duration, with_logging=with_logging)
-
-    def run_until(self, end_time: Time, with_logging: bool = True) -> int:
-        """Run the simulation until the provided end time.
-
-        Parameters
-        ----------
-        end_time
-            The time to run the simulation until. The simulation will run until
-            its clock is greater than or equal to the provided end time.
-        with_logging
-            Whether or not to log the simulation steps. Only works in an ipython
-            environment.
-
-        Returns
-        -------
-        int
-            The number of steps the simulation took.
-
-        """
-        if not isinstance(end_time, type(self._clock.time)):
-            raise ValueError(f"Provided time must be an instance of {type(self._clock.time)}")
-
-        iterations = int(ceil((end_time - self._clock.time) / self._clock.step_size))
-        self.take_steps(number_of_steps=iterations, with_logging=with_logging)
-        assert self._clock.time - self._clock.step_size < end_time <= self._clock.time
-        return iterations
+        with self._adjust_step_size(step_size) as _:
+            super().step()
 
     def take_steps(
-        self, number_of_steps: int = 1, step_size: Timedelta = None, with_logging: bool = True
+        self,
+        number_of_steps: int = 1,
+        step_size: Timedelta = None,
+        progress_bar: bool = True,
     ):
         """Run the simulation for the given number of steps.
 
@@ -137,20 +69,113 @@ class InteractiveContext(SimulationContext):
         step_size
             An optional size of step to take. Must be the same type as the
             simulation clock's step size (usually a pandas.Timedelta).
-        with_logging
-            Whether or not to log the simulation steps. Only works in an ipython
-            environment.
+        progress_bar
+            Whether to show a progress bar for the steps taken.
 
         """
         if not isinstance(number_of_steps, int):
-            raise ValueError("Number of steps must be an integer.")
+            raise TypeError("Number of steps must be an integer.")
 
-        if run_from_ipython() and with_logging:
-            for _ in log_progress(range(number_of_steps), name="Step"):
-                self.step(step_size)
-        else:
-            for _ in range(number_of_steps):
-                self.step(step_size)
+        with self._adjust_step_size(step_size) as _:
+            super().take_steps(number_of_steps, progress_bar)
+
+    def run(self, step_size: Timedelta = None, progress_bar: bool = True) -> int:
+        """Run the simulation for the duration specified in the configuration.
+
+        Parameters
+        ----------
+        step_size
+            An optional size of step to take. Must be the same type as the
+            simulation clock's step size (usually a pandas.Timedelta).
+        progress_bar
+            Whether to show a progress bar documenting the simulation steps.
+
+        Returns
+        -------
+        int
+            The number of steps the simulation took.
+
+        """
+
+        return self.run_until(
+            end_time=self._clock.stop_time,
+            step_size=step_size,
+            progress_bar=progress_bar,
+        )
+
+    def run_until(
+        self,
+        end_time: Time,
+        step_size: Timedelta = None,
+        progress_bar: bool = True,
+    ) -> int:
+        """Run the simulation until the provided end time.
+
+        Parameters
+        ----------
+        end_time
+            The time to run the simulation until. The simulation will run until
+            its clock is greater than or equal to the provided end time.
+        step_size
+            An optional size of step to take. Must be the same type as the
+            simulation clock's step size (usually a pandas.Timedelta).
+        progress_bar
+            Whether to show a progress bar documenting the simulation steps.
+
+        Returns
+        -------
+        int
+            The number of steps the simulation took.
+
+        """
+        if not isinstance(end_time, type(self._clock.time)):
+            msg = f"Provided time must be an instance of {type(self._clock.time)}"
+            raise TypeError(msg)
+
+        step_size = step_size if step_size is not None else self._clock.step_size
+        number_of_steps = int(ceil((end_time - self._clock.time) / self._clock.step_size))
+        self.take_steps(
+            number_of_steps=number_of_steps,
+            step_size=step_size,
+            progress_bar=progress_bar
+        )
+        return number_of_steps
+
+    def run_for(
+        self,
+        duration: Timedelta,
+        step_size: Timedelta,
+        progress_bar: bool = True,
+    ) -> int:
+        """Run the simulation for the given time duration.
+
+        Parameters
+        ----------
+        duration
+            The length of time to run the simulation for. Should be the same
+            type as the simulation clock's step size (usually a pandas
+            Timedelta).
+        step_size
+            An optional size of step to take. Must be the same type as the
+            simulation clock's step size (usually a pandas.Timedelta).
+        progress_bar
+            Whether to show a progress bar documenting the simulation steps.
+
+        Returns
+        -------
+        int
+            The number of steps the simulation took.
+
+        """
+        if not isinstance(duration, type(self._clock.step_size)):
+            msg = f"Provided time must be an instance of {type(self._clock.step_size)}"
+            raise TypeError(msg)
+
+        return self.run_until(
+            end_time=self._clock.time + duration,
+            step_size=step_size,
+            progress_bar=progress_bar,
+        )
 
     def get_population(self, untracked: bool = False) -> pd.DataFrame:
         """Get a copy of the population state table.
@@ -233,3 +258,16 @@ class InteractiveContext(SimulationContext):
 
         """
         return self._component_manager.get_component(name)
+
+    @contextmanager
+    def _adjust_step_size(self, step_size: Timedelta = None):
+        old_step_size = self._clock.step_size
+        if step_size is not None:
+            if not isinstance(step_size, type(self._clock.step_size)):
+                raise ValueError(
+                    f"Provided time must be an instance of {type(self._clock.step_size)}"
+                )
+            self._clock._step_size = step_size
+        yield
+        self._clock._step_size = old_step_size
+

--- a/src/vivarium/interface/utilities.py
+++ b/src/vivarium/interface/utilities.py
@@ -17,65 +17,6 @@ import yaml
 from vivarium.exceptions import VivariumError
 
 
-def run_from_ipython() -> bool:
-    """Taken from https://stackoverflow.com/questions/5376837/how-can-i-do-an-if-run-from-ipython-test-in-python"""
-    try:
-        __IPYTHON__
-        return True
-    except NameError:
-        return False
-
-
-def log_progress(sequence, every=None, size=None, name="Items"):
-    """Taken from https://github.com/alexanderkuk/log-progress"""
-    from IPython.display import display
-    from ipywidgets import HTML, IntProgress, VBox
-
-    is_iterator = False
-    if size is None:
-        try:
-            size = len(sequence)
-        except TypeError:
-            is_iterator = True
-    if size is not None:
-        if every is None:
-            if size <= 200:
-                every = 1
-            else:
-                every = int(size / 200)  # every 0.5%
-    else:
-        assert every is not None, "sequence is iterator, set every"
-
-    if is_iterator:
-        progress = IntProgress(min=0, max=1, value=1)
-        progress.bar_style = "info"
-    else:
-        progress = IntProgress(min=0, max=size, value=0)
-    label = HTML()
-    box = VBox(children=[label, progress])
-    display(box)
-
-    index = 0
-    try:
-        for index, record in enumerate(sequence, 1):
-            if index == 1 or index % every == 0:
-                if is_iterator:
-                    label.value = "{name}: {index} / ?".format(name=name, index=index)
-                else:
-                    progress.value = index
-                    label.value = "{name}: {index} / {size}".format(
-                        name=name, index=index, size=size
-                    )
-            yield record
-    except Exception as e:
-        progress.bar_style = "danger"
-        raise
-    else:
-        progress.bar_style = "success"
-        progress.value = index
-        label.value = "{name}: {index}".format(name=name, index=str(index or "?"))
-
-
 class InteractiveError(VivariumError):
     """Error raised when the Interactive context is in an inconsistent state."""
 


### PR DESCRIPTION
## Add a CLI progress bar
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: feature
*Issues*: N/A

The main thrust of this PR is to add a progress bar to the CLI and to clean up the interactive simulation progress bar implementation.

Example CLI usage:
![image](https://user-images.githubusercontent.com/6313865/221670740-d247a5d4-0771-4abc-85ae-ddbf259697fd.png)

Example interactive sim usage from REPL: 
![image](https://user-images.githubusercontent.com/6313865/221672114-48890b37-5156-4a6f-8f3e-3114e80397b4.png)

Example interactive sim usage from notebook:
![image](https://user-images.githubusercontent.com/6313865/221672530-be9cc356-c704-43da-8fc6-2871d5537836.png)


**Detailed changes**
- Add `tqdm` to framework dependencies
- Add a `steps_remaining` property to simulation clocks so they can tell us the remaining number of simulation steps.
- Add a private context manager to the `InteractiveContext` to abstract away the behavior of adjusting the simulation step size.
- Add a `take_steps` method to the base `SimulationContext` that is smart about the balance between verbose logging and using a progress bar.
- Make the time stepping methods on the base `SimulationContext` and the `InteractiveContext` more consistent and clean up their implementations a bit.
- Replace custom progress bar code in the `InteractiveContext` with `tqdm`'s implementation so we don't have to think about it when it breaks (as it's already broken).

### Testing
CI + manual testing
