### PR TITLE
create Component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier
+* @albrja @collijk @hussain-jafari @mattkappel @patricktnast @rmudambi @stevebachmeier

--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ venv.bak/
 
 # Local user jupyter notebooks directory
 notebooks/
+
+# Version file
+src/vivarium/_version.py
+

--- a/src/vivarium/__init__.py
+++ b/src/vivarium/__init__.py
@@ -12,7 +12,7 @@ from vivarium.__about__ import (
     __uri__,
 )
 from vivarium._version import __version__
-from vivarium.component import VivariumComponent
+from vivarium.component import Component
 from vivarium.config_tree import ConfigTree
 from vivarium.framework.artifact import Artifact
 from vivarium.framework.configuration import build_model_specification

--- a/src/vivarium/__init__.py
+++ b/src/vivarium/__init__.py
@@ -12,6 +12,7 @@ from vivarium.__about__ import (
     __uri__,
 )
 from vivarium._version import __version__
+from vivarium.component import VivariumComponent
 from vivarium.config_tree import ConfigTree
 from vivarium.framework.artifact import Artifact
 from vivarium.framework.configuration import build_model_specification

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from vivarium.framework.population import PopulationView, SimulantData
 
 
-class VivariumComponent(ABC):
+class Component(ABC):
     """A component that can be used in a Vivarium simulation."""
 
     """
@@ -32,7 +32,7 @@ class VivariumComponent(ABC):
         pass
 
     @property
-    def sub_components(self) -> List["VivariumComponent"]:
+    def sub_components(self) -> List["Component"]:
         """A list of the components that are managed by this component."""
         return self._sub_components
 
@@ -99,7 +99,7 @@ class VivariumComponent(ABC):
     #####################
 
     def __init__(self):
-        self._sub_components: List["VivariumComponent"] = []
+        self._sub_components: List["Component"] = []
         self.population_view: Optional[PopulationView] = None
 
     def setup(self, builder: "Builder") -> None:

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -1,16 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Callable
 
 from vivarium.framework.event import Event
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
-    from vivarium.framework.population import PopulationView, SimulantData
+    from vivarium.framework.population import SimulantData, PopulationView
 
 
 class VivariumComponent(ABC):
     """A component that can be used in a Vivarium simulation."""
 
+    """
+    A dictionary containing the defaults for any configurations managed by this
+    component.
+    """
     configuration_defaults = {}
 
     @abstractmethod
@@ -34,33 +38,60 @@ class VivariumComponent(ABC):
 
     @property
     def columns_created(self) -> List[str]:
-        """A list of the columns this component creates."""
+        """
+        A list of the columns this component creates.
+
+        An empty list means this component does not create any columns.
+        """
         return []
 
     @property
-    def columns_required(self) -> List[str]:
-        """A list of the columns this component requires that it did not create."""
-        return []
+    def columns_required(self) -> Optional[List[str]]:
+        """
+        A list of the columns this component requires that it did not create.
+
+        An empty list means all available columns are required.
+        `None` means no additional columns are required.
+        """
+        return None
 
     @property
     def initialization_columns_required(self) -> List[str]:
-        """A list of the columns this component requires during simulant initialization."""
+        """
+        A list of the columns this component requires during simulant
+        initialization.
+
+        An empty list means no columns beyond those created by this component
+        are needed during initialization.
+        """
         return []
 
     @property
     def time_step_prepare_priority(self) -> int:
+        """
+        The priority of this component's time-step prepare listener if it
+        exists.
+        """
         return 5
 
     @property
     def time_step_priority(self) -> int:
+        """ The priority of this component's time-step listener if it exists. """
         return 5
 
     @property
     def time_step_cleanup_priority(self) -> int:
+        """
+        The priority of this component's time-step cleanup listener if it
+        exists.
+        """
         return 5
 
     @property
     def collect_metrics_priority(self) -> int:
+        """
+        The priority of this component's collect metrics listener if it exists.
+        """
         return 5
 
     #####################
@@ -68,27 +99,54 @@ class VivariumComponent(ABC):
     #####################
 
     def __init__(self):
-        self._sub_components = []
+        self._sub_components: List["VivariumComponent"] = []
+        self.population_view: Optional[PopulationView] = None
 
-    # noinspection PyAttributeOutsideInit
     def setup(self, builder: "Builder") -> None:
