### PR TITLE
enable states to allow self transitions in the constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.3 - 08/28/23**
+
+ - Enable allowing self transitions directly in a State's constructor
+
 **1.2.2 - 08/04/23**
 
  - Bugfix to include all metrics outputs in results manager

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -6,7 +6,6 @@ State Machine
 A state machine implementation for use in ``vivarium`` simulations.
 
 """
-import warnings
 from enum import Enum
 from typing import TYPE_CHECKING, Callable, Iterable, List, Tuple
 
@@ -191,9 +190,11 @@ class State:
 
     """
 
-    def __init__(self, state_id: str):
+    def __init__(self, state_id: str, allow_self_transitions: bool = False):
         self.state_id = state_id
-        self.transition_set = TransitionSet(self.name)
+        self.transition_set = TransitionSet(
+            self.name, allow_null_transition=allow_self_transitions
+        )
         self._model = None
         self._sub_components = [self.transition_set]
 

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -38,6 +38,16 @@ def _even_population_fixture(column, values):
     return pop_fixture()
 
 
+def test_initialize_allowing_self_transition():
+    self_transitions = State("self-transitions", allow_self_transitions=True)
+    no_self_transitions = State("no-self-transitions", allow_self_transitions=False)
+    undefined_self_transitions = State("self-transitions")
+
+    assert self_transitions.transition_set.allow_null_transition
+    assert not no_self_transitions.transition_set.allow_null_transition
+    assert not undefined_self_transitions.transition_set.allow_null_transition
+
+
 def test_transition():
     done_state = State("done")
     start_state = State("start")


### PR DESCRIPTION
## Enable states to allow self transitions in the constructor
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-4440](https://jira.ihme.washington.edu/browse/MIC-4440)

- enable states to allow self transitions in the constructor so we don't need to make a dedicated call to `state.allow_self_transitions() when defining a disease model.
- removed unused import

### Testing
Added new test