### PR TITLE
Release v1.2.1, deprecate develop branch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**1.2.1 - 07/12/23**
+
+ - Adds logging for registering stratifications and observations
+ - Changes version metadata to use setuptools_scm
+
 **1.2.0 - 06/01/23**
 
  - Stop supporting Python 3.7 and start supporting 3.11

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,13 +33,13 @@ sys.path.insert(0, str(Path("..").resolve()))
 # -- Project information -----------------------------------------------------
 
 project = about["__title__"]
-copyright = f'2021, {about["__author__"]}'
+copyright = f'2023, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.
-version = about["__version__"]
+version = vivarium.__version__
 # The full version, including alpha/beta/rc tags.
-release = about["__version__"]
+release = vivarium.__version__
 
 
 # -- General configuration ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ if __name__ == "__main__":
         "loguru",
     ]
 
+    setup_requires = ["setuptools_scm"]
+
     interactive_requirements = [
         "IPython",
         "ipywidgets",
@@ -62,7 +64,6 @@ if __name__ == "__main__":
 
     setup(
         name=about["__title__"],
-        version=about["__version__"],
         description=about["__summary__"],
         long_description=long_description,
         license=about["__license__"],
@@ -106,4 +107,10 @@ if __name__ == "__main__":
                 simulate=vivarium.interface.cli:simulate
             """,
         zip_safe=False,
+        use_scm_version={
+            "write_to": "src/vivarium/_version.py",
+            "write_to_template": '__version__ = "{version}"\n',
+            "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+        },
+        setup_requires=setup_requires,
     )

--- a/src/vivarium/__about__.py
+++ b/src/vivarium/__about__.py
@@ -2,7 +2,6 @@ __all__ = [
     "__title__",
     "__summary__",
     "__uri__",
-    "__version__",
     "__author__",
     "__email__",
     "__license__",
@@ -12,8 +11,6 @@ __all__ = [
 __title__ = "vivarium"
 __summary__ = "vivarium is a microsimulation framework built on top of the standard scientific python stack."
 __uri__ = "https://github.com/ihmeuw/vivarium"
-
-__version__ = "1.2.0"
 
 __author__ = "The vivarium developers"
 __email__ = "vivarium.dev@gmail.com"

--- a/src/vivarium/__init__.py
+++ b/src/vivarium/__init__.py
@@ -10,8 +10,8 @@ from vivarium.__about__ import (
     __summary__,
     __title__,
     __uri__,
-    __version__,
 )
+from vivarium._version import __version__
 from vivarium.config_tree import ConfigTree
 from vivarium.framework.artifact import Artifact
 from vivarium.framework.configuration import build_model_specification

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -125,6 +125,7 @@ class ResultsManager:
         ------
         None
         """
+        self.logger.debug(f"Registering stratification {name}")
         target_columns = list(requires_columns) + list(requires_values)
         self._results_context.add_stratification(
             name, target_columns, categories, mapper, is_vectorized
@@ -189,6 +190,7 @@ class ResultsManager:
         excluded_stratifications: List[str] = (),
         when: str = "collect_metrics",
     ) -> None:
+        self.logger.debug(f"Registering observation {name}")
         self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
         self._results_context.add_observation(
             name,

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -91,9 +91,13 @@ def test_register_observation(
     assert len(interface._manager._results_context.observations) == 1
 
 
-def test_register_observations():
+def test_register_observations(mocker):
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
+    builder = mocker.Mock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
+
     assert len(interface._manager._results_context.observations) == 0
     interface.register_observation(
         "living_person_time",
@@ -121,9 +125,13 @@ def test_register_observations():
     assert len(interface._manager._results_context.observations) == 2
 
 
-def test_unhashable_pipeline():
+def test_unhashable_pipeline(mocker):
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
+    builder = mocker.Mock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
+
     assert len(interface._manager._results_context.observations) == 0
     with pytest.raises(TypeError, match="unhashable"):
         interface.register_observation(
@@ -158,6 +166,9 @@ def test_integration_full_observation(mocker):
     # Create interface
     mgr = ResultsManager()
     results_interface = ResultsInterface(mgr)
+    builder = mocker.Mock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
 
     # register stratifications
     results_interface.register_stratification("house", HOUSES, None, True, ["house"], [])


### PR DESCRIPTION
Release for v1.2.1. After this, we'll deprecate and _rename_ the `develop` branch