### PR TITLE
Make ConfigTree objects pickleable

### DIFF
--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -589,3 +589,6 @@ class ConfigTree:
                 for name, c in self._children.items()
             ]
         )
+
+    def __eq__(self, other):
+        raise NotImplementedError

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -513,11 +513,16 @@ class ConfigTree:
 
     def __setattr__(self, name, value):
         """Set a value on the outermost layer."""
-        # https://stackoverflow.com/a/50888571/
-        if name.startswith("__") and name.endswith("__"):
-            raise AttributeError
-
         if name not in self:
+            if name.startswith("__") and name.endswith("__"):
+                # Note that we allow keys that look like dunder attributes,
+                # they just raise a different error when you try to access ones
+                # that don't exist (as attributes).
+                # This is important because it is expected by some modules,
+                # in particular the pickle module.
+                # https://stackoverflow.com/a/50888571/
+                raise AttributeError
+
             raise ConfigurationKeyError(
                 "New configuration keys can only be created with the update method.",
                 self._name,
@@ -535,8 +540,13 @@ class ConfigTree:
 
     def __getattr__(self, name):
         """Get a value from the outermost layer in which it appears."""
-        # https://stackoverflow.com/a/50888571/
-        if name.startswith("__") and name.endswith("__"):
+        if name not in self and name.startswith("__") and name.endswith("__"):
+            # Note that we allow keys that look like dunder attributes,
+            # they just raise a different error when you try to access ones
+            # that don't exist (as attributes).
+            # This is important because it is expected by some modules,
+            # in particular the pickle module.
+            # https://stackoverflow.com/a/50888571/
             raise AttributeError
 
         return self.get_from_layer(name)

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -513,6 +513,9 @@ class ConfigTree:
 
     def __setattr__(self, name, value):
         """Set a value on the outermost layer."""
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError
+
         if name not in self:
             raise ConfigurationKeyError(
                 "New configuration keys can only be created with the update method.",
@@ -531,6 +534,9 @@ class ConfigTree:
 
     def __getattr__(self, name):
         """Get a value from the outermost layer in which it appears."""
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError
+
         return self.get_from_layer(name)
 
     def __getitem__(self, name):

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -513,6 +513,7 @@ class ConfigTree:
 
     def __setattr__(self, name, value):
         """Set a value on the outermost layer."""
+        # https://stackoverflow.com/a/50888571/
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError
 
@@ -534,6 +535,7 @@ class ConfigTree:
 
     def __getattr__(self, name):
         """Get a value from the outermost layer in which it appears."""
+        # https://stackoverflow.com/a/50888571/
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError
 

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -440,12 +440,14 @@ def test_to_dict_yaml(test_spec):
     assert yaml_config == config.to_dict()
 
 
-@pytest.mark.xfail(reason="Not yet implemented")
 def test_equals():
-    test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
-    config = ConfigTree(test_dict)
-    config2 = ConfigTree(test_dict.copy())
-    assert config == config2
+    # TODO: Assert should succeed, instead of raising, once equality is
+    # implemented for ConfigTrees
+    with pytest.raises(NotImplementedError):
+        test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
+        config = ConfigTree(test_dict)
+        config2 = ConfigTree(test_dict.copy())
+        assert config == config2
 
 
 def test_to_from_pickle():

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -440,10 +440,29 @@ def test_to_dict_yaml(test_spec):
     assert yaml_config == config.to_dict()
 
 
-def test_to_from_pickle():
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_equals():
     test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
     config = ConfigTree(test_dict)
-    assert pickle.loads(pickle.dumps(config)).to_dict() == test_dict
+    config2 = ConfigTree(test_dict.copy())
+    assert config == config2
+
+
+def test_to_from_pickle():
+    test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
+    second_layer = {"configuration": {"time": {"start": {"year": 2001}}}}
+    config = ConfigTree(test_dict, layers=["first_layer", "second_layer"])
+    config.update(second_layer, layer="second_layer")
+    unpickled = pickle.loads(pickle.dumps(config))
+
+    # We can't just assert unpickled == config because
+    # equals doesn't work with our custom attribute
+    # accessor scheme (also why pickling didn't use to work).
+    # See the previous xfailed test.
+    assert unpickled.to_dict() == config.to_dict()
+    assert unpickled._frozen == config._frozen
+    assert unpickled._name == config._name
+    assert unpickled._layers == config._layers
 
 
 def test_freeze():

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -1,3 +1,4 @@
+import pickle
 import textwrap
 
 import pytest
@@ -437,6 +438,12 @@ def test_to_dict_yaml(test_spec):
     with test_spec.open() as f:
         yaml_config = yaml.full_load(f)
     assert yaml_config == config.to_dict()
+
+
+def test_to_from_pickle():
+    test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
+    config = ConfigTree(test_dict)
+    assert pickle.loads(pickle.dumps(config)).to_dict() == test_dict
 
 
 def test_freeze():


### PR DESCRIPTION
Currently, this fails:

```python
import pickle

from vivarium.config_tree import ConfigTree

tree = ConfigTree({'foo': 'bar', 'baz': {'quux': 'foo'}})

print(pickle.loads(pickle.dumps(tree)))
```

with `vivarium.config_tree.ConfigurationKeyError: 'No value at name __getstate__.'`

The root of this problem is that the `__getattr__`/`__setattr__` stuff that ConfigTree does to support dot-syntax (e.g. tree.foo.bar) is also applying to dunder attributes. pickle automatically checks for a `__getstate__` attribute, and only catches AttributeError, so the ConfigurationKeyError is unhandled.

This PR fixes this issue by defining `__getstate__` and `__setstate__`.