### PR TITLE
Bugfix/sbachmei/mic 4091 crn shuffling

### DIFF
--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -304,12 +304,12 @@ the population as a whole.
     alive    100000
     Name: count, dtype: int64
     count    100000.000000
-    mean          0.500602
-    std           0.288434
-    min           0.000022
-    25%           0.251288
-    50%           0.499957
-    75%           0.749816
+    mean          0.499756
+    std           0.288412
+    min           0.000015
+    25%           0.251550
+    50%           0.497587
+    75%           0.749215
     max           0.999978
     Name: child_wasting_propensity, dtype: float64
     lower_respiratory_infections
@@ -319,8 +319,8 @@ the population as a whole.
     2021-12-31 12:00:00    100000
     Name: count, dtype: int64
     sex
-    Male      50162
-    Female    49838
+    Male      50185
+    Female    49815
     Name: count, dtype: int64
     tracked
     True    100000

--- a/src/vivarium/framework/randomness/index_map.py
+++ b/src/vivarium/framework/randomness/index_map.py
@@ -55,7 +55,9 @@ class IndexMap:
         final_mapping = self._build_final_mapping(new_mapping_index, clock_time)
 
         # Tack on the simulant index to the front of the map.
-        final_mapping.index = final_mapping.index.join(final_mapping_index).reorder_levels([self.SIM_INDEX_COLUMN] + self._key_columns)
+        final_mapping.index = final_mapping.index.join(final_mapping_index).reorder_levels(
+            [self.SIM_INDEX_COLUMN] + self._key_columns
+        )
         final_mapping = final_mapping.sort_index(level=self.SIM_INDEX_COLUMN)
         self._map = final_mapping
 
@@ -88,7 +90,9 @@ class IndexMap:
             final_mapping_index = self._map.index.append(new_mapping_index)
         return new_mapping_index, final_mapping_index
 