-        self.population_view = self.get_population_view(builder)
+        """Method that vivarium will run during the setup phase."""
+        self.set_population_view(builder)
+        self.register_simulant_initializer(builder)
+        self.register_time_step_prepare_listener(builder)
+        self.register_time_step_listener(builder)
+        self.register_time_step_cleanup_listener(builder)
+        self.register_collect_metrics_listener(builder)
 
     def on_post_setup(self, builder: "Builder") -> None:
+        """
+        Method that vivarium will run during the post-setup phase.
+
+        NOTE: this is not commonly used functionality.
+        """
         pass
 
     #################
     # Setup methods #
     #################
 
-    def get_population_view(self, builder: "Builder") -> Optional["PopulationView"]:
-        population_view_columns = self.columns_created + self.columns_required
-        if population_view_columns:
-            return builder.population.get_view(population_view_columns)
+    def set_population_view(self, builder: "Builder") -> None:
+        """
+        Creates the PopulationView for this component if it needs access to the
+        state table.
+        """
+
+        if self.columns_required:
+            # Get all columns created and required
+            population_view_columns = self.columns_created + self.columns_required
+        elif self.columns_required == []:
+            # Empty list means population view needs all available columns
+            population_view_columns = []
+        elif self.columns_required is None and self.columns_created:
+            # No additional columns required, so just get columns created
+            population_view_columns = self.columns_created
         else:
-            return None
+            # no need for a population view if no columns created or required
+            population_view_columns = None
+
+        if population_view_columns is not None:
+            self.population_view = builder.population.get_view(population_view_columns)
 
     def register_simulant_initializer(self, builder: "Builder") -> None:
+        """Registers a simulant initializer if this component has defined one."""
         builder.population.initializes_simulants(
             self.on_initialize_simulants,
             creates_columns=self.columns_created,
@@ -96,6 +154,10 @@ class VivariumComponent(ABC):
         )
 
     def register_time_step_prepare_listener(self, builder: "Builder") -> None:
+        """
+        Registers a time-step prepare listener if this component has defined
+        one.
+        """
         builder.event.register_listener(
             "time_step__prepare",
             self.on_time_step_prepare,
@@ -103,6 +165,7 @@ class VivariumComponent(ABC):
         )
 
     def register_time_step_listener(self, builder: "Builder") -> None:
+        """ Registers a time-step listener if this component has defined one. """
         builder.event.register_listener(
             "time_step",
             self.on_time_step,
@@ -110,6 +173,10 @@ class VivariumComponent(ABC):
         )
 
     def register_time_step_cleanup_listener(self, builder: "Builder") -> None:
+        """
+        Registers a time-step cleanup listener if this component has defined
+        one.
+        """
         builder.event.register_listener(
             "time_step__cleanup",
             self.on_time_step_cleanup,
@@ -117,6 +184,9 @@ class VivariumComponent(ABC):
         )
 
     def register_collect_metrics_listener(self, builder: "Builder") -> None:
+        """
+        Registers a collect metrics listener if this component has defined one.
+        """
         builder.event.register_listener(
             "collect_metrics",
             self.on_collect_metrics,

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -1,11 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional, Callable
+from typing import TYPE_CHECKING, List, Optional
 
 from vivarium.framework.event import Event
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
-    from vivarium.framework.population import SimulantData, PopulationView
+    from vivarium.framework.population import PopulationView, SimulantData
 
 
 class VivariumComponent(ABC):
@@ -76,7 +76,7 @@ class VivariumComponent(ABC):
 
     @property
     def time_step_priority(self) -> int:
-        """ The priority of this component's time-step listener if it exists. """
+        """The priority of this component's time-step listener if it exists."""
         return 5
 
     @property
@@ -160,7 +160,7 @@ class VivariumComponent(ABC):
         )
 
     def register_time_step_listener(self, builder: "Builder") -> None:
