### PR TITLE
refactor lookup tables into a package

### DIFF
--- a/docs/source/api_reference/framework/lookup.rst
+++ b/docs/source/api_reference/framework/lookup.rst
@@ -1,1 +1,0 @@
-.. automodule:: vivarium.framework.lookup

--- a/docs/source/api_reference/framework/lookup/index.rst
+++ b/docs/source/api_reference/framework/lookup/index.rst
@@ -1,0 +1,7 @@
+.. automodule:: vivarium.framework.lookup
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   *

--- a/docs/source/api_reference/framework/lookup/interpolation.rst
+++ b/docs/source/api_reference/framework/lookup/interpolation.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium.framework.lookup.interpolation

--- a/docs/source/api_reference/framework/lookup/manager.rst
+++ b/docs/source/api_reference/framework/lookup/manager.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium.framework.lookup.manager

--- a/docs/source/api_reference/framework/lookup/table.rst
+++ b/docs/source/api_reference/framework/lookup/table.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium.framework.lookup.table

--- a/docs/source/api_reference/interpolation.rst
+++ b/docs/source/api_reference/interpolation.rst
@@ -1,1 +1,0 @@
-.. automodule:: vivarium.interpolation

--- a/docs/source/concepts/lookup.rst
+++ b/docs/source/concepts/lookup.rst
@@ -9,7 +9,7 @@ reasonable way to look at a simulation is to think of it as a task of
 getting the right data and the right random numbers in the appropriate
 place at the appropriate time.  To address the first concern,
 :mod:`vivarium` provides the
-:class:`Lookup Table <vivarium.framework.lookup.LookupTable>` abstraction
+:class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>` abstraction
 to ensure that the right data can be retrieved when it's needed. In
 particular, it attempts to wrap different strategies for constructing
 interpolations or distributions on data such that a user simply needs to
@@ -26,35 +26,35 @@ extended to compositions of of several data-based values by :mod:`vivarium`'s
 The Lookup Table
 ----------------
 
-A :class:`Lookup Table <vivarium.framework.lookup.LookupTable>`
+A :class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>`
 for a quantity is a callable object that is built from
 a scalar value or a :class:`pandas.DataFrame` of data points that describes
 how the quantity varies with other variable(s). It is called with a
 :class:`pandas.Index` as a function parameter which represents a simulated
 population as discussed in the :ref:`population concept <population_concept>`.
-When called, the :class:`Lookup Table <vivarium.framework.lookup.LookupTable>`
+When called, the :class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>`
 simply returns appropriate values of the quantity for the population it was
 passed, interpolating if necessary or extrapolating if configured to. This
 behavior represents the standard interface for asking for data about a
 population in a simulation.
 
 The lookup table system is built in layers. At the top is the
-:class:`Lookup Table <vivarium.framework.lookup.LookupTable>` object which
+:class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>` object which
 is responsible for providing a uniform interface to the user regardless
 of the underlying implementation. From the user's perspective, it takes in
 a data set or scalar value on initialization and then lets them query against
 that data with a population index.
 
 The next layer is selected at initialization time based on the type of data
