### PR TITLE
pin pandas>=2; stop supporting python 3.7; fix failing doctest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python --version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python --version

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Vivarium
 Vivarium is a simulation framework written using standard scientific Python
 tools.
 
-**Vivarium requires Python 3.8-3.10 to run**
+**Vivarium requires Python 3.8-3.11 to run**
 
 You can install ``vivarium`` from PyPI with pip:
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Vivarium
 Vivarium is a simulation framework written using standard scientific Python
 tools.
 
-**Vivarium requires Python 3.7-3.10 to run**
+**Vivarium requires Python 3.8-3.10 to run**
 
 You can install ``vivarium`` from PyPI with pip:
 

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Vivarium
 Vivarium is a simulation framework written using standard scientific Python
 tools.
 
-**Vivarium requires Python 3.8-3.11 to run**
+**Vivarium requires Python 3.8-3.10 to run**
 
 You can install ``vivarium`` from PyPI with pip:
 

--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -297,8 +297,9 @@ the population as a whole.
     75%           3.744090
     max           4.999967
     Name: age, dtype: float64
+    alive
     alive    100000
-    Name: alive, dtype: int64
+    Name: count, dtype: int64
     count    100000.000000
     mean          0.500602
     std           0.288434
@@ -308,15 +309,19 @@ the population as a whole.
     75%           0.749816
     max           0.999978
     Name: child_wasting_propensity, dtype: float64
+    lower_respiratory_infections
     susceptible_to_lower_respiratory_infections    100000
-    Name: lower_respiratory_infections, dtype: int64
+    Name: count, dtype: int64
+    entrance_time
     2021-12-31 12:00:00    100000
-    Name: entrance_time, dtype: int64
+    Name: count, dtype: int64
+    sex
     Male      50162
     Female    49838
-    Name: sex, dtype: int64
+    Name: count, dtype: int64
+    tracked
     True    100000
-    Name: tracked, dtype: int64
+    Name: count, dtype: int64
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 
-min_version, max_version = ((3, 6), "3.6"), ((3, 10), "3.10")
+min_version, max_version = ((3, 8), "3.8"), ((3, 10), "3.10")
 
 if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "numpy",
-        "pandas<2.0.0",
+        "pandas>=2.0",
         "pyyaml>=5.1",
         "scipy",
         "click",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 
-min_version, max_version = ((3, 8), "3.8"), ((3, 10), "3.10")
+min_version, max_version = ((3, 8), "3.8"), ((3, 11), "3.11")
 
 if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 
-min_version, max_version = ((3, 8), "3.8"), ((3, 11), "3.11")
+min_version, max_version = ((3, 8), "3.8"), ((3, 10), "3.10")
 
 if not (min_version[0] <= sys.version_info[:2] <= max_version[0]):
     # Python 3.5 does not support f-strings


### PR DESCRIPTION
## Title: Update for Pandas v2.0

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3948](https://jira.ihme.washington.edu/browse/MIC-3948)

Doctests started failing with Pandas 2.0 and we temporarily pinned it at <2.0.
This goes all in with Pandas v2.0+.
- Pins Pandas>=2.0
- Removes support of python 3.7 (Pandas 2.0 requires python 3.8+)
- Updates readme 
- Fixes failing doctest

### Testing
CI is passing again

