### PR TITLE
datetime and Timestamp are incompatible in run_until

### DIFF
--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -48,14 +48,17 @@ class InteractiveContext(SimulationContext):
         Parameters
         ----------
         step_size
-            An optional size of step to take. Must be the same type as the
+            An optional size of step to take. Must be compatible with the
             simulation clock's step size (usually a pandas.Timedelta).
         """
         old_step_size = self._clock.step_size
         if step_size is not None:
-            if not isinstance(step_size, type(self._clock.step_size)):
+            if not (
+                isinstance(step_size, type(self._clock.step_size))
+                or isinstance(self._clock.step_size, type(step_size))
+            ):
                 raise ValueError(
-                    f"Provided time must be an instance of {type(self._clock.step_size)}"
+                    f"Provided time must be compatible with {type(self._clock.step_size)}"
                 )
             self._clock._step_size = step_size
         super().step()
@@ -84,8 +87,8 @@ class InteractiveContext(SimulationContext):
         Parameters
         ----------
         duration
-            The length of time to run the simulation for. Should be the same
-            type as the simulation clock's step size (usually a pandas
+            The length of time to run the simulation for. Should be compatible
+            with the simulation clock's step size (usually a pandas
             Timedelta).
         with_logging
             Whether or not to log the simulation steps. Only works in an ipython
@@ -107,7 +110,7 @@ class InteractiveContext(SimulationContext):
         end_time
             The time to run the simulation until. The simulation will run until
             its clock is greater than or equal to the provided end time. Must be
-            the same type as the simulation clock's step size (usually a pandas.Timestamp)
+            compatible with the simulation clock's step size (usually a pandas.Timestamp)
 
         with_logging
             Whether or not to log the simulation steps. Only works in an ipython
@@ -119,8 +122,13 @@ class InteractiveContext(SimulationContext):
             The number of steps the simulation took.
 
         """
-        if not isinstance(end_time, type(self._clock.time)):
-            raise ValueError(f"Provided time must be an instance of {type(self._clock.time)}")
+        if not (
+            isinstance(end_time, type(self._clock.time))
+            or isinstance(self._clock.time, type(end_time))
+        ):
+            raise ValueError(
+                f"Provided time must be compatible with {type(self._clock.time)}"
+            )
 
         iterations = int(ceil((end_time - self._clock.time) / self._clock.step_size))
         self.take_steps(number_of_steps=iterations, with_logging=with_logging)
@@ -137,7 +145,7 @@ class InteractiveContext(SimulationContext):
         number_of_steps
             The number of steps to take.
         step_size
-            An optional size of step to take. Must be the same type as the
+            An optional size of step to take. Must be compatible with the
             simulation clock's step size (usually a pandas.Timedelta).
         with_logging
             Whether or not to log the simulation steps. Only works in an ipython

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -106,7 +106,9 @@ class InteractiveContext(SimulationContext):
         ----------
         end_time
             The time to run the simulation until. The simulation will run until
-            its clock is greater than or equal to the provided end time.
+            its clock is greater than or equal to the provided end time. Must be
+            the same type as the simulation clock's step size (usually a pandas.Timestamp)
+
         with_logging
             Whether or not to log the simulation steps. Only works in an ipython
             environment.


### PR DESCRIPTION
##datetime and Timestamp are incompatible in run_until
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
documentation
- *JIRA issue*: [MIC-2706](https://jira.ihme.washington.edu/browse/MIC-2706)

<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The bug as described in MIC-2706 is explicitly coded:

```
if not isinstance(end_time, type(self._clock.time)):            
     raise ValueError(f"Provided time must be an instance of {type(self._clock.time)}") 
```
the clock is a pd.Timestamp, and datetime is not a subclass of Timestamp (namely, the reverse is true)

I see three options, in order of increasing effort:

1. This is working as intended, but needs a simple addition to the docstring in line with elsewhere e.g. ln 88 (
Must be the same type as the simulation clock's step size (usually a pandas.Timedelta)
.)
2. datetime and timestamp are interoperable, so we should just allow for this flexibility (as well as in the other places in `interactive.py` where we enforce the clock type explicitly)
3. We could go even further than (1) and just decide to not support non-pandas datetime clocks and remove datetime/timedelta from Time and Timedelta types. It doesn't seem to me like it would cause any problems, since it should be easy to convert datetime to pandas.Timestamp, and vivarium requires pandas anyway.

My preference would be to just do (1), and this PR is made in that spirit. Would be interested to hear opinions in the comments, if you disagree.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

Made sure that Timestamp and datetime work together, but an integer passed in with a timestamp clock doesn't.