### PR TITLE
Warn instead of erroring and add logger to components

### DIFF
--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -165,10 +165,12 @@ class Component(ABC):
         self._repr: str = ""
         self._name: str = ""
         self._sub_components: List["Component"] = []
+        self.logger = None
         self.population_view: Optional[PopulationView] = None
 
     def setup(self, builder: "Builder") -> None:
         """Method that vivarium will run during the setup phase."""
+        self.logger = builder.logging.get_logger(self.name)
         self.set_population_view(builder)
         self.register_post_setup_listener(builder)
         self.register_simulant_initializer(builder)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -189,11 +189,14 @@ class SimulationContext:
 
         non_components = [obj for obj in components if not isinstance(obj, Component)]
         if non_components:
-            raise ComponentConfigError(
+            message = (
                 "Attempting to create a simulation with the following components "
                 "that do not inherit from `vivarium.Component`: "
                 f"[{[c.name for c in non_components]}]."
             )
+            self._logger.warning(message)
+            # TODO: raise error once all active Component implementations have been refactored
+            # raise ComponentConfigError(message)
 
         self._lifecycle.add_constraint(self.add_components, allow_during=["initialization"])
         self._lifecycle.add_constraint(

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -76,13 +76,20 @@ class InitializerComponentSet:
             )
         component = initializer.__self__
         # TODO: consider if we can initialize the tracked column with a component instead
-        if not (isinstance(component, Component) or isinstance(component, PopulationManager)):
+        # TODO: raise error once all active Component implementations have been refactored
+        # if not (isinstance(component, Component) or isinstance(component, PopulationManager)):
+        #     raise AttributeError(
+        #         "Population initializers must be methods of vivarium Components "
+        #         "or the simulation's PopulationManager. "
+        #         f"You provided {initializer} which is bound to {component} that "
+        #         f"is of type {type(component)} which does not inherit from "
+        #         "Component."
+        #     )
+        if not hasattr(component, "name"):
             raise AttributeError(
-                "Population initializers must be methods of vivarium Components "
-                "or the simulation's PopulationManager. "
-                f"You provided {initializer} which is bound to {component} that "
-                f"is of type {type(component)} which does not inherit from "
-                "Component."
+                "Population initializers must be methods of named simulation components. "
+                f"You provided {initializer} which is bound to {component} that has no "
+                f"name attribute."
             )
 
         component_name = component.name

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 
+from vivarium import Component
 from vivarium.framework.artifact import ArtifactInterface, ArtifactManager
 from vivarium.framework.components import (
     ComponentConfigError,
@@ -50,12 +51,14 @@ def log(mocker):
     return mocker.patch("vivarium.framework.logging.manager.logger")
 
 
-def test_simulation_with_non_components(SimulationContext, components: List):
+@pytest.mark.xfail
+def test_simulation_with_non_components(SimulationContext, components: List[Component]):
     class NonComponent:
         def __init__(self):
             self.name = "non_component"
 
     with pytest.raises(ComponentConfigError):
+        # noinspection PyTypeChecker
         SimulationContext(components=components + [NonComponent()])
 
 


### PR DESCRIPTION
## Warn instead of erroring and add logger to components
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature/revert
- *JIRA issue*: [MIC-4486](https://jira.ihme.washington.edu/browse/MIC-4486)

Changes:
-  Add logger to components
- Warn instead of failing if components in a simulation don't inherit from Component

### Testing
Tests pass