### PR TITLE
Remove the need for all setup methods to call super

### DIFF
--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -181,9 +181,10 @@ class Component(ABC):
         self.logger = None
         self.population_view: Optional[PopulationView] = None
 
-    def setup(self, builder: "Builder") -> None:
+    def setup_component(self, builder: "Builder") -> None:
         """Method that vivarium will run during the setup phase."""
         self.logger = builder.logging.get_logger(self.name)
+        self.setup(builder)
         self.set_population_view(builder)
         self.register_post_setup_listener(builder)
         self.register_simulant_initializer(builder)
@@ -196,6 +197,13 @@ class Component(ABC):
     #################
     # Setup methods #
     #################
+
+    def setup(self, builder: "Builder") -> None:
+        """
+        Method in which to define custom actions this component needs to run
+        during the setup phase.
+        """
+        pass
 
     def set_population_view(self, builder: "Builder") -> None:
         """

--- a/src/vivarium/examples/boids/location.py
+++ b/src/vivarium/examples/boids/location.py
@@ -9,7 +9,6 @@ from vivarium.framework.population import SimulantData
 
 
 class Location(Component):
-
     ##############
     # Properties #
     ##############
@@ -31,7 +30,6 @@ class Location(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.width = builder.configuration.location.width
         self.height = builder.configuration.location.height
 

--- a/src/vivarium/examples/boids/neighbors.py
+++ b/src/vivarium/examples/boids/neighbors.py
@@ -10,7 +10,6 @@ from vivarium.framework.population import SimulantData
 
 
 class Neighbors(Component):
-
     ##############
     # Properties #
     ##############
@@ -27,7 +26,6 @@ class Neighbors(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.radius = builder.configuration.neighbors.radius
 
         self.neighbors_calculated = False

--- a/src/vivarium/examples/boids/population.py
+++ b/src/vivarium/examples/boids/population.py
@@ -9,7 +9,6 @@ from vivarium.framework.population import SimulantData
 
 
 class Population(Component):
-
     ##############
     # Properties #
     ##############
@@ -30,7 +29,6 @@ class Population(Component):
     #####################
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.colors = builder.configuration.population.colors
 
     ########################

--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -12,7 +12,6 @@ from vivarium.framework.values import list_combiner, union_post_processor
 
 
 class DiseaseTransition(Transition):
-
     #####################
     # Lifecycle methods #
     #####################
@@ -67,7 +66,6 @@ class DiseaseTransition(Transition):
 
 
 class DiseaseState(State):
-
     ##############
     # Properties #
     ##############
@@ -147,7 +145,6 @@ class DiseaseState(State):
 
 
 class DiseaseModel(Machine):
-
     ##############
     # Properties #
     ##############

--- a/src/vivarium/examples/disease_model/intervention.py
+++ b/src/vivarium/examples/disease_model/intervention.py
@@ -32,7 +32,6 @@ class TreatmentIntervention(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         effect_size = builder.configuration[self.intervention].effect_size
         builder.value.register_value_modifier(
             self.affected_value, modifier=self.intervention_effect

--- a/src/vivarium/examples/disease_model/mortality.py
+++ b/src/vivarium/examples/disease_model/mortality.py
@@ -9,7 +9,6 @@ from vivarium.framework.event import Event
 
 
 class Mortality(Component):
-
     ##############
     # Properties #
     ##############
@@ -52,7 +51,6 @@ class Mortality(Component):
         builder :
             Access to simulation tools and subsystems.
         """
-        super().setup(builder)
         self.config = builder.configuration.mortality
         self.randomness = builder.randomness.get_stream("mortality")
 

--- a/src/vivarium/examples/disease_model/observer.py
+++ b/src/vivarium/examples/disease_model/observer.py
@@ -7,7 +7,6 @@ from vivarium.framework.engine import Builder
 
 
 class Observer(Component):
-
     ##############
     # Properties #
     ##############
