### PR TITLE
Refactor ComponentConfigurationParser creating Components as they are parsed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.1 - 10/13/23**
+
+ - Refactor `ComponentConfigurationParser` to create components as they are parsed
+
 **2.1.0 - 10/12/23**
 
  - Remove explicit support for Python 3.8

--- a/src/vivarium/framework/components/parser.py
+++ b/src/vivarium/framework/components/parser.py
@@ -36,7 +36,6 @@ class ParsingError(ComponentConfigError):
 
 
 class ComponentConfigurationParser:
-    # todo update docstring
     """
     Parses component configuration from model specification and initializes
     components.
@@ -120,7 +119,7 @@ class ComponentConfigurationParser:
         return self.process_level(component_config.to_dict(), [])
 
     def process_level(
-        self, level: Union[List[str], Dict[str, Union[Dict, List]]], prefix: List[str]
+        self, level: Union[str, List[str], Dict[str, Union[Dict, List]]], prefix: List[str]
     ) -> List[Component]:
         """Helper function for parsing hierarchical component configuration into a
         flat list of Components.
@@ -174,10 +173,16 @@ class ComponentConfigurationParser:
         if isinstance(level, dict):
             for name, child in level.items():
                 component_list.extend(self.process_level(child, prefix + [name]))
+        elif isinstance(level, list):
+            component_list.extend([self.process_level(child, prefix) for child in level])
+        elif isinstance(level, str):
+            component = self.create_component_from_string(".".join(prefix + [level]))
+            component_list.append(component)
         else:
-            for child in level:
-                component = self.create_component_from_string(".".join(prefix + [child]))
-                component_list.append(component)
+            raise ParsingError(
+                f"Check your configuration. Component {''.join(prefix)}::{level}"
+                " should be a string, list, or dictionary."
+            )
 
         return component_list
 

--- a/src/vivarium/framework/components/parser.py
+++ b/src/vivarium/framework/components/parser.py
@@ -172,9 +172,12 @@ class ComponentConfigurationParser:
         component_list = []
         if isinstance(level, dict):
             for name, child in level.items():
-                component_list.extend(self.process_level(child, prefix + [name]))
+                components = self.process_level(child, prefix + [name])
+                component_list.extend(components)
         elif isinstance(level, list):
-            component_list.extend([self.process_level(child, prefix) for child in level])
+            for child in level:
+                component = self.process_level(child, prefix)
+                component_list.extend(component)
         elif isinstance(level, str):
             component = self.create_component_from_string(".".join(prefix + [level]))
             component_list.append(component)

--- a/tests/framework/components/test_parser.py
+++ b/tests/framework/components/test_parser.py
@@ -14,10 +14,11 @@ from .mocks import MockComponentA, MockComponentB
 
 TEST_COMPONENTS_NESTED = """
 components:
-    ministry.silly_walk:
-       - Prance()
-       - Jump('front_flip')
-       - PratFall('15')
+    ministry:
+        silly_walk:
+           - Prance()
+           - Jump('front_flip')
+           - PratFall('15')
     pet_shop:
        - Parrot()
        - dangerous_animals.Crocodile('gold_tooth', 'teacup', '3.14')


### PR DESCRIPTION
## Refactor ComponentConfigurationParser creating Components as they are parsed
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4597

### Changes and notes
- Refactored all functions to be instance or static method of `ComponentConfigurationParser` (first commit)
- Refactored parser to create components iteratively as they are parsed. 
- Updated unit tests to match new usage

**Note: it may be easier to understand the functionality changes if you exclude the first commit while reviewing.**

### Testing
Automated tests pass. Ran CVD sim with it.

