### PR TITLE
Mic-4384/Notify when cron or deploy builds fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,3 +50,22 @@ jobs:
       - name: Doctest
         run: |
           make doctest -C docs/
+      - name: Send mail
+        # Notify when cron job fails
+        if: (github.event_name == 'schedule' && failure())
+        uses: dawidd6/action-send-mail@v2
+        with:
+          # mail server settings
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.NOTIFY_PASSWORD }}
+          # email subject
+          subject: ${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}
+          # email body as text
+          body: ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has ${{ job.status }}
+          # comma-separated string, send email to
+          to: uw_ihme_simulationscience@uw.edu
+          # from email name
+          from: Dr Manhattan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,4 +68,4 @@ jobs:
           # comma-separated string, send email to
           to: uw_ihme_simulationscience@uw.edu
           # from email name
-          from: Dr Manhattan
+          from: Vivarium Notifications

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,5 +47,5 @@ jobs:
           # comma-separated string, send email to
           to: uw_ihme_simulationscience@uw.edu
           # from email name
-          from: Dr Manhattan
+          from: Vivarium Notifications
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,23 @@ jobs:
         run: |
           python setup.py sdist bdist_wheel
           twine upload dist/*
+      - name: Send mail
+        # Notify when cron job fails
+        if: failure()
+        uses: dawidd6/action-send-mail@v2
+        with:
+          # mail server settings
+          server_address: smtp.gmail.com
+          server_port: 465
+          # user credentials
+          username: ${{ secrets.NOTIFY_EMAIL }}
+          password: ${{ secrets.NOTIFY_PASSWORD }}
+          # email subject
+          subject: ${{ github.job }} job of ${{ github.repository }} has ${{ job.status }}
+          # email body as text
+          body: ${{ github.job }} job in worflow ${{ github.workflow }} of ${{ github.repository }} has ${{ job.status }}
+          # comma-separated string, send email to
+          to: uw_ihme_simulationscience@uw.edu
+          # from email name
+          from: Dr Manhattan
       


### PR DESCRIPTION
## Mic-4384/Notify when cron or deploy builds fail

### Sends email notification if cron workflow actions or deploy fails.
- *Category*: CI
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4384

### Changes and notes
-sends email notification when schedule build or deploy build fails

### Testing
Received email when pushing broken build.

