### PR TITLE
enable RandomnessStream to sample from distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.1 - 10/13/23**
+
+ - Enable RandomnessStream to sample from a distribution
+
 **2.1.0 - 10/12/23**
 
  - Remove explicit support for Python 3.8

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -7,6 +7,9 @@ py:class pandas.core.frame.DataFrame
 py:class pandas.core.series.Series
 py:class pandas.core.generic.PandasObject
 
+#scipy
+py:class scipy.stats._distn_infrastructure.rv_continuous
+
 # loguru
 py:class loguru._logger.Logger
 

--- a/tests/framework/randomness/test_stream.py
+++ b/tests/framework/randomness/test_stream.py
@@ -183,13 +183,13 @@ def test_sample_from_distribution_using_scipy(
 
 def test_sample_from_distribution_using_ppf(index: pd.Index):
     def silly_ppf(x, add, mult):
-        return mult * (x ** 2) + add
+        return mult * (x**2) + add
 
     randomness_stream = RandomnessStream(
         "test", lambda: pd.Timestamp(2020, 1, 1), 1, IndexMap()
     )
     draws = randomness_stream.get_draw(index, "some_key")
-    expected = 2 * (draws ** 2) + 1
+    expected = 2 * (draws**2) + 1
 
     sample = randomness_stream.sample_from_distribution(
         index=index, ppf=silly_ppf, additional_key="some_key", add=1, mult=2

--- a/tests/framework/randomness/test_stream.py
+++ b/tests/framework/randomness/test_stream.py
@@ -1,6 +1,9 @@
+from typing import Dict
+
 import numpy as np
 import pandas as pd
 import pytest
+from scipy import stats
 
 from vivarium.framework.randomness import (
     RESIDUAL_CHOICE,
@@ -133,3 +136,65 @@ def test_choice_with_residuals(randomness_stream, index, choices, weights_with_r
 
         for k, c in count.items():
             assert np.isclose(c / len(index), weights[choices.index(k)], atol=0.01)
+
+
+@pytest.mark.parametrize(
+    "distribution, ppf, error_message",
+    [
+        (None, None, "Either distribution or ppf must be provided"),
+        (stats.norm, lambda x: x, "Only one of distribution or ppf can be provided"),
+    ],
+)
+def test_sample_from_distribution_bad_args(
+    distribution, ppf, error_message, randomness_stream
+):
+    with pytest.raises(ValueError, match=error_message):
+        randomness_stream.sample_from_distribution(
+            index=pd.Index([]),
+            distribution=distribution,
+            ppf=ppf,
+        )
+
+
+@pytest.mark.parametrize(
+    "distribution, params",
+    [
+        (stats.norm, {"loc": 5, "scale": 1}),
+        (stats.beta, {"a": 1, "b": 2}),
+    ],
+)
+def test_sample_from_distribution_using_scipy(
+    index: pd.Index, distribution: stats.rv_continuous, params: Dict
+):
+    randomness_stream = RandomnessStream(
+        "test", lambda: pd.Timestamp(2020, 1, 1), 1, IndexMap()
+    )
+    draws = randomness_stream.get_draw(index, "some_key")
+    expected = distribution.ppf(draws, **params)
+
+    sample = randomness_stream.sample_from_distribution(
+        index=index, distribution=distribution, additional_key="some_key", **params
+    )
+
+    assert isinstance(sample, pd.Series)
+    assert sample.index.equals(index)
+    assert np.allclose(sample, expected)
+
+
+def test_sample_from_distribution_using_ppf(index: pd.Index):
+    def silly_ppf(x, add, mult):
+        return mult * (x ** 2) + add
+
+    randomness_stream = RandomnessStream(
+        "test", lambda: pd.Timestamp(2020, 1, 1), 1, IndexMap()
+    )
+    draws = randomness_stream.get_draw(index, "some_key")
+    expected = 2 * (draws ** 2) + 1
+
+    sample = randomness_stream.sample_from_distribution(
+        index=index, ppf=silly_ppf, additional_key="some_key", add=1, mult=2
+    )
+
+    assert isinstance(sample, pd.Series)
+    assert sample.index.equals(index)
+    assert np.allclose(sample, expected)


### PR DESCRIPTION
## Enable RandomnessStream to sample from distributions
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-3462

### Changes and notes
- Enable RandomnessStream to sample from distributions
- Distributions can either be scipy.stats distributions or defined by a custom ppf function 

### Testing
Added unit tests
