### PR TITLE
set None as default value for config_node.get_value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 **2.1.0 - 10/12/23**
 
  - Remove explicit support for Python 3.8
+ - Set default value for ConfigNode::get_value to None
 
 **2.0.1 - 10/04/23**
 

--- a/src/vivarium/config_tree.py
+++ b/src/vivarium/config_tree.py
@@ -143,7 +143,7 @@ class ConfigNode:
         """
         self._frozen = True
 
-    def get_value(self, layer: Optional[str]) -> Any:
+    def get_value(self, layer: Optional[str] = None) -> Any:
         """Returns the value at the specified layer.
 
         If no layer is specified, the outermost (highest priority) layer

--- a/tests/config_tree/test_basic_functionality.py
+++ b/tests/config_tree/test_basic_functionality.py
@@ -144,16 +144,20 @@ def test_node_get_value_with_source(full_node):
 
 def test_node_get_value_empty(empty_node):
     with pytest.raises(ConfigurationKeyError):
-        empty_node.get_value(layer=None)
+        empty_node.get_value()
 
     for layer in empty_node._layers:
         with pytest.raises(ConfigurationKeyError):
-            empty_node.get_value(layer=layer)
+            empty_node.get_value()
 
     assert not empty_node.accessed
 
 
 def test_node_get_value(full_node):
+    assert full_node.get_value() == f"test_value_{len(full_node._layers)}"
+    assert full_node.accessed
+    full_node._accessed = False
+
     assert full_node.get_value(layer=None) == f"test_value_{len(full_node._layers)}"
     assert full_node.accessed
     full_node._accessed = False


### PR DESCRIPTION
## Set None as default value for config_node.get_value
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4606

### Changes and notes
- Set None as default argument for `ConfigNode::get_value`

### Testing
Added automated test coverage