### PR TITLE
Use Vivarium Components in unit tests

### DIFF
--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -96,6 +96,15 @@ class Component(ABC):
         return []
 
     @property
+    def population_view_query(self) -> Optional[str]:
+        """
+        A pandas query string to use to filter the component's `PopulationView`.
+
+        None if no filtering is desired.
+        """
+        return None
+
+    @property
     def post_setup_priority(self) -> int:
         """The priority of this component's post_setup listener if it exists."""
         return DEFAULT_EVENT_PRIORITY
@@ -175,7 +184,9 @@ class Component(ABC):
             population_view_columns = None
 
         if population_view_columns is not None:
-            self.population_view = builder.population.get_view(population_view_columns)
+            self.population_view = builder.population.get_view(
+                population_view_columns, self.population_view_query
+            )
 
     def register_post_setup_listener(self, builder: "Builder") -> None:
         """Registers a post_setup listener if this component has defined one."""

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -28,7 +28,7 @@ class Component(ABC):
     A dictionary containing the defaults for any configurations managed by this
     component.
     """
-    configuration_defaults = {}
+    CONFIGURATION_DEFAULTS: Dict[str, Any] = {}
 
     def __repr__(self):
         """A string representation of the __init__ call made to create this object"""
@@ -70,6 +70,14 @@ class Component(ABC):
     def sub_components(self) -> List["Component"]:
         """A list of the components that are managed by this component."""
         return self._sub_components
+
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        """
+        A dictionary containing the defaults for any configurations managed by
+        this component.
+        """
+        return self.CONFIGURATION_DEFAULTS
 
     @property
     def columns_created(self) -> List[str]:

--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -169,20 +169,20 @@ class DiseaseModel(Machine):
     # Event-driven methods #
     ########################
 
-    def on_initialize_simulants(self, pop_data: SimulantData):
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         condition_column = pd.Series(
             self.initial_state, index=pop_data.index, name=self.state_column
         )
         self.population_view.update(condition_column)
 
-    def on_time_step(self, event: Event):
+    def on_time_step(self, event: Event) -> None:
         self.transition(event.index, event.time)
 
     ##################################
     # Pipeline sources and modifiers #
     ##################################
 
-    def delete_cause_specific_mortality(self, index: pd.Index, rates: pd.Series):
+    def delete_cause_specific_mortality(self, index: pd.Index, rates: pd.Series) -> pd.Series:
         return rates - self.cause_specific_mortality_rate(index)
 
     def metrics(self, index: pd.Index, metrics: Dict[str, Any]):

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -8,7 +8,7 @@ The manager and :ref:`builder <builder_concept>` interface for the
 
 """
 from types import MethodType
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import pandas as pd
 
@@ -279,7 +279,7 @@ class PopulationManager:
             "column", list(creates_columns), initializer, dependencies
         )
 
-    def get_simulant_creator(self) -> Callable:
+    def get_simulant_creator(self) -> Callable[[int, Optional[Dict[str, Any]]], pd.Index]:
         """Gets a function that can generate new simulants.
 
         Returns
@@ -408,7 +408,7 @@ class PopulationInterface:
         """
         return self._manager.get_view(columns, query)
 
-    def get_simulant_creator(self) -> Callable[[int, Union[Dict[str, Any], None]], pd.Index]:
+    def get_simulant_creator(self) -> Callable[[int, Optional[Dict[str, Any]]], pd.Index]:
         """Gets a function that can generate new simulants.
 
         Returns

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -231,7 +231,7 @@ class PopulationManager:
             if query is None:
                 query = "tracked == True"
             elif "tracked" not in query:
-                query += "and tracked == True"
+                query += " and tracked == True"
         self._last_id += 1
         return PopulationView(self, self._last_id, columns, query)
 

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -111,7 +111,7 @@ def _process_trigger(trigger):
         raise ValueError("Invalid trigger state provided: {}".format(trigger))
 
 
-class Transition:
+class Transition(Component):
     """A process by which an entity might change into a particular state.
 
     Parameters
@@ -126,6 +126,10 @@ class Transition:
 
     """
 
+    #####################
+    # Lifecycle methods #
+    #####################
+
     def __init__(
         self,
         input_state: "State",
@@ -135,18 +139,15 @@ class Transition:
         ),
         triggered=Trigger.NOT_TRIGGERED,
     ):
+        super().__init__()
         self.input_state = input_state
         self.output_state = output_state
         self._probability = probability_func
         self._active_index, self.start_active = _process_trigger(triggered)
 
-    @property
-    def name(self) -> str:
-        transition_type = self.__class__.__name__.lower()
-        return f"{transition_type}.{self.input_state.name}.{self.output_state.name}"
-
-    def setup(self, builder: "Builder") -> None:
-        pass
+    ##################
+    # Public methods #
+    ##################
 
     def set_active(self, index: pd.Index) -> None:
         if self._active_index is None:
@@ -174,10 +175,6 @@ class Transition:
         activated = pd.Series(self._probability(activated_index), index=activated_index)
         null = pd.Series(np.zeros(len(null_index), dtype=float), index=null_index)
         return activated.append(null)
-
-    def __repr__(self):
-        c = self.__class__.__name__
-        return f"{c}({self.input_state}, {self.output_state})"
 
 
 class State(Component):

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -180,7 +180,7 @@ class Transition:
         return f"{c}({self.input_state}, {self.output_state})"
 
 
-class State:
+class State(Component):
     """An abstract representation of a particular position in a state space.
 
     Attributes
