### PR TITLE
Fix nasty bug in Component repr and name

### DIFF
--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -34,12 +34,15 @@ class Component(ABC):
         """A string representation of the __init__ call made to create this object"""
         if not self._repr:
             args = [
-                f"{name}={value}"
+                f"{name}={value.__repr__() if isinstance(value, Component) else value}"
                 for name, value in self.get_initialization_parameters().items()
             ]
             args = ", ".join(args)
             self._repr = f"{type(self).__name__}({args})"
 
+        return self._repr
+
+    def __str__(self):
         return self._repr
 
     ##############

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -31,7 +31,13 @@ class Component(ABC):
     CONFIGURATION_DEFAULTS: Dict[str, Any] = {}
 
     def __repr__(self):
-        """A string representation of the __init__ call made to create this object"""
+        """
+        A string representation of the __init__ call made to create this object.
+
+        IMPORTANT: this property must not be accessed within this component or
+        its subclasses' `__init__` functions or its value may not be initialized
+        correctly.
+        """
         if not self._repr:
             args = [
                 f"{name}={value.__repr__() if isinstance(value, Component) else value}"
@@ -56,6 +62,10 @@ class Component(ABC):
         arguments of the `__init__` appended separated by '.'.
 
         Names must be unique within a simulation.
+
+        IMPORTANT: this property must not be accessed within this component or
+        its subclasses' `__init__` functions or its value may not be initialized
+        correctly.
         """
         if not self._name:
             base_name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", type(self).__name__)

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -205,7 +205,7 @@ class State(Component):
         super().__init__()
         self.state_id = state_id
         self.transition_set = TransitionSet(
-            self.name, allow_self_transition=allow_self_transition
+            self.state_id, allow_self_transition=allow_self_transition
         )
         self._model = None
         self._sub_components = [self.transition_set]
@@ -293,7 +293,7 @@ class TransitionSet(Component):
 
     Parameters
     ----------
-    state_name
+    state_id
         The unique name of the state that instantiated this TransitionSet. Typically
         a string but any object implementing __str__ will do.
     iterable
@@ -309,17 +309,17 @@ class TransitionSet(Component):
 
     @property
     def name(self) -> str:
-        return f"transition_set.{self.state_name}"
+        return f"transition_set.{self.state_id}"
 
     #####################
     # Lifecycle methods #
     #####################
 
     def __init__(
-        self, state_name: str, *transitions: Transition, allow_self_transition: bool = False
+        self, state_id: str, *transitions: Transition, allow_self_transition: bool = False
     ):
         super().__init__()
-        self.state_name = state_name
+        self.state_id = state_id
         self.allow_null_transition = allow_self_transition
         self.transitions = []
         self._sub_components = self.transitions


### PR DESCRIPTION
## Fix nasty bug in Component __repr__ and name
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-4473](https://jira.ihme.washington.edu/browse/MIC-4473)

### Changes and notes
- Remove call to `self.name` during `State`'s `__init__` which was causing names to get set before the uniquely defining attributes have been set on the object. 
- Define a `__str__` method to try to guard against this happening for the `__repr__` as well.

### Testing
This was discovered when working with `BaseDiseaseState` components in VPH. This has now been resolved in that case.