### PR TITLE
Add logging for registering stratifications and observations

### DIFF
--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -125,6 +125,7 @@ class ResultsManager:
         ------
         None
         """
+        self.logger.debug(f"Registering stratification {name}")
         target_columns = list(requires_columns) + list(requires_values)
         self._results_context.add_stratification(
             name, target_columns, categories, mapper, is_vectorized
@@ -189,6 +190,7 @@ class ResultsManager:
         excluded_stratifications: List[str] = (),
         when: str = "collect_metrics",
     ) -> None:
+        self.logger.debug(f"Registering observation {name}")
         self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
         self._results_context.add_observation(
             name,

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -91,9 +91,13 @@ def test_register_observation(
     assert len(interface._manager._results_context.observations) == 1
 
 
-def test_register_observations():
+def test_register_observations(mocker):
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
+    builder = mocker.Mock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
+
     assert len(interface._manager._results_context.observations) == 0
     interface.register_observation(
         "living_person_time",
@@ -121,9 +125,13 @@ def test_register_observations():
     assert len(interface._manager._results_context.observations) == 2
 
 
-def test_unhashable_pipeline():
+def test_unhashable_pipeline(mocker):
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
+    builder = mocker.Mock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
+
     assert len(interface._manager._results_context.observations) == 0
     with pytest.raises(TypeError, match="unhashable"):
         interface.register_observation(
@@ -158,6 +166,9 @@ def test_integration_full_observation(mocker):
     # Create interface
     mgr = ResultsManager()
     results_interface = ResultsInterface(mgr)
+    builder = mocker.Mock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
 
     # register stratifications
     results_interface.register_stratification("house", HOUSES, None, True, ["house"], [])


### PR DESCRIPTION
## Add logging for registering stratifications and observations
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-4228](https://jira.ihme.washington.edu/browse/MIC-4228)

Added logging to the results manager's registration methods.
This matches the usage in `ValuesManager`

### Testing
Ran unit tests and  ran a simple simulation and verified log messages appear