### PR TITLE
Mic-4057/Update ci button

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ Vivarium
 .. image:: https://badge.fury.io/py/vivarium.svg
     :target: https://badge.fury.io/py/vivarium
 
-.. image:: https://travis-ci.org/ihmeuw/vivarium.svg?branch=master
-    :target: https://travis-ci.org/ihmeuw/vivarium
+.. image:: https://github.com/ihmeuw/vivarium/actions/workflows/build.yml/badge.svg?branch=main
+    :target: https://github.com/ihmeuw/vivarium
     :alt: Latest Version
 
 .. image:: https://readthedocs.org/projects/vivarium/badge/?version=latest


### PR DESCRIPTION
## Mic-4057/Update ci button

### Remove Travis CI button and replace it with github workflow badge.
- *Category*: Other
- *JIRA issue*: [MIC-4057](https://jira.ihme.washington.edu/browse/MIC-4057)

-Remove Travis CI button and replace it with github workflow badge.

### Testing