@@ -192,7 +192,12 @@ class State:
 
     """
 
+    #####################
+    # Lifecycle methods #
+    #####################
+
     def __init__(self, state_id: str, allow_self_transitions: bool = False):
+        super().__init__()
         self.state_id = state_id
         self.transition_set = TransitionSet(
             self.name, allow_null_transition=allow_self_transitions
@@ -200,17 +205,9 @@ class State:
         self._model = None
         self._sub_components = [self.transition_set]
 
-    @property
-    def name(self) -> str:
-        state_type = self.__class__.__name__.lower()
-        return f"{state_type}.{self.state_id}"
-
-    @property
-    def sub_components(self) -> List:
-        return self._sub_components
-
-    def setup(self, builder: "Builder") -> None:
-        pass
+    ##################
+    # Public methods #
+    ##################
 
     def set_model(self, model_name: str) -> None:
         """Defines the column name for the model this state belongs to"""
@@ -268,6 +265,11 @@ class State:
         ----------
         output
             The end state after the transition.
+        probability_func
+            Function to be used to determine the probability of exiting this
+            state by means of this transition
+        triggered
+            The triggered state this transition should be initialized with
 
         Returns
         -------
@@ -282,15 +284,15 @@ class State:
     def allow_self_transitions(self) -> None:
         self.transition_set.allow_null_transition = True
 
+    ##################
+    # Helper methods #
+    ##################
+
     def _transition_side_effect(self, index: pd.Index, event_time: "Time") -> None:
         pass
 
     def _cleanup_effect(self, index: pd.Index, event_time: "Time") -> None:
         pass
-
-    def __repr__(self):
-        c = self.__class__.__name__
-        return f"{c}({self.state_id})"
 
 
 class Transient:
@@ -300,8 +302,7 @@ class Transient:
 
 
 class TransientState(State, Transient):
-    def __repr__(self):
-        return f"TransientState({self.state_id})"
+    pass
 
 
 class TransitionSet:

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -131,7 +131,7 @@ class Transition:
         input_state: "State",
         output_state: "State",
         probability_func: Callable[[pd.Index], pd.Series] = lambda index: pd.Series(
-            1, index=index
+            1.0, index=index
         ),
         triggered=Trigger.NOT_TRIGGERED,
     ):
@@ -254,10 +254,10 @@ class State(Component):
 
         """
         population_view.update(pd.Series(self.state_id, index=index))
-        self._transition_side_effect(index, event_time)
+        self.transition_side_effect(index, event_time)
 
     def cleanup_effect(self, index: pd.Index, event_time: "Time") -> None:
-        self._cleanup_effect(index, event_time)
+        pass
 
     def add_transition(self, transition: Transition) -> None:
         """Adds a transition to this state and its `TransitionSet`.
@@ -277,10 +277,7 @@ class State(Component):
     # Helper methods #
     ##################
 
-    def _transition_side_effect(self, index: pd.Index, event_time: "Time") -> None:
-        pass
-
-    def _cleanup_effect(self, index: pd.Index, event_time: "Time") -> None:
+    def transition_side_effect(self, index: pd.Index, event_time: "Time") -> None:
         pass
 
 

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -196,11 +196,11 @@ class State(Component):
     # Lifecycle methods #
     #####################
 
-    def __init__(self, state_id: str, allow_self_transitions: bool = False):
+    def __init__(self, state_id: str, allow_self_transition: bool = False):
         super().__init__()
         self.state_id = state_id
         self.transition_set = TransitionSet(
-            self.name, allow_null_transition=allow_self_transitions
+            self.name, allow_null_transition=allow_self_transition
         )
         self._model = None
         self._sub_components = [self.transition_set]

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -192,6 +192,14 @@ class State(Component):
 
     """
 
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def model(self) -> str:
+        return self._model
+
     #####################
     # Lifecycle methods #
     #####################
@@ -251,35 +259,16 @@ class State(Component):
     def cleanup_effect(self, index: pd.Index, event_time: "Time") -> None:
         self._cleanup_effect(index, event_time)
 
-    def add_transition(
-        self,
-        output: "State",
-        probability_func: Callable[[pd.Index], pd.Series] = lambda index: pd.Series(
-            1.0, index=index
-        ),
-        triggered=Trigger.NOT_TRIGGERED,
-    ) -> Transition:
-        """Builds a transition from this state to the given state.
+    def add_transition(self, transition: Transition) -> None:
+        """Adds a transition to this state and its `TransitionSet`.
 
         Parameters
         ----------
-        output
-            The end state after the transition.
-        probability_func
-            Function to be used to determine the probability of exiting this
-            state by means of this transition
-        triggered
-            The triggered state this transition should be initialized with
-
-        Returns
-        -------
-        Transition
-            The created transition object.
+        transition
+            The transition to add
 
         """
-        t = Transition(self, output, probability_func=probability_func, triggered=triggered)
-        self.transition_set.append(t)
-        return t
+        self.transition_set.append(transition)
 
     def allow_self_transitions(self) -> None:
         self.transition_set.allow_null_transition = True

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -208,7 +208,7 @@ class State(Component):
         super().__init__()
         self.state_id = state_id
         self.transition_set = TransitionSet(
-            self.name, allow_null_transition=allow_self_transition
+            self.name, allow_self_transition=allow_self_transition
         )
         self._model = None
         self._sub_components = [self.transition_set]
@@ -291,7 +291,7 @@ class TransientState(State, Transient):
     pass
 
 
-class TransitionSet:
+class TransitionSet(Component):
     """A container for state machine transitions.
 
     Parameters
@@ -302,26 +302,32 @@ class TransitionSet:
     iterable
         Any iterable whose elements are `Transition` objects.
     allow_null_transition
