### PR TITLE
fix ScalarValue import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,8 @@
-**2.2.0 - 10/19/23**
+**2.2.1 - 10/24/23**
+
+ - Hotfix to expose ScalarValue at the lookup package level
+
+**2.2.0 - 10/24/23**
 
  - Refactor Manager configuration defaults
  - Throw an error if simulation attempts to use a component that is not an instance of Component

--- a/src/vivarium/framework/lookup/__init__.py
+++ b/src/vivarium/framework/lookup/__init__.py
@@ -3,4 +3,4 @@ from vivarium.framework.lookup.manager import (
     LookupTableManager,
     validate_build_table_parameters,
 )
-from vivarium.framework.lookup.table import LookupTable, LookupTableData
+from vivarium.framework.lookup.table import LookupTable, LookupTableData, ScalarValue


### PR DESCRIPTION
## Fix ScalarValue import
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4664

### Changes and notes
- Fix import of ScalarValue which causes VPH builds to break 

### Testing
Ran automated tests of both vivarium and vph