### PR TITLE
Set pipeline's returned Series' name to the pipeline's name

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 <!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
 - *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                    revert, test, release, other/misc -->
-- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)
+- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
 
 ### Changes and notes
 <!-- 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.0.1 - 10/04/23**
+
+ - Set pipeline's returned Series' name to the pipeline's name
+
 **2.0.0 - 09/22/23**
 
  - Create `Component` and `Manager` classes

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -239,6 +239,8 @@ class Pipeline:
             value = self.combiner(value, mutator, *args, **kwargs)
         if self.post_processor and not skip_post_processor:
             return self.post_processor(value, self.manager.step_size())
+        if isinstance(value, pd.Series):
+            value.name = self.name
 
         return value
 

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -55,3 +55,11 @@ def test_contains(manager):
     manager.register_value_producer("test_value", source=lambda: 1)
     assert value in manager
     assert rate not in manager
+
+
+def test_returned_series_name(manager):
+    value = manager.register_value_producer(
+        "test",
+        source=lambda idx: pd.Series(0.0, index=idx),
+    )
+    assert value(pd.Index(range(10))).name == "test"


### PR DESCRIPTION
## Set pipeline's returned Series' name to the pipeline's name
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: [MIC-4594](https://jira.ihme.washington.edu/browse/MIC-4594)

### Changes and notes
Set pipeline's returned Series' name to the pipeline's name

### Testing
Added unit test to cover this case