+        Specified whether it is possible not to transition on a given time-step
 
     """
 
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def name(self) -> str:
+        return f"transition_set.{self.state_name}"
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
     def __init__(
-        self, state_name: str, *transitions: Transition, allow_null_transition: bool = False
+        self, state_name: str, *transitions: Transition, allow_self_transition: bool = False
     ):
-        self._state_name = state_name
-        self.allow_null_transition = allow_null_transition
+        super().__init__()
+        self.state_name = state_name
+        self.allow_null_transition = allow_self_transition
         self.transitions = []
         self._sub_components = self.transitions
 
         self.extend(transitions)
-
-    @property
-    def name(self) -> str:
-        return f"transition_set.{self._state_name}"
-
-    @property
-    def sub_components(self) -> List:
-        return self._sub_components
 
     def setup(self, builder: "Builder") -> None:
         """Performs this component's simulation setup and return sub-components.
@@ -333,7 +339,12 @@ class TransitionSet:
             number generation, in particular.
 
         """
+        super().setup(builder)
         self.random = builder.randomness.get_stream(self.name)
+
+    ##################
+    # Public methods #
+    ##################
 
     def choose_new_state(self, index: pd.Index) -> Tuple[List, pd.Series]:
         """Chooses a new state for each simulant in the index.
@@ -361,6 +372,22 @@ class TransitionSet:
         probabilities = np.transpose(probabilities)
         outputs, probabilities = self._normalize_probabilities(outputs, probabilities)
         return outputs, self.random.choice(index, outputs, probabilities)
+
+    def append(self, transition: Transition) -> None:
+        if not isinstance(transition, Transition):
+            raise TypeError(
+                "TransitionSet must contain only Transition objects. "
+                f"Check constructor arguments: {self}"
+            )
+        self.transitions.append(transition)
+
+    def extend(self, transitions: Iterable[Transition]) -> None:
+        for transition in transitions:
+            self.append(transition)
+
+    ##################
+    # Helper methods #
+    ##################
 
     def _normalize_probabilities(self, outputs, probabilities):
         """Normalize probabilities to sum to 1 and add a null transition.
@@ -418,27 +445,11 @@ class TransitionSet:
 
         return outputs, probabilities
 
-    def append(self, transition: Transition) -> None:
-        if not isinstance(transition, Transition):
-            raise TypeError(
-                "TransitionSet must contain only Transition objects. Check constructor arguments: {}".format(
-                    self
-                )
-            )
-        self.transitions.append(transition)
-
-    def extend(self, transitions: Iterable[Transition]) -> None:
-        for transition in transitions:
-            self.append(transition)
-
     def __iter__(self):
         return iter(self.transitions)
 
     def __len__(self):
         return len(self.transitions)
-
-    def __repr__(self):
-        return f"TransitionSet(transitions={[x for x in self.transitions]})"
 
     def __hash__(self):
         return hash(id(self))

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -7,10 +7,12 @@ A state machine implementation for use in ``vivarium`` simulations.
 
 """
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+
+from vivarium import Component
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
@@ -455,7 +457,7 @@ class TransitionSet:
         return hash(id(self))
 
 
-class Machine:
+class Machine(Component):
     """A collection of states and transitions between those states.
 
     Attributes
@@ -469,23 +471,32 @@ class Machine:
 
     """
 
-    def __init__(self, state_column: str, states: Iterable[State] = ()):
-        self.states = []
-        self.state_column = state_column
-        if states:
-            self.add_states(states)
-
-    @property
-    def name(self) -> str:
-        machine_type = self.__class__.__name__.lower()
-        return f"{machine_type}.{self.state_column}"
+    ##############
+    # Properties #
+    ##############
 
     @property
     def sub_components(self):
         return self.states
 
-    def setup(self, builder: "Builder") -> None:
-        self.population_view = builder.population.get_view([self.state_column])
+    @property
+    def columns_required(self) -> Optional[List[str]]:
+        return [self.state_column]
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
+    def __init__(self, state_column: str, states: Iterable[State] = ()):
+        super().__init__()
+        self.states = []
+        self.state_column = state_column
+        if states:
+            self.add_states(states)
+
+    ##################
+    # Public methods #
+    ##################
 
     def add_states(self, states: Iterable[State]) -> None:
         for state in states:
@@ -523,5 +534,16 @@ class Machine:
             for state in self.states
         ]
 