-    def _build_final_mapping(self, new_mapping_index: pd.Index, clock_time: pd.Timestamp) -> pd.Series:
+    def _build_final_mapping(
+        self, new_mapping_index: pd.Index, clock_time: pd.Timestamp
+    ) -> pd.Series:
         """Builds a new mapping between key columns and the randomness index from the
         new mapping index and the existing map.
 

--- a/src/vivarium/framework/randomness/index_map.py
+++ b/src/vivarium/framework/randomness/index_map.py
@@ -52,7 +52,8 @@ class IndexMap:
         final_mapping = self._build_final_mapping(new_mapping_index)
 
         # Tack on the simulant index to the front of the map.
-        final_mapping.index = final_mapping_index
+        final_mapping.index = final_mapping.index.join(final_mapping_index).reorder_levels([self.SIM_INDEX_COLUMN] + self._key_columns)
+        final_mapping = final_mapping.sort_index(level=self.SIM_INDEX_COLUMN)
         self._map = final_mapping
 
     def _parse_new_keys(self, new_keys: pd.DataFrame) -> Tuple[pd.MultiIndex, pd.MultiIndex]:

--- a/src/vivarium/framework/randomness/manager.py
+++ b/src/vivarium/framework/randomness/manager.py
@@ -167,7 +167,7 @@ class RandomnessManager:
             raise RandomnessError(
                 "The simulants dataframe does not have all specified key_columns."
             )
-        self._key_mapping.update(simulants.loc[:, self._key_columns])
+        self._key_mapping.update(simulants.loc[:, self._key_columns], self._clock())
 
     def __str__(self):
         return "RandomnessManager()"

--- a/tests/framework/randomness/test_index_map.py
+++ b/tests/framework/randomness/test_index_map.py
@@ -169,8 +169,9 @@ def test_hash_uniformity(map_size_and_hashed_values):
 def index_map(mocker):
     mock_index_map = IndexMap
 
-    def hash_mock(k, salt=0):
+    def hash_mock(k, salt):
         seed = 123456
+        salt = IndexMap()._convert_to_ten_digit_int(pd.Series(salt, index=k))
         rs = np.random.RandomState(seed=seed + salt)
         return pd.Series(rs.randint(0, len(k) * 10, size=len(k)), index=k)
 
@@ -183,21 +184,21 @@ def test_update_empty_bad_keys(index_map):
     keys = pd.DataFrame({"A": ["a"] * 10}, index=range(10))
     m = index_map(key_columns=list(keys.columns))
     with pytest.raises(RandomnessError):
-        m.update(keys)
+        m.update(keys, pd.to_datetime("2023-01-01"))
 
 
 def test_update_nonempty_bad_keys(index_map):
     keys = generate_keys(1000)
     m = index_map(key_columns=list(keys.columns))
-    m.update(keys)
+    m.update(keys, pd.to_datetime("2023-01-01"))
     with pytest.raises(RandomnessError):
-        m.update(keys)
+        m.update(keys, pd.to_datetime("2023-01-01"))
 
 
 def test_update_empty_good_keys(index_map):
     keys = generate_keys(1000)
     m = index_map(key_columns=list(keys.columns))
-    m.update(keys)
+    m.update(keys, pd.to_datetime("2023-01-01"))
     key_index = keys.set_index(list(keys.columns)).index
     assert len(m._map) == len(keys), "All keys not in mapping"
     assert (
@@ -211,8 +212,8 @@ def test_update_nonempty_good_keys(index_map):
     m = index_map(key_columns=list(keys.columns))
     keys1, keys2 = keys[:1000], keys[1000:]
 
-    m.update(keys1)
-    m.update(keys2)
+    m.update(keys1, pd.to_datetime("2023-01-01"))
+    m.update(keys2, pd.to_datetime("2023-01-01"))
 
     key_index = keys.set_index(list(keys.columns)).index
     assert len(m._map) == len(keys), "All keys not in mapping"


### PR DESCRIPTION
## Title: Bugfix inter-simulation CRN shuffling

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4091](https://jira.ihme.washington.edu/browse/MIC-4091)

This PR consists of two changes: a bugfix and then a related improvement. I stumbled
across this issue when putting together a simple demonstration for the 
CC presentation on randomness.

What I was finding was that supposedly-common simulants that exist in both the baseline
sim and the 2x fertility counterfactual sim would on occasion end up with different
details (entrance time, age, and/or sex). It boiled down to the fact that
their IndexMap `draw_index`es were different between the two sims and so
they were getting assigned different draws.

**Bugfix (first commit)**
During the `self._build_final_mpaaing` portion of index map, the index map itself
can potentially become shuffled a bit. It's unclear to me why, though I think 
it's happing in hash conflict resolution. But then after building the
final mapping we need to stick the simulant index back on, but it currently does so
via a brute force reassignment (that assumes no shuffling occurred). This PR
instead uses `.join` and then`.sort_index` to properly align the simulant index
with the potentially-shuffled index map.

**Improvement (second commit)**
Even with the above bugfix, I was finding (a much smaller number of) instances
where common simulants were still getting assigned different `draw_index`. 
I couldn't 100% confirm, but I believe the issue is the following:

- Simulant A is NOT born in the baseline but is born in the counterfactual.
  This simulant gets hashed to a spot in the index map as usual.
- Simulant B is common and born in both sims. However, this simulant
  gets hashed to the same spot in the IndexMap as simulant A. In the baseline,
  that hash hasn't been used yet (b/c simulant A doesn't exist) and so
  it uses that. But in the counterfactual, simulant A does exist and already
  took that value and so there is a collision and it rehashes to some new 
  number. Simulant A and B thus are mapped to different draws in the
  IndexMap and we've lost CRN.

James confirmed that we can't 100% solve the problem b/c hashing isn't perfect.
He suggested two solutions:
- Find a better hashing function
- Use time step as the salt to the hashing function.

I opted for the latter and use the clock time as the salt. This won't solve the problem
but should reduce the number of inter-sim collisions. 

### Testing
pytests pass
I'm no longer seeing the issue
NOTE: I think a new test should be written for this but I'm not exactly sure how since
it's not easily reproducible. 

