### PR TITLE
Mic-4381/Add runslow to conftest so deploy will work

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,24 @@ from vivarium.framework.configuration import (
 from vivarium.testing_utilities import metadata
 
 
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
 @pytest.fixture
 def caplog(caplog: LogCaptureFixture):
     handler_id = logger.add(caplog.handler, format="{message}")


### PR DESCRIPTION
## Mic-4381/add runslow markers to confest

### Deploy workflow is failing because we do not have runslow marker set up for test suites.
- *Category*: CI
- *JIRA issue*: [MIC-4381](https://jira.ihme.washington.edu/browse/MIC-4381)

### Changes and notes
-Adds runslow markers to conftest.py

### Testing


