### PR TITLE
Update vivarium to use setuptools_scm versioning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,13 +33,13 @@ sys.path.insert(0, str(Path("..").resolve()))
 # -- Project information -----------------------------------------------------
 
 project = about["__title__"]
-copyright = f'2021, {about["__author__"]}'
+copyright = f'2023, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.
-version = about["__version__"]
+version = vivarium.__version__
 # The full version, including alpha/beta/rc tags.
-release = about["__version__"]
+release = vivarium.__version__
 
 
 # -- General configuration ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ if __name__ == "__main__":
         "loguru",
     ]
 
+    setup_requires = ["setuptools_scm"]
+
     interactive_requirements = [
         "IPython",
         "ipywidgets",
@@ -62,7 +64,6 @@ if __name__ == "__main__":
 
     setup(
         name=about["__title__"],
-        version=about["__version__"],
         description=about["__summary__"],
         long_description=long_description,
         license=about["__license__"],
@@ -106,4 +107,10 @@ if __name__ == "__main__":
                 simulate=vivarium.interface.cli:simulate
             """,
         zip_safe=False,
+        use_scm_version={
+            "write_to": "src/vivarium/_version.py",
+            "write_to_template": '__version__ = "{version}"\n',
+            "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+        },
+        setup_requires=setup_requires,
     )

--- a/src/vivarium/__about__.py
+++ b/src/vivarium/__about__.py
@@ -2,7 +2,6 @@ __all__ = [
     "__title__",
     "__summary__",
     "__uri__",
-    "__version__",
     "__author__",
     "__email__",
     "__license__",
@@ -12,8 +11,6 @@ __all__ = [
 __title__ = "vivarium"
 __summary__ = "vivarium is a microsimulation framework built on top of the standard scientific python stack."
 __uri__ = "https://github.com/ihmeuw/vivarium"
-
-__version__ = "1.2.0"
 
 __author__ = "The vivarium developers"
 __email__ = "vivarium.dev@gmail.com"

--- a/src/vivarium/__init__.py
+++ b/src/vivarium/__init__.py
@@ -10,8 +10,8 @@ from vivarium.__about__ import (
     __summary__,
     __title__,
     __uri__,
-    __version__,
 )
+from vivarium._version import __version__
 from vivarium.config_tree import ConfigTree
 from vivarium.framework.artifact import Artifact
 from vivarium.framework.configuration import build_model_specification


### PR DESCRIPTION
## Update vivarium to use setuptools_scm versioning

### Description
- *Category*: CI/infrastructure
- *JIRA issue*: [MIC-4238](https://jira.ihme.washington.edu/browse/MIC-4238)

- Updates repo to use setuptools_scm versioning. This should be mostly transparent as a change, except dev versions will be more informative.

### Testing
`python setup.py --version` gives the expected version from tag, dropping the expected `_version.py`. Docs built successfully.