@@ -30,9 +29,7 @@ class Observer(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.life_expectancy = builder.configuration.mortality.life_expectancy
-
         builder.value.register_value_modifier("metrics", self.metrics)
 
     ##################################

--- a/src/vivarium/examples/disease_model/population.py
+++ b/src/vivarium/examples/disease_model/population.py
@@ -52,7 +52,6 @@ class BasePopulation(Component):
         builder :
             Access to simulation tools and subsystems.
         """
-        super().setup(builder)
         self.config = builder.configuration
 
         self.with_common_random_numbers = bool(self.config.randomness.key_columns)

--- a/src/vivarium/examples/disease_model/risk.py
+++ b/src/vivarium/examples/disease_model/risk.py
@@ -7,7 +7,6 @@ from vivarium.framework.engine import Builder
 
 
 class Risk(Component):
-
     CONFIGURATION_DEFAULTS = {
         "risk": {
             "proportion_exposed": 0.3,
@@ -44,7 +43,6 @@ class Risk(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         proportion_exposed = builder.configuration[self.risk].proportion_exposed
         self.base_exposure_threshold = builder.value.register_value_producer(
             f"{self.risk}.base_proportion_exposed",
@@ -103,7 +101,6 @@ class RiskEffect(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         relative_risk = builder.configuration[self.risk].relative_risk
         self.relative_risk = builder.value.register_value_producer(
             f"{self.risk}.relative_risk",

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -195,7 +195,7 @@ class SimulationContext:
                 f"[{[c.name for c in non_components]}]."
             )
             self._logger.warning(message)
-            # TODO: raise error once all active Component implementations have been refactored
+            # TODO: raise error as part of MIC-4487
             # raise ComponentConfigError(message)
 
         self._lifecycle.add_constraint(self.add_components, allow_during=["initialization"])

--- a/src/vivarium/framework/metrics.py
+++ b/src/vivarium/framework/metrics.py
@@ -9,14 +9,18 @@ The component here is a normal ``vivarium`` component whose only purpose is
 to provide an empty :class:`dict` as the source of the *"Metrics"* pipeline.
 It is included by default in all simulations.
 """
+from typing import TYPE_CHECKING
+
 from vivarium import Component
+
+if TYPE_CHECKING:
+    from vivarium.framework.engine import Builder
 
 
 class Metrics(Component):
     """This class declares a value pipeline that allows other components to store summary metrics."""
 
-    def setup(self, builder):
-        super().setup(builder)
+    def setup(self, builder: "Builder") -> None:
         self.metrics = builder.value.register_value_producer(
             "metrics", source=lambda index: {}
         )

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -336,7 +336,6 @@ class TransitionSet(Component):
             number generation, in particular.
 
         """
-        super().setup(builder)
         self.random = builder.randomness.get_stream(self.name)
 
     ##################

--- a/src/vivarium/manager.py
+++ b/src/vivarium/manager.py
@@ -1,3 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vivarium.framework.engine import Builder
+
+
 class Manager:
     # TODO implement
-    pass
+    def setup(self, builder: "Builder"):
+        pass

--- a/src/vivarium/testing_utilities.py
+++ b/src/vivarium/testing_utilities.py
@@ -34,7 +34,6 @@ class NonCRNTestPopulation(Component):
         return ["age", "sex", "location", "alive", "entrance_time", "exit_time"]
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.config = builder.configuration
         self.randomness = builder.randomness.get_stream(
             "population_age_fuzz", initializes_crn_attributes=True

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -35,7 +35,6 @@ class MockComponentB(Component):
                 self._sub_components.append(MockComponentB(arg, name=arg))
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.builder_used_for_setup = builder
         builder.value.register_value_modifier("metrics", self.metrics)
 
@@ -76,7 +75,6 @@ class MockGenericComponent(Component):
         self.builder_used_for_setup = None
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.builder_used_for_setup = builder
         self.config = builder.configuration[self.name]
 

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -14,7 +14,6 @@ class ColumnCreator(Component):
         return ["test_column_1", "test_column_2", "test_column_3"]
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         builder.value.register_value_producer("pipeline_1", lambda x: x)
         builder.randomness.get_stream("stream_1")
 

--- a/tests/framework/randomness/test_crn.py
+++ b/tests/framework/randomness/test_crn.py
@@ -84,7 +84,6 @@ class BasePopulation(Component):
         self.sims_to_add = sims_to_add
 
     def setup(self, builder: Builder) -> None:
-        super().setup(builder)
         self.register = builder.randomness.register_simulants
         self.randomness_init = builder.randomness.get_stream(
             "crn_init",


### PR DESCRIPTION
## Remove the need for all setup methods to call super
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-4543](https://jira.ihme.washington.edu/browse/MIC-4543)

### Changes
The real changes are all in 3 files: 
- `src/vivarium/component.py`
- `src/vivarium/framework/components/manager.py`
- `src/vivarium/manager.py`

The rest is just removing calls to `super().setup(builder)` and updating typing in one place.

In `component.py`, rename `setup` to `setup_component` and call the new `setup` method which is empty. This has the added benefit of ordering calls better. Previously, we had to make the `super` call later in `setup` for some components, because we needed some code to have run in the component's setup before we could create a population view or register a listener properly. Now we can define the logger first and do the population view creation and listener registration last, like we usually want to.

In `src/vivarium/framework/components/manager.py` we update component setup to call `setup_component` for all components, while continuing to call `setup` for managers (and non-component components, though that will soon not be possible to exist).

In `manager.py` we define an empty `setup` function just so that all managers will have one for the above method.

### Testing
Automated tests pass. Ran US CVD simulation for a few steps