-    def __repr__(self):
-        return f"Machine(state_column= {self.state_column})"
+    ##################
+    # Helper methods #
+    ##################
+
+    def get_initialization_parameters(self) -> Dict[str, Any]:
+        """
+        Gets the values of the state column specified in the __init__`.
+
+        Note: this retrieves the value of the attribute at the time of calling
+        which is not guaranteed to be the same as the original value.
+        """
+
+        return {"state_column": self.state_column}

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -7,16 +7,21 @@ Utility functions and classes to make testing ``vivarium`` components easier.
 
 """
 from pathlib import Path
+from typing import List
 
 import numpy as np
 import pandas as pd
 
+from vivarium import Component
 from vivarium.framework import randomness
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+from vivarium.framework.population import SimulantData
 from vivarium.framework.randomness.index_map import IndexMap
 
 
-class NonCRNTestPopulation:
-    configuration_defaults = {
+class NonCRNTestPopulation(Component):
+    CONFIGURATION_DEFAULTS = {
         "population": {
             "age_start": 0,
             "age_end": 100,
@@ -25,24 +30,17 @@ class NonCRNTestPopulation:
     }
 
     @property
-    def name(self):
-        return "non_crn_test_population"
+    def columns_created(self) -> List[str]:
+        return ["age", "sex", "location", "alive", "entrance_time", "exit_time"]
 
-    def setup(self, builder):
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
         self.config = builder.configuration
         self.randomness = builder.randomness.get_stream(
             "population_age_fuzz", initializes_crn_attributes=True
         )
-        columns = ["age", "sex", "location", "alive", "entrance_time", "exit_time"]
-        self.population_view = builder.population.get_view(columns)
 
-        builder.population.initializes_simulants(
-            self.generate_test_population, creates_columns=columns
-        )
-
-        builder.event.register_listener("time_step", self.age_simulants)
-
-    def generate_test_population(self, pop_data):
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         age_start = pop_data.user_data.get("age_start", self.config.population.age_start)
         age_end = pop_data.user_data.get("age_end", self.config.population.age_end)
         location = self.config.input_data.location
@@ -58,25 +56,21 @@ class NonCRNTestPopulation:
         )
         self.population_view.update(population)
 
-    def age_simulants(self, event):
+    def on_time_step(self, event: Event) -> None:
         population = self.population_view.get(event.index, query="alive == 'alive'")
         population["age"] += event.step_size / pd.Timedelta(days=365)
         self.population_view.update(population)
 
 
 class TestPopulation(NonCRNTestPopulation):
-    @property
-    def name(self):
-        return "test_population"
-
-    def setup(self, builder):
+    def setup(self, builder: Builder) -> None:
         super().setup(builder)
         self.age_randomness = builder.randomness.get_stream(
             "age_initialization", initializes_crn_attributes=True
         )
         self.register = builder.randomness.register_simulants
 
-    def generate_test_population(self, pop_data):
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         age_start = pop_data.user_data.get("age_start", self.config.population.age_start)
         age_end = pop_data.user_data.get("age_end", self.config.population.age_end)
         age_draw = self.age_randomness.get_draw(pop_data.index)

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -1,32 +1,43 @@
-class MockComponentA:
+from typing import Any, Dict
+
+from vivarium import Component
+from vivarium.framework.engine import Builder
+from vivarium.framework.event import Event
+
+
+class MockComponentA(Component):
+
+    @property
+    def name(self) -> str:
+        return self._name
+
     def __init__(self, *args, name="mock_component_a"):
-        self.name = name
-        self.args = args
-        self.builder_used_for_setup = None
-
-    def __eq__(self, other):
-        return type(self) == type(other) and self.name == other.name
-
-
-class MockComponentB:
-    def __init__(self, *args, name="mock_component_b"):
+        super().__init__()
         self._name = name
         self.args = args
         self.builder_used_for_setup = None
-        self._sub_components = []
+
+    def __eq__(self, other: Any) -> bool:
+        return type(self) == type(other) and self.name == other.name
+
+
+class MockComponentB(Component):
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __init__(self, *args, name="mock_component_b"):
+        super().__init__()
+        self._name = name
+        self.args = args
+        self.builder_used_for_setup = None
         if len(self.args) > 1:
             for arg in self.args:
                 self._sub_components.append(MockComponentB(arg, name=arg))
 
-    @property
-    def name(self):
-        return self._name
-
-    @property
-    def sub_components(self):
-        return self._sub_components
-
-    def setup(self, builder):
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
         self.builder_used_for_setup = builder
         builder.value.register_value_modifier("metrics", self.metrics)
 
@@ -37,12 +48,12 @@ class MockComponentB:
             metrics["test"] = 1
         return metrics
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return type(self) == type(other) and self.name == other.name
 
 
-class MockGenericComponent:
-    configuration_defaults = {
+class MockGenericComponent(Component):
+    CONFIGURATION_DEFAULTS = {
         "component": {
             "key1": "val",
             "key2": {
@@ -53,59 +64,54 @@ class MockGenericComponent:
         }
     }
 
-    def __init__(self, name):
-        self.name = name
-        self.configuration_defaults = {
-            self.name: MockGenericComponent.configuration_defaults["component"]
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        return {
+            self.name: self.CONFIGURATION_DEFAULTS["component"]
         }
+
+    def __init__(self, name: str):
+        super().__init__()
+        self._name = name
         self.builder_used_for_setup = None
 
-    def setup(self, builder):
+    def setup(self, builder: Builder) -> None:
+        super().setup(builder)
         self.builder_used_for_setup = builder
         self.config = builder.configuration[self.name]
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return type(self) == type(other) and self.name == other.name
-
-
-class NamelessComponent:
-    def __init__(self, *args):
-        self.args = args
 
 
 class Listener(MockComponentB):
     def __init__(self, *args, name="test_listener"):
         super().__init__(*args, name=name)
         self.post_setup_called = False
-        self.time_step__prepare_called = False
+        self.time_step_prepare_called = False
         self.time_step_called = False
-        self.time_step__cleanup_called = False
+        self.time_step_cleanup_called = False
         self.collect_metrics_called = False
         self.simulation_end_called = False
 
-    def setup(self, builder):
-        super().setup(builder)
-        builder.event.register_listener("post_setup", self.on_post_setup)
-        builder.event.register_listener("time_step__prepare", self.on_time_step__prepare)
-        builder.event.register_listener("time_step", self.on_time_step)
-        builder.event.register_listener("time_step__cleanup", self.on_time_step__cleanup)
-        builder.event.register_listener("collect_metrics", self.on_collect_metrics)
-        builder.event.register_listener("simulation_end", self.on_simulation_end)
-
-    def on_post_setup(self, _):
+    def on_post_setup(self, event: Event) -> None:
         self.post_setup_called = True
 
-    def on_time_step__prepare(self, _):
-        self.time_step__prepare_called = True
+    def on_time_step_prepare(self, event: Event) -> None:
+        self.time_step_prepare_called = True
 
-    def on_time_step(self, _):
+    def on_time_step(self, event: Event) -> None:
         self.time_step_called = True
 
-    def on_time_step__cleanup(self, _):
-        self.time_step__cleanup_called = True
+    def on_time_step_cleanup(self, event: Event) -> None:
+        self.time_step_cleanup_called = True
 
-    def on_collect_metrics(self, _):
+    def on_collect_metrics(self, event: Event) -> None:
         self.collect_metrics_called = True
 
-    def on_simulation_end(self, _):
+    def on_simulation_end(self, event: Event) -> None:
         self.simulation_end_called = True

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -6,7 +6,6 @@ from vivarium.framework.event import Event
 
 
 class MockComponentA(Component):
-
     @property
     def name(self) -> str:
         return self._name
@@ -22,7 +21,6 @@ class MockComponentA(Component):
 
 
 class MockComponentB(Component):
-
     @property
     def name(self) -> str:
         return self._name
@@ -70,9 +68,7 @@ class MockGenericComponent(Component):
 
     @property
     def configuration_defaults(self) -> Dict[str, Any]:
-        return {
-            self.name: self.CONFIGURATION_DEFAULTS["component"]
-        }
+        return {self.name: self.CONFIGURATION_DEFAULTS["component"]}
 
     def __init__(self, name: str):
         super().__init__()

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import pandas as pd
 
@@ -43,6 +43,12 @@ class AllColumnsRequirer(Component):
     @property
     def columns_required(self) -> List[str]:
         return []
+
+
+class FilteredPopulationView(ColumnRequirer):
+    @property
+    def population_view_query(self) -> Optional[str]:
+        return "test_column_1 == 5"
 
 
 class NoPopulationView(Component):
@@ -174,6 +180,14 @@ def test_component_that_requires_all_columns_population_view():
 
     assert component.population_view is not None
     assert set(component.population_view.columns) == set(expected_columns)
+
+
+def test_component_with_filtered_population_view():
+    component = FilteredPopulationView()
+    InteractiveContext(components=[ColumnCreator(), component])
+
+    # Assert population view is being filtered using the desired query
+    assert component.population_view.query == "test_column_1 == 5 and tracked == True"
 
 
 def test_component_with_no_population_view():

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -55,14 +55,18 @@ class NoPopulationView(Component):
     pass
 
 
-class ParameterizedNoName(Component):
-    def __repr__(self):
-        return f"ParameterizedNoName({self.parameter_one}, {self.parameter_two})"
-
-    def __init__(self, parameter_one: str, parameter_two: int):
+class Parameterized(Component):
+    def __init__(self, p_one: str, p_two: int, p_three: str):
         super().__init__()
-        self.parameter_one = parameter_one
-        self.parameter_two = parameter_two
+        self.p_one = p_one
+        self.p_two = p_two
+        self._p_three = p_three
+
+
+class ParameterizedByComponent(Component):
+    def __init__(self, param: Parameterized):
+        super().__init__()
+        self.param = param
 
 
 class DefaultPriorities(Component):
@@ -119,10 +123,19 @@ def test_unique_component_has_correct_repr():
 
 
 def test_parameterized_component_has_repr_that_incorporates_arguments():
-    component = ParameterizedNoName("some_value", 5)
+    component = Parameterized("some_value", 5, "another_value")
 
-    # Assert component has the correct name
-    assert component.__repr__() == "ParameterizedNoName(some_value, 5)"
+    # Assert component has the correct repr
+    assert component.__repr__() == "Parameterized(p_one=some_value, p_two=5)"
+
+
+def test_component_by_other_component_has_repr_that_incorporates_arguments():
+    arg = Parameterized("some_value", 5, "another_value")
+    component = ParameterizedByComponent(arg)
+
+    # Assert component has the correct repr
+    expected_repr = "ParameterizedByComponent(param=Parameterized(p_one=some_value, p_two=5))"
+    assert component.__repr__() == expected_repr
 
 
 def test_component_with_no_arguments_has_correct_name():
@@ -133,10 +146,19 @@ def test_component_with_no_arguments_has_correct_name():
 
 
 def test_parameterized_component_has_name_that_incorporates_arguments():
-    component = ParameterizedNoName("some_value", 5)
+    component = Parameterized("some_value", 5, "another_value")
 
     # Assert component has the correct name
-    assert component.name == "parameterized_no_name.some_value.5"
+    assert component.name == "parameterized.some_value.5"
+
+
+def test_component_by_other_component_has_name_that_incorporates_arguments():
+    arg = Parameterized("some_value", 5, "another_value")
+    component = ParameterizedByComponent(arg)
+
+    # Assert component has the correct repr
+    expected = "parameterized_by_component.'parameterized.some_value.5'"
+    assert component.name == expected
 
 
 def test_component_that_creates_columns_population_view():

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import pytest
 
 from vivarium.framework.components.manager import (
@@ -7,15 +9,10 @@ from vivarium.framework.components.manager import (
 )
 from vivarium.framework.configuration import build_simulation_configuration
 
-from .mocks import (
-    MockComponentA,
-    MockComponentB,
-    MockGenericComponent,
-    NamelessComponent,
-)
+from .mocks import MockComponentA, MockComponentB, MockGenericComponent
 
 
-def test_ComponentSet_add():
+def test_component_set_add():
     component_list = OrderedComponentSet()
 
     component_0 = MockComponentA(name="component_0")
@@ -28,12 +25,8 @@ def test_ComponentSet_add():
     with pytest.raises(ComponentConfigError, match="duplicate name"):
         component_list.add(component_0)
 
-    # no name
-    with pytest.raises(ComponentConfigError, match="no name"):
-        component_list.add(NamelessComponent())
 
-
-def test_ComponentSet_update():
+def test_component_set_update():
     component_list = OrderedComponentSet()
 
     components = [MockComponentA(name="component_0"), MockComponentA("component_1")]
@@ -42,11 +35,9 @@ def test_ComponentSet_update():
 
     with pytest.raises(ComponentConfigError, match="duplicate name"):
         component_list.update(components)
-    with pytest.raises(ComponentConfigError, match="no name"):
-        component_list.update([NamelessComponent()])
 
 
-def test_ComponentSet_initialization():
+def test_component_set_initialization():
     component_1 = MockComponentA()
     component_2 = MockComponentB()
 
@@ -54,7 +45,7 @@ def test_ComponentSet_initialization():
     assert component_list.components == [component_1, component_2]
 
 
-def test_ComponentSet_pop():
+def test_component_set_pop():
     component = MockComponentA()
     component_list = OrderedComponentSet(component)
 
@@ -65,7 +56,7 @@ def test_ComponentSet_pop():
         component_list.pop()
 
 
-def test_ComponentSet_contains():
+def test_component_set_contains():
     component_list = OrderedComponentSet()
 
     assert not bool(component_list)
@@ -80,10 +71,10 @@ def test_ComponentSet_contains():
     assert component_3 not in component_list
 
     with pytest.raises(ComponentConfigError, match="no name"):
-        throwaway = 10 in component_list
+        _ = 10 in component_list
 
 
-def test_ComponentSet_eq():
+def test_component_set_eq():
     component_1 = MockComponentA()
     component_2 = MockComponentB()
     component_list = OrderedComponentSet(component_1, component_2)
@@ -95,7 +86,7 @@ def test_ComponentSet_eq():
     assert component_list != second_list
 
 
-def test_ComponentSet_bool_len():
+def test_component_set_bool_len():
     component_list = OrderedComponentSet()
 
     assert not bool(component_list)
@@ -109,7 +100,7 @@ def test_ComponentSet_bool_len():
     assert len(component_list) == 2
 
 
-def test_ComponentSet_dunder_add():
+def test_component_set_dunder_add():
     l1 = OrderedComponentSet(*[MockComponentA(name=str(i)) for i in range(5)])
     l2 = OrderedComponentSet(*[MockComponentA(name=str(i)) for i in range(5, 10)])
     combined = OrderedComponentSet(*[MockComponentA(name=str(i)) for i in range(10)])
@@ -166,7 +157,7 @@ def test_flatten_with_nested_sub_components():
         if depth == 1:
             return MockComponentA(name=str(start))
         c = MockComponentA(name=str(start))
-        c.sub_components = [nest(start + 1, depth - 1)]
+        c._sub_components = [nest(start + 1, depth - 1)]
         return c
 
     components = []
@@ -219,7 +210,7 @@ def test_apply_configuration_defaults_no_op():
 
 def test_apply_configuration_defaults_duplicate():
     config = build_simulation_configuration()
-    c = config.to_dict()
+
     cm = ComponentManager()
     cm.configuration = config
     component = MockGenericComponent("test_component")
@@ -231,13 +222,17 @@ def test_apply_configuration_defaults_duplicate():
 
 
 def test_apply_configuration_defaults_bad_structure():
+    class BadConfigComponent(MockComponentA):
+        @property
+        def configuration_defaults(self) -> Dict[str, Any]:
+            return {"test_component": "val"}
+
     config = build_simulation_configuration()
-    c = config.to_dict()
+
     cm = ComponentManager()
     cm.configuration = config
     component1 = MockGenericComponent("test_component")
-    component2 = MockComponentA(name="test_component2")
-    component2.configuration_defaults = {"test_component": "val"}
+    component2 = BadConfigComponent(name="test_component2")
 
     cm.apply_configuration_defaults(component1)
     cm._components.add(component1)
@@ -267,7 +262,7 @@ def test_add_components():
     "components",
     ([MockComponentA("Eric"), MockComponentB("half", "a", "bee")], [MockComponentA("Eric")]),
 )
-def test_ComponentManager_add_components(components):
+def test_component_manager_add_components(components):
     config = build_simulation_configuration()
     cm = ComponentManager()
     cm.configuration = config
@@ -288,7 +283,7 @@ def test_ComponentManager_add_components(components):
         [MockComponentA(), MockComponentA(), MockComponentB("foo", "bar")],
     ),
 )
-def test_ComponentManager_add_components_duplicated(components):
+def test_component_manager_add_components_duplicated(components):
     config = build_simulation_configuration()
     cm = ComponentManager()
     cm.configuration = config
@@ -299,21 +294,4 @@ def test_ComponentManager_add_components_duplicated(components):
     cm = ComponentManager()
     cm.configuration = config
     with pytest.raises(ComponentConfigError, match="duplicate name"):
-        cm.add_components(components)
-
-
-@pytest.mark.parametrize(
-    "components", ([NamelessComponent()], [NamelessComponent(), MockComponentA()])
-)
-def test_ComponentManager_add_components_unnamed(components):
-    config = build_simulation_configuration()
-    cm = ComponentManager()
-    cm.configuration = config
-    with pytest.raises(ComponentConfigError, match="no name"):
-        cm.add_managers(components)
-
-    config = build_simulation_configuration()
-    cm = ComponentManager()
-    cm.configuration = config
-    with pytest.raises(ComponentConfigError, match="no name"):
         cm.add_components(components)

--- a/tests/framework/population/test_manager.py
+++ b/tests/framework/population/test_manager.py
@@ -66,6 +66,13 @@ def test_initializer_set_duplicate_columns():
         component_set.add(component2.initializer, ["sneaky_column"] + columns)
 
 
+def test_initializer_set_population_manager():
+    component_set = InitializerComponentSet()
+    population_manager = PopulationManager()
+
+    component_set.add(population_manager.on_initialize_simulants, ["tracked"])
+
+
 def test_initializer_set():
     component_set = InitializerComponentSet()
     for i in range(10):

--- a/tests/framework/randomness/test_manager.py
+++ b/tests/framework/randomness/test_manager.py
@@ -10,7 +10,7 @@ def mock_clock():
     return pd.Timestamp("1/1/2005")
 
 
-def test_RandomnessManager_get_randomness_stream():
+def test_randomness_manager_get_randomness_stream():
     seed = 123456
 
     rm = RandomnessManager()
@@ -28,7 +28,7 @@ def test_RandomnessManager_get_randomness_stream():
         rm.get_randomness_stream("test")
 
 
-def test_RandomnessManager_register_simulants():
+def test_randomness_manager_register_simulants():
     seed = 123456
     rm = RandomnessManager()
     rm._add_constraint = lambda f, **kwargs: f

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -202,17 +202,17 @@ def test_SimulationContext_step(SimulationContext, log, base_config, components)
 
     listener = [c for c in components if "listener" in c.args][0]
 
-    assert not listener.time_step__prepare_called
+    assert not listener.time_step_prepare_called
     assert not listener.time_step_called
-    assert not listener.time_step__cleanup_called
+    assert not listener.time_step_cleanup_called
     assert not listener.collect_metrics_called
 
     sim.step()
 
     assert log.debug.called_once_with(current_time)
-    assert listener.time_step__prepare_called
+    assert listener.time_step_prepare_called
     assert listener.time_step_called
-    assert listener.time_step__cleanup_called
+    assert listener.time_step_cleanup_called
     assert listener.collect_metrics_called
 
     assert sim._clock.time == current_time + step_size

--- a/tests/framework/test_resource.py
+++ b/tests/framework/test_resource.py
@@ -12,7 +12,6 @@ from vivarium.framework.resource import (
 
 
 class RsesourceProducer(Component):
-
     @property
     def name(self) -> str:
         return self._name

--- a/tests/framework/test_resource.py
+++ b/tests/framework/test_resource.py
@@ -1,6 +1,7 @@
 import networkx as nx
 import pytest
 
+from vivarium import Component
 from vivarium.framework.resource import (
     NULL_RESOURCE_TYPE,
     RESOURCE_TYPES,
@@ -10,16 +11,22 @@ from vivarium.framework.resource import (
 )
 
 
-class Component:
-    def __init__(self, name):
-        self.name = name
+class RsesourceProducer(Component):
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __init__(self, name: str):
+        super().__init__()
+        self._name = name
 
     def producer(self):
         return "resources!"
 
 
 def test_resource_group():
-    c = Component("base")
+    c = RsesourceProducer("base")
     r_type = "column"
     r_names = [str(i) for i in range(5)]
     r_producer = c.producer
@@ -36,7 +43,7 @@ def test_resource_group():
 
 def test_resource_manager_get_resource_group():
     rm = ResourceManager()
-    c = Component("base")
+    c = RsesourceProducer("base")
     r_type = "column"
     r_names = [str(i) for i in range(5)]
     r_producer = c.producer
@@ -53,7 +60,7 @@ def test_resource_manager_get_resource_group():
 
 def test_resource_manager_get_resource_group_null():
     rm = ResourceManager()
-    c = Component("base")
+    c = RsesourceProducer("base")
     r_type = "column"
     r_names = []
     r_producer = c.producer
@@ -70,7 +77,7 @@ def test_resource_manager_get_resource_group_null():
 
 def test_resource_manager_add_resources_bad_type():
     rm = ResourceManager()
-    c = Component("base")
+    c = RsesourceProducer("base")
     r_type = "unknown"
     r_names = [str(i) for i in range(5)]
     r_producer = c.producer
@@ -82,8 +89,8 @@ def test_resource_manager_add_resources_bad_type():
 
 def test_resource_manager_add_resources_multiple_producers():
     rm = ResourceManager()
-    c1 = Component("1")
-    c2 = Component("2")
+    c1 = RsesourceProducer("1")
+    c2 = RsesourceProducer("2")
     r_type = "column"
     r1_names = [str(i) for i in range(5)]
     r2_names = [str(i) for i in range(5, 10)] + ["1"]
@@ -101,7 +108,7 @@ def test_resource_manager_add_resources():
     for r_type in RESOURCE_TYPES:
         old_names = []
         for i in range(5):
-            c = Component(f"r_type_{i}")
+            c = RsesourceProducer(f"r_type_{i}")
             names = [f"r_type_{i}_{j}" for j in range(5)]
             rm.add_resources(r_type, names, c.producer, old_names)
             old_names = names
@@ -109,7 +116,7 @@ def test_resource_manager_add_resources():
 
 def test_resource_manager_sorted_nodes_two_node_cycle():
     rm = ResourceManager()
-    c = Component("test")
+    c = RsesourceProducer("test")
 
     rm.add_resources("column", ["1"], c.producer, ["stream.2"])
     rm.add_resources("stream", ["2"], c.producer, ["column.1"])
@@ -120,7 +127,7 @@ def test_resource_manager_sorted_nodes_two_node_cycle():
 
 def test_resource_manager_sorted_nodes_three_node_cycle():
     rm = ResourceManager()
-    c = Component("test")
+    c = RsesourceProducer("test")
 
     rm.add_resources("column", ["1"], c.producer, ["stream.3"])
     rm.add_resources("stream", ["2"], c.producer, ["column.1"])
@@ -132,7 +139,7 @@ def test_resource_manager_sorted_nodes_three_node_cycle():
 
 def test_resource_manager_sorted_nodes_large_cycle():
     rm = ResourceManager()
-    c = Component("test")
+    c = RsesourceProducer("test")
 
     for i in range(10):
         rm.add_resources("column", [f"{i}"], c.producer, [f"column.{i%10}"])
@@ -143,7 +150,7 @@ def test_resource_manager_sorted_nodes_large_cycle():
 
 def test_resource_manager_sorted_nodes_diamond():
     rm = ResourceManager()
-    c = Component("test")
+    c = RsesourceProducer("test")
 
     rm.add_resources("column", ["1"], c.producer, [])
     rm.add_resources("column", ["2"], c.producer, ["column.1"])

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 import numpy as np
 import pandas as pd
 
-from vivarium import InteractiveContext, Component
+from vivarium import Component, InteractiveContext
 from vivarium.framework.population import SimulantData
 from vivarium.framework.state_machine import Machine, State, Transition
 from vivarium.framework.time import Time

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -1,41 +1,28 @@
+from typing import List, Optional
+
 import numpy as np
 import pandas as pd
 
-from vivarium import InteractiveContext
+from vivarium import InteractiveContext, Component
+from vivarium.framework.population import SimulantData
 from vivarium.framework.state_machine import Machine, State, Transition
+from vivarium.framework.time import Time
 
 
 def _population_fixture(column, initial_value):
-    class PopFixture:
+    class PopFixture(Component):
         @property
-        def name(self):
+        def name(self) -> str:
             return f"test_pop_fixture_{column}_{initial_value}"
 
-        def setup(self, builder):
-            self.population_view = builder.population.get_view([column])
-            builder.population.initializes_simulants(self.inner, creates_columns=[column])
+        @property
+        def columns_created(self) -> List[str]:
+            return [column]
 
-        def inner(self, pop_data):
+        def on_initialize_simulants(self, pop_data: SimulantData) -> None:
             self.population_view.update(pd.Series(initial_value, index=pop_data.index))
 
     return PopFixture()
-
-
-def _even_population_fixture(column, values):
-    class pop_fixture:
-        @property
-        def name(self):
-            return "test_pop_fixture"
-
-        def setup(self, builder):
-            self.randomness = builder.randomness.get_stream(self.name)
-            self.population_view = builder.population.get_view([column])
-            builder.population.initializes_simulants(self.inner, creates_columns=[column])
-
-        def inner(self, pop_data):
-            self.population_view.update(self.randomness.choice(pop_data.index, values))
-
-    return pop_fixture()
 
 
 def test_initialize_allowing_self_transition():
@@ -51,7 +38,7 @@ def test_initialize_allowing_self_transition():
 def test_transition():
     done_state = State("done")
     start_state = State("start")
-    start_state.add_transition(done_state)
+    start_state.add_transition(Transition(start_state, done_state))
     machine = Machine("state", states=[start_state, done_state])
 
     simulation = InteractiveContext(
@@ -70,10 +57,14 @@ def test_choice(base_config):
     b_state = State("b")
     start_state = State("start")
     start_state.add_transition(
-        a_state, probability_func=lambda agents: np.full(len(agents), 0.5)
+        Transition(
+            start_state, a_state, probability_func=lambda agents: np.full(len(agents), 0.5)
+        )
     )
     start_state.add_transition(
-        b_state, probability_func=lambda agents: np.full(len(agents), 0.5)
+        Transition(
+            start_state, b_state, probability_func=lambda agents: np.full(len(agents), 0.5)
+        )
     )
     machine = Machine("state", states=[start_state, a_state, b_state])
 
@@ -93,7 +84,9 @@ def test_null_transition(base_config):
     a_state = State("a")
     start_state = State("start")
     start_state.add_transition(
-        a_state, probability_func=lambda agents: np.full(len(agents), 0.5)
+        Transition(
+            start_state, a_state, probability_func=lambda agents: np.full(len(agents), 0.5)
+        )
     )
     start_state.allow_self_transitions()
 
@@ -138,21 +131,21 @@ def test_no_null_transition(base_config):
 def test_side_effects():
     class DoneState(State):
         @property
-        def name(self):
+        def name(self) -> str:
             return "test_done_state"
 
-        def setup(self, builder):
-            super().setup(builder)
-            self.population_view = builder.population.get_view(["count"])
+        @property
+        def columns_required(self) -> Optional[List[str]]:
+            return ["count"]
 
-        def _transition_side_effect(self, index, event_time):
+        def transition_side_effect(self, index: pd.Index, _: Time) -> None:
             pop = self.population_view.get(index)
             self.population_view.update(pop["count"] + 1)
 
     done_state = DoneState("done")
     start_state = State("start")
-    start_state.add_transition(done_state)
-    done_state.add_transition(start_state)
+    start_state.add_transition(Transition(start_state, done_state))
+    done_state.add_transition(Transition(done_state, start_state))
 
     machine = Machine("state", states=[start_state, done_state])
 

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -39,8 +39,8 @@ def _even_population_fixture(column, values):
 
 
 def test_initialize_allowing_self_transition():
-    self_transitions = State("self-transitions", allow_self_transitions=True)
-    no_self_transitions = State("no-self-transitions", allow_self_transitions=False)
+    self_transitions = State("self-transitions", allow_self_transition=True)
+    no_self_transitions = State("no-self-transitions", allow_self_transition=False)
     undefined_self_transitions = State("self-transitions")
 
     assert self_transitions.transition_set.allow_null_transition


### PR DESCRIPTION
## Use Vivarium Components in unit tests
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: test
- *JIRA issue*: [MIC-4454](https://jira.ihme.washington.edu/browse/MIC-4454)

Changes:
- Use Vivarium Components in unit tests
- Modified configuration defaults to bring it in line with other Component attributes
- Improved typing on the register simulant callable 

### Testing
Ran unit tests. The configuration defaults changes should really be in a different PR, but it would be a pain to move it. It is tested in the example DiseaseModel simulation which will appear in a subsequent PR.

