### PR TITLE
support creating population views with custom query filters

### DIFF
--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -96,6 +96,15 @@ class Component(ABC):
         return []
 
     @property
+    def population_view_query(self) -> Optional[str]:
+        """
+        A pandas query string to use to filter the component's `PopulationView`.
+
+        None if no filtering is desired.
+        """
+        return None
+
+    @property
     def post_setup_priority(self) -> int:
         """The priority of this component's post_setup listener if it exists."""
         return DEFAULT_EVENT_PRIORITY
@@ -175,7 +184,9 @@ class Component(ABC):
             population_view_columns = None
 
         if population_view_columns is not None:
-            self.population_view = builder.population.get_view(population_view_columns)
+            self.population_view = builder.population.get_view(
+                population_view_columns, self.population_view_query
+            )
 
     def register_post_setup_listener(self, builder: "Builder") -> None:
         """Registers a post_setup listener if this component has defined one."""

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -231,7 +231,7 @@ class PopulationManager:
             if query is None:
                 query = "tracked == True"
             elif "tracked" not in query:
-                query += "and tracked == True"
+                query += " and tracked == True"
         self._last_id += 1
         return PopulationView(self, self._last_id, columns, query)
 

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 
@@ -43,6 +43,12 @@ class AllColumnsRequirer(Component):
     @property
     def columns_required(self) -> List[str]:
         return []
+
+
+class FilteredPopulationView(ColumnRequirer):
+    @property
+    def population_view_query(self) -> Optional[str]:
+        return "test_column_1 == 5"
 
 
 class NoPopulationView(Component):
@@ -174,6 +180,14 @@ def test_component_that_requires_all_columns_population_view():
 
     assert component.population_view is not None
     assert set(component.population_view.columns) == set(expected_columns)
+
+
+def test_component_with_filtered_population_view():
+    component = FilteredPopulationView()
+    InteractiveContext(components=[ColumnCreator(), component])
+
+    # Assert population view is being filtered using the desired query
+    assert component.population_view.query == "test_column_1 == 5 and tracked == True"
 
 
 def test_component_with_no_population_view():


### PR DESCRIPTION
## Support creating population views with custom query filters
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-4452](https://jira.ihme.washington.edu/browse/MIC-4452)

Changes
- Adds population view query property that is used to create the population view
- Fixes bug in population view query filter usage that didn't have a leading space when adding the tracked filter to columns lacking the tracked column.

### Testing
Added automated tests