### PR TITLE
refactor setting manager configuration_defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.2.0 - 10/19/23**
+
+ - Refactor Manager configuration defaults
+
 **2.1.1 - 10/13/23**
 
  - Enable RandomnessStream to sample from a distribution

--- a/src/vivarium/framework/artifact/manager.py
+++ b/src/vivarium/framework/artifact/manager.py
@@ -23,7 +23,7 @@ _Filter = Union[str, int, Sequence[int], Sequence[str]]
 class ArtifactManager(Manager):
     """The controller plugin component for managing a data artifact."""
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "input_data": {
             "artifact_path": None,
             "artifact_filter_term": None,

--- a/src/vivarium/framework/lookup.py
+++ b/src/vivarium/framework/lookup.py
@@ -323,7 +323,7 @@ class LookupTableManager(Manager):
 
     """
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "interpolation": {"order": 0, "validate": True, "extrapolate": True}
     }
 

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -119,8 +119,8 @@ class PopulationManager(Manager):
     """Manages the state of the simulated population."""
 
     # TODO: Move the configuration for initial population creation to
-    # user components.
-    configuration_defaults = {
+    #  user components.
+    CONFIGURATION_DEFAULTS = {
         "population": {
             "population_size": 100,
         },

--- a/src/vivarium/framework/randomness/manager.py
+++ b/src/vivarium/framework/randomness/manager.py
@@ -14,7 +14,7 @@ from vivarium.manager import Manager
 class RandomnessManager(Manager):
     """Access point for common random number generation."""
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "randomness": {
             "map_size": 1_000_000,
             "key_columns": [],

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -30,7 +30,7 @@ class ResultsManager(Manager):
     `collect_metrics`).
     """
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "stratification": {
             "default": [],
         }

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -64,7 +64,7 @@ class SimulationClock(Manager):
 class SimpleClock(SimulationClock):
     """A unitless step-count based simulation clock."""
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "time": {
             "start": 0,
             "end": 100,
@@ -92,7 +92,7 @@ def get_time_stamp(time):
 class DateTimeClock(SimulationClock):
     """A date-time based simulation clock."""
 
-    configuration_defaults = {
+    CONFIGURATION_DEFAULTS = {
         "time": {
             "start": {"year": 2005, "month": 7, "day": 2},
             "end": {

--- a/src/vivarium/manager.py
+++ b/src/vivarium/manager.py
@@ -6,13 +6,43 @@ Manager
 A base Manager class to be used to create manager for use in ``vivarium``
 simulations.
 """
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
 
 
 class Manager:
-    # TODO implement
+    CONFIGURATION_DEFAULTS: Dict[str, Any] = {}
+    """
+    A dictionary containing the defaults for any configurations managed by this
+    manager. An empty dictionary indicates no managed configurations.
+    """
+
+    ##############
+    # Properties #
+    ##############
+
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        """
+        Provides a dictionary containing the defaults for any configurations
+        managed by this manager.
+
+        These default values will be stored at the `component_configs` layer of the
+        simulation's ConfigTree.
+
+        Returns
+        -------
+        Dict[str, Any]
+            A dictionary containing the defaults for any configurations managed by
+            this manager.
+        """
+        return self.CONFIGURATION_DEFAULTS
+
+    #####################
+    # Lifecycle methods #
+    #####################
+
     def setup(self, builder: "Builder"):
         pass


### PR DESCRIPTION
## Refactor setting manager configuration_defaults
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4646

### Changes and notes
- Refactor configuration defaults for managers to match configuration defaults of components 

### Testing
Automated tests pass and able to run a simulation.