### PR TITLE
Upgrade Pandas to 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.2.7 - 09/14/23**
+
+ - Allow pandas <2.1.0
+
 **1.2.6 - 09/14/23**
 
  - Update state machine to prepare for pandas 2.0

--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -300,8 +300,9 @@ the population as a whole.
     75%           3.744090
     max           4.999967
     Name: age, dtype: float64
+    alive
     alive    100000
-    Name: alive, dtype: int64
+    Name: count, dtype: int64
     count    100000.000000
     mean          0.499756
     std           0.288412
@@ -311,15 +312,19 @@ the population as a whole.
     75%           0.749215
     max           0.999978
     Name: child_wasting_propensity, dtype: float64
+    lower_respiratory_infections
     susceptible_to_lower_respiratory_infections    100000
-    Name: lower_respiratory_infections, dtype: int64
+    Name: count, dtype: int64
+    entrance_time
     2021-12-31 12:00:00    100000
-    Name: entrance_time, dtype: int64
+    Name: count, dtype: int64
+    sex
     Male      50185
     Female    49815
-    Name: sex, dtype: int64
+    Name: count, dtype: int64
+    tracked
     True    100000
-    Name: tracked, dtype: int64
+    Name: count, dtype: int64
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "numpy",
-        "pandas",
+        "pandas<2.1.0",
         "pyyaml>=5.1",
         "scipy",
         "click",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "numpy",
-        "pandas<2.0.0",
+        "pandas",
         "pyyaml>=5.1",
         "scipy",
         "click",


### PR DESCRIPTION
## Upgrade Pandas 2.0
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
misc?
- *JIRA issue*: [MIC-4542](https://jira.ihme.washington.edu/browse/MIC-4542)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
to unpin pandas in vivarium, we first need to pin to <2.1 and resolve any issues. doctest was failing because the format of value_counts() has changed slightly:

[What’s new in 2.0.0 (April 3, 2023) — pandas 2.0.3 documentation (pydata.org)](https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html#value-counts-sets-the-resulting-name-to-count)

With a fix to the expected doc outputs, CI passes for pandas <2.1.0 
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
CI passes, and we looked into known FutureWarnings, and I don't see any new ones arise in CVD testing.