-provided. The :class:`Lookup Table <vivarium.framework.lookup.LookupTable>`
-picks either a :class:`ScalarTable <vivarium.framework.lookup.ScalarTable>`
+provided. The :class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>`
+picks either a :class:`ScalarTable <vivarium.framework.lookup.table.ScalarTable>`
 if a single value is provided as the data or a
-:class:`InterpolatedTable <vivarium.framework.lookup.InterpolatedTable>` if
+:class:`InterpolatedTable <vivarium.framework.lookup.table.InterpolatedTable>` if
 a :class:`pandas.DataFrame` is provided as the data.
 
 .. note::
 
-   The :class:`InterpolatedTable <vivarium.framework.lookup.InterpolatedTable>`
+   The :class:`InterpolatedTable <vivarium.framework.lookup.table.InterpolatedTable>`
    is a misnomer here. It confuses the data handling strategy with the
    underlying data representation.  A better name would be ``BinnedDataTable``
    to indicate that it wraps data where the continuous parameters are
@@ -64,14 +64,14 @@ a :class:`pandas.DataFrame` is provided as the data.
    parameters are categorical.
 
 If the underlying data is a single value, this is the last layer of
-abstraction. The :class:`ScalarTable <vivarium.framework.lookup.ScalarTable>`
+abstraction. The :class:`ScalarTable <vivarium.framework.lookup.table.ScalarTable>`
 has only one reasonable strategy which is to broadcast the value over
 the population index.  If we have a :class:`pandas.DataFrame` and therefore an
-:class:`InterpolatedTable <vivarium.framework.lookup.InterpolatedTable>`,
+:class:`InterpolatedTable <vivarium.framework.lookup.table.InterpolatedTable>`,
 there are additional layers to the lookup system to allow the user to
 control the strategy for turning the population index into values based on
 the data.  The
-:class:`InterpolatedTable <vivarium.framework.lookup.InterpolatedTable>`
+:class:`InterpolatedTable <vivarium.framework.lookup.table.InterpolatedTable>`
 is then responsible for turning the population index into a set of
 attributes relevant to the value production based on the structure of
 the input data and then providing those attributes to the value production

--- a/src/vivarium/framework/lookup/__init__.py
+++ b/src/vivarium/framework/lookup/__init__.py
@@ -1,0 +1,6 @@
+from vivarium.framework.lookup.manager import LookupTableInterface, LookupTableManager
+from vivarium.framework.lookup.table import (
+    LookupTable,
+    LookupTableData,
+    validate_parameters,
+)

--- a/src/vivarium/framework/lookup/interpolation.py
+++ b/src/vivarium/framework/lookup/interpolation.py
@@ -7,7 +7,6 @@ Provides interpolation algorithms across tabular data for ``vivarium``
 simulations.
 
 """
-import warnings
 from typing import List, Tuple, Union
 
 import numpy as np

--- a/src/vivarium/framework/lookup/manager.py
+++ b/src/vivarium/framework/lookup/manager.py
@@ -1,0 +1,151 @@
+"""
+=============
+Lookup Tables
+=============
+
+Simulations tend to require a large quantity of data to run.  :mod:`vivarium`
+provides the :class:`LookupTable` abstraction to ensure that accurate data can
+be retrieved when it's needed. It's a callable object that takes in a
+population index and returns data specific to the individuals represented by
+that index. See the :ref:`lookup concept note <lookup_concept>` for more.
+
+"""
+from typing import TYPE_CHECKING, List, Tuple, Union
+
+from vivarium.framework.lookup.table import LookupTable, LookupTableData
+from vivarium.manager import Manager
+
+if TYPE_CHECKING:
+    from vivarium.framework.engine import Builder
+
+
+class LookupTableManager(Manager):
+    """Manages complex data in the simulation.
+
+    Notes
+    -----
+    Client code should never access this class directly. Use ``lookup`` on the
+    builder during setup to get references to LookupTable objects.
+
+    """
+
+    configuration_defaults = {
+        "interpolation": {"order": 0, "validate": True, "extrapolate": True}
+    }
+
+    @property
+    def name(self) -> str:
+        return "lookup_table_manager"
+
+    def setup(self, builder: "Builder") -> None:
+        self.tables = {}
+        self._pop_view_builder = builder.population.get_view
+        self.clock = builder.time.clock()
+        self._interpolation_order = builder.configuration.interpolation.order
+        self._extrapolate = builder.configuration.interpolation.extrapolate
+        self._validate = builder.configuration.interpolation.validate
+        self._add_constraint = builder.lifecycle.add_constraint
+
+        builder.lifecycle.add_constraint(self.build_table, allow_during=["setup"])
+
+    def build_table(
+        self,
+        data: LookupTableData,
+        key_columns: Union[List[str], Tuple[str]],
+        parameter_columns: Union[List[str], Tuple[str]],
+        value_columns: Union[List[str], Tuple[str]],
+    ) -> LookupTable:
+        """Construct a lookup table from input data."""
+        table = self._build_table(data, key_columns, parameter_columns, value_columns)
+        self._add_constraint(
+            table._call, restrict_during=["initialization", "setup", "post_setup"]
+        )
+        return table
+
+    def _build_table(
+        self,
+        data: LookupTableData,
+        key_columns: Union[List[str], Tuple[str]],
+        parameter_columns: Union[List[str], Tuple[str]],
+        value_columns: Union[List[str], Tuple[str]],
+    ) -> LookupTable:
+        # We don't want to require explicit names for tables, but giving them
+        # generic names is useful for introspection.
+        table_number = len(self.tables)
+        table = LookupTable(
+            table_number,
+            data,
+            self._pop_view_builder,
+            key_columns,
+            parameter_columns,
+            value_columns,
+            self._interpolation_order,
+            self.clock,
+            self._extrapolate,
+            self._validate,
+        )
+        self.tables[table_number] = table
+        return table
+
+    def __repr__(self) -> str:
+        return "LookupTableManager()"
+
+
+class LookupTableInterface:
+    """The lookup table management system.
+
+    Simulations tend to require a large quantity of data to run. ``vivarium``
+    provides the :class:`Lookup Table <vivarium.framework.lookup.LookupTable>`
+    abstraction to ensure that accurate data can be retrieved when it's needed.
+
+    For more information, see :ref:`here <lookup_concept>`.
+
+    """
+
+    def __init__(self, manager: LookupTableManager):
+        self._manager = manager
+
+    def build_table(
+        self,
+        data: LookupTableData,
+        key_columns: Union[List[str], Tuple[str]] = None,
+        parameter_columns: Union[List[str], Tuple[str]] = None,
+        value_columns: Union[List[str], Tuple[str]] = None,
+    ) -> LookupTable:
+        """Construct a LookupTable from input data.
+
+        If data is a :class:`pandas.DataFrame`, an interpolation function of
+        the order specified in the simulation
+        :term:`configuration <Configuration>` will be calculated for each
+        permutation of the set of key_columns. The columns in parameter_columns
+        will be used as parameters for the interpolation functions which will
+        estimate all remaining columns in the table.
+
+        If data is a number, time, list, or tuple, a scalar table will be
+        constructed with the values in data as the values in each column of
+        the table, named according to value_columns.
+
+
+        Parameters
+        ----------
+        data
+            The source data which will be used to build the resulting
+            :class:`LookupTable`.
+        key_columns
+            Columns used to select between interpolation functions. These
+            should be the non-continuous variables in the data. For example
+            'sex' in data about a population.
+        parameter_columns
+            The columns which contain the parameters to the interpolation
+            functions. These should be the continuous variables. For example
+            'age' in data about a population.
+        value_columns
+            The data columns that will be in the resulting LookupTable. Columns
+            to be interpolated over if interpolation or the names of the columns
+            in the scalar table.
+
+        Returns
+        -------
+            LookupTable
+        """
+        return self._manager.build_table(data, key_columns, parameter_columns, value_columns)

--- a/src/vivarium/framework/lookup/manager.py
+++ b/src/vivarium/framework/lookup/manager.py
@@ -4,10 +4,11 @@ Lookup Tables
 =============
 
 Simulations tend to require a large quantity of data to run.  :mod:`vivarium`
-provides the :class:`LookupTable` abstraction to ensure that accurate data can
-be retrieved when it's needed. It's a callable object that takes in a
-population index and returns data specific to the individuals represented by
-that index. See the :ref:`lookup concept note <lookup_concept>` for more.
+provides the :class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>`
+abstraction to ensure that accurate data can be retrieved when it's needed. It's
+a callable object that takes in a population index and returns data specific to
+the individuals represented by that index. See the
+:ref:`lookup concept note <lookup_concept>` for more.
 
 """
 from typing import TYPE_CHECKING, List, Tuple, Union
@@ -95,7 +96,7 @@ class LookupTableInterface:
     """The lookup table management system.
 
     Simulations tend to require a large quantity of data to run. ``vivarium``
