### PR TITLE
Mic-4382/lint-before-tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[dev]
+      - name: Lint
+        run: |
+          pip install black==22.3.0 isort
+          black . --check --diff
+          isort . --check --verbose --only-modified --diff
       - name: Test
         run: |
           pytest ./tests
@@ -36,8 +41,3 @@ jobs:
       - name: Doctest
         run: |
           make doctest -C docs/
-      - name: Lint
-        run: |
-          pip install black==22.3.0 isort
-          black . --check --diff
-          isort . --check --verbose --only-modified --diff

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,3 @@
-**1.2.6 - 09/05/23**
-
- - Update to run linting before tests for builds.
-
 **1.2.5 - 09/05/23**
 
  - Update ConfigTree to make it pickleable; raise NotImplementedError on equality calls

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.6 - 09/05/23**
+
+ - Update to run linting before tests for builds.
+
 **1.2.5 - 09/05/23**
 
  - Update ConfigTree to make it pickleable; raise NotImplementedError on equality calls


### PR DESCRIPTION
## Mic-4382/lint-before-tests

### Switches order linting and tests for builds.
- *Category*: Other
- *JIRA issue*: [MIC-4382](https://jira.ihme.washington.edu/browse/MIC-4382)

-switches order of linting and tests for builds.

### Testing
Successfully ran builds with new order.