-        """ Registers a time-step listener if this component has defined one. """
+        """Registers a time-step listener if this component has defined one."""
         builder.event.register_listener(
             "time_step",
             self.on_time_step,

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -1,0 +1,143 @@
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, List, Optional
+
+from vivarium.framework.event import Event
+
+if TYPE_CHECKING:
+    from vivarium.framework.engine import Builder
+    from vivarium.framework.population import PopulationView, SimulantData
+
+
+class VivariumComponent(ABC):
+    """A component that can be used in a Vivarium simulation."""
+
+    configuration_defaults = {}
+
+    @abstractmethod
+    def __repr__(self):
+        pass
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """The name of the component. Names must be unique within a simulation."""
+        pass
+
+    @property
+    def sub_components(self) -> List["VivariumComponent"]:
+        """A list of the components that are managed by this component."""
+        return self._sub_components
+
+    @property
+    def columns_created(self) -> List[str]:
+        """A list of the columns this component creates."""
+        return []
+
+    @property
+    def columns_required(self) -> List[str]:
+        """A list of the columns this component requires that it did not create."""
+        return []
+
+    @property
+    def initialization_columns_required(self) -> List[str]:
+        """A list of the columns this component requires during simulant initialization."""
+        return []
+
+    @property
+    def time_step_prepare_priority(self) -> int:
+        return 5
+
+    @property
+    def time_step_priority(self) -> int:
+        return 5
+
+    @property
+    def time_step_cleanup_priority(self) -> int:
+        return 5
+
+    @property
+    def collect_metrics_priority(self) -> int:
+        return 5
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
+    def __init__(self):
+        self._sub_components = []
+
+    # noinspection PyAttributeOutsideInit
+    def setup(self, builder: "Builder") -> None:
+        self.population_view = self.get_population_view(builder)
+
+    def on_post_setup(self, builder: "Builder") -> None:
+        pass
+
+    #################
+    # Setup methods #
+    #################
+
+    def get_population_view(self, builder: "Builder") -> Optional["PopulationView"]:
+        population_view_columns = self.columns_created + self.columns_required
+        if population_view_columns:
+            return builder.population.get_view(population_view_columns)
+        else:
+            return None
+
+    def register_simulant_initializer(self, builder: "Builder") -> None:
+        builder.population.initializes_simulants(
+            self.on_initialize_simulants,
+            creates_columns=self.columns_created,
+            requires_streams=self.initialization_columns_required,
+        )
+
+    def register_time_step_prepare_listener(self, builder: "Builder") -> None:
+        builder.event.register_listener(
+            "time_step__prepare",
+            self.on_time_step_prepare,
+            self.time_step_prepare_priority,
+        )
+
+    def register_time_step_listener(self, builder: "Builder") -> None:
+        builder.event.register_listener(
+            "time_step",
+            self.on_time_step,
+            self.time_step_priority,
+        )
+
+    def register_time_step_cleanup_listener(self, builder: "Builder") -> None:
+        builder.event.register_listener(
+            "time_step__cleanup",
+            self.on_time_step_cleanup,
+            self.time_step_cleanup_priority,
+        )
+
+    def register_collect_metrics_listener(self, builder: "Builder") -> None:
+        builder.event.register_listener(
+            "collect_metrics",
+            self.on_collect_metrics,
+            self.collect_metrics_priority,
+        )
+
+    ########################
+    # Event-driven methods #
+    ########################
+
+    def on_initialize_simulants(self, pop_data: "SimulantData") -> None:
+        pass
+
+    def on_time_step_prepare(self, event: Event) -> None:
+        pass
+
+    def on_time_step(self, event: Event) -> None:
+        pass
+
+    def on_time_step_cleanup(self, event: Event) -> None:
+        pass
+
+    def on_collect_metrics(self, event: Event) -> None:
+        pass

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -105,11 +105,6 @@ class VivariumComponent(ABC):
     def setup(self, builder: "Builder") -> None:
         """Method that vivarium will run during the setup phase."""
         self.set_population_view(builder)
-        self.register_simulant_initializer(builder)
-        self.register_time_step_prepare_listener(builder)
-        self.register_time_step_listener(builder)
-        self.register_time_step_cleanup_listener(builder)
-        self.register_collect_metrics_listener(builder)
 
     def on_post_setup(self, builder: "Builder") -> None:
         """


### PR DESCRIPTION
## Create Component
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor/POC
- *JIRA issue*: [MIC-4329](https://jira.ihme.washington.edu/browse/MIC-4329)

Creates a standard base class called `Component` that all components used in vivarium simulations should inherit from.

Features include:
- Ensuring components define required attributes/properties: `__repr__` and `name`
- Defining a default implementation of lifecycle methods: `__init__`, `setup`, and `on_post_setup`
- Defining existing attributes/properties that are not required but are currently being used by the vivarium framework: `configuration_defaults`, `sub_components`
- Defining new properties to standardize setting column requirements: `columns_created`, `columns_required`, `initialization_columns_required`
- Defining new properties to standardize setting priority requirements: `X_priority`
- Defining methods for registering listeners and creating population views: `set_population_view`, `register_simulant_initializer`, and `register_X_listener`
- Defining placeholder methods for the listeners to register (e.g. `on_initialize_simulants`, `on_time_step`)


### Testing
Tests pass locally and I can run a simulation with `BasePopulation` inheriting from `Component`