-    provides the :class:`Lookup Table <vivarium.framework.lookup.LookupTable>`
+    provides the :class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>`
     abstraction to ensure that accurate data can be retrieved when it's needed.
 
     For more information, see :ref:`here <lookup_concept>`.
@@ -130,7 +131,7 @@ class LookupTableInterface:
         ----------
         data
             The source data which will be used to build the resulting
-            :class:`LookupTable`.
+            :class:`Lookup Table <vivarium.framework.lookup.table.LookupTable>`.
         key_columns
             Columns used to select between interpolation functions. These
             should be the non-continuous variables in the data. For example

--- a/src/vivarium/framework/lookup/table.py
+++ b/src/vivarium/framework/lookup/table.py
@@ -12,16 +12,12 @@ that index. See the :ref:`lookup concept note <lookup_concept>` for more.
 """
 from datetime import datetime, timedelta
 from numbers import Number
-from typing import TYPE_CHECKING, Callable, List, Tuple, Union
+from typing import Callable, List, Tuple, Union
 
 import pandas as pd
 
+from vivarium.framework.lookup.interpolation import Interpolation
 from vivarium.framework.population import PopulationView
-from vivarium.interpolation import Interpolation
-from vivarium.manager import Manager
-
-if TYPE_CHECKING:
-    from vivarium.framework.engine import Builder
 
 ScalarValue = Union[Number, timedelta, datetime]
 LookupTableData = Union[ScalarValue, pd.DataFrame, List[ScalarValue], Tuple[ScalarValue]]
@@ -311,135 +307,3 @@ def validate_parameters(
                     f"The value columns you supplied: {value_columns} do not match "
                     f"the non-parameter columns in the passed data: {data_value_columns}"
                 )
-
-
-class LookupTableManager(Manager):
-    """Manages complex data in the simulation.
-
-    Notes
-    -----
-    Client code should never access this class directly. Use ``lookup`` on the
-    builder during setup to get references to LookupTable objects.
-
-    """
-
-    configuration_defaults = {
-        "interpolation": {"order": 0, "validate": True, "extrapolate": True}
-    }
-
-    @property
-    def name(self) -> str:
-        return "lookup_table_manager"
-
-    def setup(self, builder: "Builder") -> None:
-        self.tables = {}
-        self._pop_view_builder = builder.population.get_view
-        self.clock = builder.time.clock()
-        self._interpolation_order = builder.configuration.interpolation.order
-        self._extrapolate = builder.configuration.interpolation.extrapolate
-        self._validate = builder.configuration.interpolation.validate
-        self._add_constraint = builder.lifecycle.add_constraint
-
-        builder.lifecycle.add_constraint(self.build_table, allow_during=["setup"])
-
-    def build_table(
-        self,
-        data: LookupTableData,
-        key_columns: Union[List[str], Tuple[str]],
-        parameter_columns: Union[List[str], Tuple[str]],
-        value_columns: Union[List[str], Tuple[str]],
-    ) -> LookupTable:
-        """Construct a lookup table from input data."""
-        table = self._build_table(data, key_columns, parameter_columns, value_columns)
-        self._add_constraint(
-            table._call, restrict_during=["initialization", "setup", "post_setup"]
-        )
-        return table
-
-    def _build_table(
-        self,
-        data: LookupTableData,
-        key_columns: Union[List[str], Tuple[str]],
-        parameter_columns: Union[List[str], Tuple[str]],
-        value_columns: Union[List[str], Tuple[str]],
-    ) -> LookupTable:
-        # We don't want to require explicit names for tables, but giving them
-        # generic names is useful for introspection.
-        table_number = len(self.tables)
-        table = LookupTable(
-            table_number,
-            data,
-            self._pop_view_builder,
-            key_columns,
-            parameter_columns,
-            value_columns,
-            self._interpolation_order,
-            self.clock,
-            self._extrapolate,
-            self._validate,
-        )
-        self.tables[table_number] = table
-        return table
-
-    def __repr__(self) -> str:
-        return "LookupTableManager()"
-
-
-class LookupTableInterface:
-    """The lookup table management system.
-
-    Simulations tend to require a large quantity of data to run. ``vivarium``
-    provides the :class:`Lookup Table <vivarium.framework.lookup.LookupTable>`
-    abstraction to ensure that accurate data can be retrieved when it's needed.
-
-    For more information, see :ref:`here <lookup_concept>`.
-
-    """
-
-    def __init__(self, manager: LookupTableManager):
-        self._manager = manager
-
-    def build_table(
-        self,
-        data: LookupTableData,
-        key_columns: Union[List[str], Tuple[str]] = None,
-        parameter_columns: Union[List[str], Tuple[str]] = None,
-        value_columns: Union[List[str], Tuple[str]] = None,
-    ) -> LookupTable:
-        """Construct a LookupTable from input data.
-
-        If data is a :class:`pandas.DataFrame`, an interpolation function of
-        the order specified in the simulation
-        :term:`configuration <Configuration>` will be calculated for each
-        permutation of the set of key_columns. The columns in parameter_columns
-        will be used as parameters for the interpolation functions which will
-        estimate all remaining columns in the table.
-
-        If data is a number, time, list, or tuple, a scalar table will be
-        constructed with the values in data as the values in each column of
-        the table, named according to value_columns.
-
-
-        Parameters
-        ----------
-        data
-            The source data which will be used to build the resulting
-            :class:`LookupTable`.
-        key_columns
-            Columns used to select between interpolation functions. These
-            should be the non-continuous variables in the data. For example
-            'sex' in data about a population.
-        parameter_columns
-            The columns which contain the parameters to the interpolation
-            functions. These should be the continuous variables. For example
-            'age' in data about a population.
-        value_columns
-            The data columns that will be in the resulting LookupTable. Columns
-            to be interpolated over if interpolation or the names of the columns
-            in the scalar table.
-
-        Returns
-        -------
-            LookupTable
-        """
-        return self._manager.build_table(data, key_columns, parameter_columns, value_columns)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from vivarium.interpolation import (
+from vivarium.framework.lookup.interpolation import (
     Interpolation,
     Order0Interp,
     check_data_complete,


### PR DESCRIPTION
## Refactor lookup tables into a package
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4642

### Changes and notes
- Refactors LookupTable files into a package following the model set by logging, population, etc.
-  No code changes other than moving files and splitting the former `lookup.py` into `manager.py` and `table.py`

### Testing
All tests pass.

