### PR TITLE
Make ConfigTree objects pickleable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.5 - 09/05/23**
+
+ - Update ConfigTree to make it pickleable; raise NotImplementedError on equality calls
+
 **1.2.4 - 09/01/23**
 
  - Create LookupTableData type alias for the source data to LookupTables

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -589,3 +589,6 @@ class ConfigTree:
                 for name, c in self._children.items()
             ]
         )
+
+    def __eq__(self, other):
+        raise NotImplementedError

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -513,11 +513,16 @@ class ConfigTree:
 
     def __setattr__(self, name, value):
         """Set a value on the outermost layer."""
-        # https://stackoverflow.com/a/50888571/
-        if name.startswith("__") and name.endswith("__"):
-            raise AttributeError
-
         if name not in self:
+            if name.startswith("__") and name.endswith("__"):
+                # Note that we allow keys that look like dunder attributes,
+                # they just raise a different error when you try to access ones
+                # that don't exist (as attributes).
+                # This is important because it is expected by some modules,
+                # in particular the pickle module.
+                # https://stackoverflow.com/a/50888571/
+                raise AttributeError
+
             raise ConfigurationKeyError(
                 "New configuration keys can only be created with the update method.",
                 self._name,
@@ -535,8 +540,13 @@ class ConfigTree:
 
     def __getattr__(self, name):
         """Get a value from the outermost layer in which it appears."""
-        # https://stackoverflow.com/a/50888571/
-        if name.startswith("__") and name.endswith("__"):
+        if name not in self and name.startswith("__") and name.endswith("__"):
+            # Note that we allow keys that look like dunder attributes,
+            # they just raise a different error when you try to access ones
+            # that don't exist (as attributes).
+            # This is important because it is expected by some modules,
+            # in particular the pickle module.
+            # https://stackoverflow.com/a/50888571/
             raise AttributeError
 
         return self.get_from_layer(name)

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -513,6 +513,9 @@ class ConfigTree:
 
     def __setattr__(self, name, value):
         """Set a value on the outermost layer."""
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError
+
         if name not in self:
             raise ConfigurationKeyError(
                 "New configuration keys can only be created with the update method.",
@@ -531,6 +534,9 @@ class ConfigTree:
 
     def __getattr__(self, name):
         """Get a value from the outermost layer in which it appears."""
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError
+
         return self.get_from_layer(name)
 
     def __getitem__(self, name):

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -513,6 +513,7 @@ class ConfigTree:
 
     def __setattr__(self, name, value):
         """Set a value on the outermost layer."""
+        # https://stackoverflow.com/a/50888571/
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError
 
@@ -534,6 +535,7 @@ class ConfigTree:
 
     def __getattr__(self, name):
         """Get a value from the outermost layer in which it appears."""
+        # https://stackoverflow.com/a/50888571/
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError
 

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -440,12 +440,14 @@ def test_to_dict_yaml(test_spec):
     assert yaml_config == config.to_dict()
 
 
-@pytest.mark.xfail(reason="Not yet implemented")
 def test_equals():
-    test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
-    config = ConfigTree(test_dict)
-    config2 = ConfigTree(test_dict.copy())
-    assert config == config2
+    # TODO: Assert should succeed, instead of raising, once equality is
+    # implemented for ConfigTrees
+    with pytest.raises(NotImplementedError):
+        test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
+        config = ConfigTree(test_dict)
+        config2 = ConfigTree(test_dict.copy())
+        assert config == config2
 
 
 def test_to_from_pickle():

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -440,10 +440,29 @@ def test_to_dict_yaml(test_spec):
     assert yaml_config == config.to_dict()
 
 
-def test_to_from_pickle():
+@pytest.mark.xfail(reason="Not yet implemented")
+def test_equals():
     test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
     config = ConfigTree(test_dict)
-    assert pickle.loads(pickle.dumps(config)).to_dict() == test_dict
+    config2 = ConfigTree(test_dict.copy())
+    assert config == config2
+
+
+def test_to_from_pickle():
+    test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
+    second_layer = {"configuration": {"time": {"start": {"year": 2001}}}}
+    config = ConfigTree(test_dict, layers=["first_layer", "second_layer"])
+    config.update(second_layer, layer="second_layer")
+    unpickled = pickle.loads(pickle.dumps(config))
+
+    # We can't just assert unpickled == config because
+    # equals doesn't work with our custom attribute
+    # accessor scheme (also why pickling didn't use to work).
+    # See the previous xfailed test.
+    assert unpickled.to_dict() == config.to_dict()
+    assert unpickled._frozen == config._frozen
+    assert unpickled._name == config._name
+    assert unpickled._layers == config._layers
 
 
 def test_freeze():

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -1,3 +1,4 @@
+import pickle
 import textwrap
 
 import pytest
@@ -437,6 +438,12 @@ def test_to_dict_yaml(test_spec):
     with test_spec.open() as f:
         yaml_config = yaml.full_load(f)
     assert yaml_config == config.to_dict()
+
+
+def test_to_from_pickle():
+    test_dict = {"configuration": {"time": {"start": {"year": 2000}}}}
+    config = ConfigTree(test_dict)
+    assert pickle.loads(pickle.dumps(config)).to_dict() == test_dict
 
 
 def test_freeze():


### PR DESCRIPTION
## Make ConfigTree objects pickleable
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: N/A

Changes:
- ConfigTree objects are now pickleable
- Equality doesn't work on ConfigTrees. Rather than just always returning False, we now throw a `NotImplementedError` 

### Testing
Automated testing added.