### PR TITLE
Address Pandas >2.0.0 FutureWarnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.6 - 09/14/23**
+
+ - Update state machine to prepare for pandas 2.0
+
 **1.2.5 - 09/05/23**
 
  - Update ConfigTree to make it pickleable; raise NotImplementedError on equality calls

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "numpy",
-        "pandas",
+        "pandas<2.0.0",
         "pyyaml>=5.1",
         "scipy",
         "click",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "numpy",
-        "pandas<2.0.0",
+        "pandas",
         "pyyaml>=5.1",
         "scipy",
         "click",

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -82,7 +82,9 @@ def _groupby_new_state(
         into that state.
 
     """
-    groups = pd.Series(index).groupby(pd.Categorical(decisions.values,categories=outputs),observed=False)
+    groups = pd.Series(index).groupby(
+        pd.Categorical(decisions.values, categories=outputs), observed=False
+    )
     return [(output, pd.Index(sub_group.values)) for output, sub_group in groups]
 
 

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -82,14 +82,8 @@ def _groupby_new_state(
         into that state.
 
     """
-    output_map = {o: i for i, o in enumerate(outputs)}
-    groups = pd.Series(index).groupby([output_map[d] for d in decisions])
-    results = [(outputs[i], pd.Index(sub_group.values)) for i, sub_group in groups]
-    selected_outputs = [o for o, _ in results]
-    for output in outputs:
-        if output not in selected_outputs:
-            results.append((output, pd.Index([])))
-    return results
+    groups = pd.Series(index).groupby(pd.Categorical(decisions.values,categories=outputs),observed=False)
+    return [(output, pd.Index(sub_group.values)) for output, sub_group in groups]
 
 
 class Trigger(Enum):

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -62,6 +62,23 @@ def test_transition():
     assert np.all(simulation.get_population().state == "done")
 
 
+def test_single_transition(base_config):
+    base_config.update(
+        {"population": {"population_size": 1}, "randomness": {"key_columns": []}}
+    )
+    done_state = State("done")
+    start_state = State("start")
+    start_state.add_transition(done_state)
+    machine = Machine("state", states=[start_state, done_state])
+
+    simulation = InteractiveContext(
+        components=[machine, _population_fixture("state", "start")], configuration=base_config
+    )
+    event_time = simulation._clock.time + simulation._clock.step_size
+    machine.transition(simulation.get_population().index, event_time)
+    assert np.all(simulation.get_population().state == "done")
+
+
 def test_choice(base_config):
     base_config.update(
         {"population": {"population_size": 10000}, "randomness": {"key_columns": []}}


### PR DESCRIPTION
## Title: Address Pandas >2.0.0 FutureWarnings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature

- *JIRA issue*: [MIC-4076](https://jira.ihme.washington.edu/browse/MIC-4076)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This fixes an error that arises from a change to how groupby objects return group labels in pandas > 2.0.  From the 
pandas deprecation warning: "A length 1 tuple will be returned when iterating over a groupby with a grouper equal to a list of length 1" We map possible transition states onto integers, group by that mapping, and then try to use it as a list index, which fails if groupby returns a tuple.

It seemed preferable to group more directly, but naive methods of doing so didn't seem to work for one reason or another. However, by grouping by a `pd.Categorical` object (as described in https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html#handling-of-un-observed-categorical-values), we can avoid the list comprehension, as well as obviating the rest of the logic in the method, which is doing the same thing that `observed=False` does. 

It's probably possible to slim this down even more and just get rid of the internal method, but I thought it might be best to leave the structure intact.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
I checked manually in the CVD repository that the method returns identical results (apart from the case where the existing behavior fails), and existing tests for state_machine.py pass.

I added (more like copied) a test for the specific situation where the existing behavior will fail with pandas 2.0 in CVD, that is, if the index passed into `_groupby_new_state` contains a single simulant, the groupby object will return a tuple of length 1 from the output map instead of an integer. It might be better to integrate this into the existing tests somehow, since it is very similar; I'm happy to take opinions/suggestions.