### PR TITLE
Individiual Clocks integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,9 +107,11 @@ venv.bak/
 # Pycharm project settings
 .idea/
 
+# Visual Studio Code project settings
+.vscode/
+
 # Local user jupyter notebooks directory
 notebooks/
 
 # Version file
 src/vivarium/_version.py
-

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -237,7 +237,7 @@ class SimulationContext:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
-            pop_to_update = self._clock.aligned_pop(
+            pop_to_update = self._clock.get_active_population(
                 self._population.get_population(True).index,
                 self._clock.event_time,
             )

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -237,7 +237,10 @@ class SimulationContext:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
-            self.time_step_emitters[event](self._population.get_population(True).index)
+            pop_to_update = self._clock.aligned_pop(
+                self._population.get_population(True).index, event.time
+            )
+            self.time_step_emitters[event](pop_to_update.index)
         self._clock.step_forward(self._population.get_population(True).index)
 
     def run(self) -> None:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -238,7 +238,8 @@ class SimulationContext:
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.aligned_pop(
-                self._population.get_population(True).index, self._clock.time + self._clock.step_size
+                self._population.get_population(True).index,
+                self._clock.time + self._clock.step_size,
             )
             self.time_step_emitters[event](pop_to_update.index)
         self._clock.step_forward(self._population.get_population(True).index)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -239,7 +239,7 @@ class SimulationContext:
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.aligned_pop(
                 self._population.get_population(True).index,
-                self._clock.time + self._clock.step_size,
+                self._clock.event_time,
             )
             self.time_step_emitters[event](pop_to_update.index)
         self._clock.step_forward(self._population.get_population(True).index)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -238,7 +238,7 @@ class SimulationContext:
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.aligned_pop(
-                self._population.get_population(True).index, event.time
+                self._population.get_population(True).index, self._clock.time + self._clock.step_size
             )
             self.time_step_emitters[event](pop_to_update.index)
         self._clock.step_forward(self._population.get_population(True).index)

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -236,7 +236,7 @@ class ResultsManager(Manager):
     def _add_resources(self, target: List[str], target_type: SourceType):
         if not len(target):
             return  # do nothing on empty lists
-        target = set(target) - {"event_time", "current_time", "step_size"}
+        target = set(target) - {"event_time", "current_time", "event_step_size"}
         if target_type == SourceType.COLUMN:
             self._required_columns.update(target)
         elif target_type == SourceType.VALUE:
@@ -247,7 +247,7 @@ class ResultsManager(Manager):
             event.index
         )
         population["current_time"] = self.clock()
-        population["step_size"] = event.step_size
+        population["event_step_size"] = event.step_size
         population["event_time"] = self.clock() + event.step_size
         for k, v in event.user_data.items():
             population[k] = v

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -56,7 +56,7 @@ class SimulationClock(Manager):
         if not self._clock_step_size:
             raise ValueError("No step size provided")
         return self._clock_step_size
-    
+
     @property
     def event_time(self) -> Time:
         "Convenience method for event time, or clock + step"

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -84,13 +84,13 @@ class SimulationClock(Manager):
         """The next time each simulant will be updated."""
         if not self.population_view:
             raise ValueError("No population view defined")
-        return self.population_view.subview(["next_event_time"]).get(index)
+        return self.population_view.subview(["next_event_time"]).get(index).squeeze()
 
     def simulant_step_sizes(self, index: pd.Index) -> pd.Series:
         """The step size for each simulant."""
         if not self.population_view:
             raise ValueError("No population view defined")
-        return self.population_view.subview(["step_size"]).get(index)
+        return self.population_view.subview(["step_size"]).get(index).squeeze()
 
     def step_backward(self) -> None:
         """Rewinds the clock by the current step size."""

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -89,13 +89,13 @@ class SimulationClock(Manager):
         """The next time each simulant will be updated."""
         if not self.population_view:
             raise ValueError("No population view defined")
-        return self.population_view.subview(["next_event_time"]).get(index).squeeze()
+        return self.population_view.subview(["next_event_time"]).get(index).squeeze(axis=1)
 
     def simulant_step_sizes(self, index: pd.Index) -> pd.Series:
         """The step size for each simulant."""
         if not self.population_view:
             raise ValueError("No population view defined")
-        return self.population_view.subview(["step_size"]).get(index).squeeze()
+        return self.population_view.subview(["step_size"]).get(index).squeeze(axis=1)
 
     def step_backward(self) -> None:
         """Rewinds the clock by the current step size."""

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -56,6 +56,11 @@ class SimulationClock(Manager):
         if not self._clock_step_size:
             raise ValueError("No step size provided")
         return self._clock_step_size
+    
+    @property
+    def event_time(self) -> Time:
+        "Convenience method for event time, or clock + step"
+        return self.time + self.step_size
 
     def __init__(self):
         self._clock_time = None
@@ -73,7 +78,7 @@ class SimulationClock(Manager):
         """Sets the next_event_time and step_size columns for each simulant"""
         simulant_clocks = pd.DataFrame(
             {
-                "next_event_time": [self.time + self.step_size] * len(pop_data.index),
+                "next_event_time": [self.event_time] * len(pop_data.index),
                 "step_size": [self.step_size] * len(pop_data.index),
             },
             index=pop_data.index,
@@ -98,7 +103,7 @@ class SimulationClock(Manager):
 
     def step_forward(self, index: pd.Index) -> None:
         """Advances the clock by the current step size, and updates aligned simulant clocks."""
-        event_time = self.time + self.step_size
+        event_time = self.event_time
         pop_to_update = self.aligned_pop(index, event_time)
         pop_to_update["next_event_time"] = event_time + pop_to_update["step_size"]
         self.population_view.update(pop_to_update)

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -104,12 +104,12 @@ class SimulationClock(Manager):
     def step_forward(self, index: pd.Index) -> None:
         """Advances the clock by the current step size, and updates aligned simulant clocks."""
         event_time = self.event_time
-        pop_to_update = self.aligned_pop(index, event_time)
+        pop_to_update = self.get_active_population(index, event_time)
         pop_to_update["next_event_time"] = event_time + pop_to_update["step_size"]
         self.population_view.update(pop_to_update)
         self._clock_time += self.step_size
 
-    def aligned_pop(self, index: pd.Index, time: Time):
+    def get_active_population(self, index: pd.Index, time: Time):
         """Gets population that is aligned with global clock"""
         pop = self.population_view.get(index)
         return pop[pop.next_event_time <= time]
@@ -190,8 +190,8 @@ class TimeInterface:
 
     def simulant_next_event_times(self) -> Callable[[pd.Index], pd.Series]:
         """Gets a callable that returns the current simulation step size."""
-        return self._manager.simulant_next_event_times
+        return lambda: self._manager.simulant_next_event_times
 
     def simulant_step_sizes(self) -> Callable[[pd.Index], pd.Series]:
         """Gets a callable that returns the current simulation step size."""
-        return self._manager.simulant_step_sizes
+        return lambda: self._manager.simulant_step_sizes

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -111,12 +111,12 @@ def rescale_post_processor(value: NumberLike, time_step: Union[pd.Timedelta, Cal
 
     """
     if isinstance(time_step, Callable):
-        if not hasattr(value, 'index'):
+        if not hasattr(value, "index"):
             raise ValueError(
                 "Using a rescale post-processor with individual clocks"
                 "requires a pipeline with indexed values."
-                )
-        
+            )
+
         time_step = time_step(value.index).dt
     return from_yearly(value, time_step)
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -87,7 +87,7 @@ def list_combiner(value: List, mutator: Callable, *args: Any, **kwargs: Any) -> 
     return value
 
 
-def rescale_post_processor(value: NumberLike, time_step: Union[pd.Timedelta, pd.Series]):
+def rescale_post_processor(value: NumberLike, time_step: Union[pd.Timedelta, Callable]):
     """Rescales annual rates to time-step appropriate rates.
 
     This should only be used with a simulation using a
@@ -110,8 +110,8 @@ def rescale_post_processor(value: NumberLike, time_step: Union[pd.Timedelta, pd.
         The annual rates rescaled to the size of the current time step size.
 
     """
-    if isinstance(time_step, pd.Series):
-        time_step = time_step.dt
+    if isinstance(time_step, Callable):
+        time_step = time_step(value.index).dt
     return from_yearly(value, time_step)
 
 
@@ -240,7 +240,7 @@ class Pipeline:
         for mutator in self.mutators:
             value = self.combiner(value, mutator, *args, **kwargs)
         if self.post_processor and not skip_post_processor:
-            return self.post_processor(value, self.manager.step_sizes(value.index))
+            return self.post_processor(value, self.manager.step_sizes)
         if isinstance(value, pd.Series):
             value.name = self.name
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -110,9 +110,13 @@ def rescale_post_processor(value: NumberLike, time_step: Union[pd.Timedelta, Cal
         The annual rates rescaled to the size of the current time step size.
 
     """
-    if not value.index:
-        raise ValueError("Rescale post processor requires a pandas index")
     if isinstance(time_step, Callable):
+        if not hasattr(value, 'index'):
+            raise ValueError(
+                "Using a rescale post-processor with individual clocks"
+                "requires a pipeline with indexed values."
+                )
+        
         time_step = time_step(value.index).dt
     return from_yearly(value, time_step)
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -240,7 +240,7 @@ class Pipeline:
         for mutator in self.mutators:
             value = self.combiner(value, mutator, *args, **kwargs)
         if self.post_processor and not skip_post_processor:
-            return self.post_processor(value, self.manager.step_sizes())
+            return self.post_processor(value, self.manager.step_sizes(value.index))
         if isinstance(value, pd.Series):
             value.name = self.name
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -271,7 +271,7 @@ class ValuesManager(Manager):
 
     def setup(self, builder):
         self.logger = builder.logging.get_logger(self.name)
-        self.step_size = builder.time.simulant_step_sizes
+        self.step_size = builder.time.simulant_step_sizes()
         builder.event.register_listener("post_setup", self.on_post_setup)
 
         self.resources = builder.resources

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -112,6 +112,8 @@ def rescale_post_processor(value: NumberLike, time_step: Union[pd.Timedelta, Cal
     """
     if isinstance(time_step, Callable):
         if not hasattr(value, "index"):
+            ## TODO MIC-4665 - Accommodate non-indexed values by using global clock
+            ## Ideally with keyword args
             raise ValueError(
                 "Using a rescale post-processor with individual clocks"
                 "requires a pipeline with indexed values."

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -246,7 +246,7 @@ class Pipeline:
         for mutator in self.mutators:
             value = self.combiner(value, mutator, *args, **kwargs)
         if self.post_processor and not skip_post_processor:
-            return self.post_processor(value, self.manager.step_size)
+            return self.post_processor(value, self.manager.step_size())
         if isinstance(value, pd.Series):
             value.name = self.name
 
@@ -269,7 +269,7 @@ class ValuesManager(Manager):
 
     def setup(self, builder):
         self.logger = builder.logging.get_logger(self.name)
-        self.step_size = builder.time.simulant_step_sizes()
+        self.step_size = builder.time.simulant_step_sizes
         builder.event.register_listener("post_setup", self.on_post_setup)
 
         self.resources = builder.resources

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -91,7 +91,7 @@ class Listener(MockComponentB):
         self.time_step_cleanup_called = False
         self.collect_metrics_called = False
         self.simulation_end_called = False
-        
+
         self.time_step_prepare_index = None
         self.time_step_index = None
         self.time_step_cleanup_index = None

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -91,30 +91,33 @@ class Listener(MockComponentB):
         self.time_step_cleanup_called = False
         self.collect_metrics_called = False
         self.simulation_end_called = False
+        
+        self.event_indexes = {
+            "time_step_prepare": None,
+            "time_step": None,
+            "time_step_cleanup": None,
+            "collect_metrics": None,
+        }
 
-        self.time_step_prepare_index = None
-        self.time_step_index = None
-        self.time_step_cleanup_index = None
-        self.collect_metrics_index = None
 
     def on_post_setup(self, event: Event) -> None:
         self.post_setup_called = True
 
     def on_time_step_prepare(self, event: Event) -> None:
         self.time_step_prepare_called = True
-        self.time_step_prepare_index = event.index
+        self.event_indexes["time_step_prepare"] = event.index
 
     def on_time_step(self, event: Event) -> None:
         self.time_step_called = True
-        self.time_step_index = event.index
+        self.event_indexes["time_step"] = event.index
 
     def on_time_step_cleanup(self, event: Event) -> None:
         self.time_step_cleanup_called = True
-        self.time_step_cleanup_index = event.index
+        self.event_indexes["time_step_cleanup"] = event.index
 
     def on_collect_metrics(self, event: Event) -> None:
         self.collect_metrics_called = True
-        self.collect_metrics_index = event.index
+        self.event_indexes["collect_metrics"] = event.index
 
     def on_simulation_end(self, event: Event) -> None:
         self.simulation_end_called = True

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -91,14 +91,13 @@ class Listener(MockComponentB):
         self.time_step_cleanup_called = False
         self.collect_metrics_called = False
         self.simulation_end_called = False
-        
+
         self.event_indexes = {
             "time_step_prepare": None,
             "time_step": None,
             "time_step_cleanup": None,
             "collect_metrics": None,
         }
-
 
     def on_post_setup(self, event: Event) -> None:
         self.post_setup_called = True

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -91,21 +91,30 @@ class Listener(MockComponentB):
         self.time_step_cleanup_called = False
         self.collect_metrics_called = False
         self.simulation_end_called = False
+        
+        self.time_step_prepare_index = None
+        self.time_step_index = None
+        self.time_step_cleanup_index = None
+        self.collect_metrics_index = None
 
     def on_post_setup(self, event: Event) -> None:
         self.post_setup_called = True
 
     def on_time_step_prepare(self, event: Event) -> None:
         self.time_step_prepare_called = True
+        self.time_step_prepare_index = event.index
 
     def on_time_step(self, event: Event) -> None:
         self.time_step_called = True
+        self.time_step_index = event.index
 
     def on_time_step_cleanup(self, event: Event) -> None:
         self.time_step_cleanup_called = True
+        self.time_step_cleanup_index = event.index
 
     def on_collect_metrics(self, event: Event) -> None:
         self.collect_metrics_called = True
+        self.collect_metrics_index = event.index
 
     def on_simulation_end(self, event: Event) -> None:
         self.simulation_end_called = True

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -243,7 +243,7 @@ def test_gather_results(
     population = BASE_POPULATION.copy()
     # Mock out some extra columns that would be produced by the manager's _prepare_population() method
     population["current_time"] = pd.Timestamp(year=2045, month=1, day=1, hour=12)
-    population["step_size"] = timedelta(days=28)
+    population["event_step_size"] = timedelta(days=28)
     population["event_time"] = pd.Timestamp(year=2045, month=1, day=1, hour=12) + timedelta(
         days=28
     )
@@ -316,7 +316,7 @@ def test_gather_results_partial_stratifications_in_results(
 
     # Mock out some extra columns that would be produced by the manager's _prepare_population() method
     population["current_time"] = pd.Timestamp(year=2045, month=1, day=1, hour=12)
-    population["step_size"] = timedelta(days=28)
+    population["event_step_size"] = timedelta(days=28)
     population["event_time"] = pd.Timestamp(year=2045, month=1, day=1, hour=12) + timedelta(
         days=28
     )

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -167,7 +167,7 @@ def mock__prepare_population(self, event):
 
     # Mock out some extra columns that would be produced by the manager's _prepare_population() method
     population["current_time"] = pd.Timestamp(year=2045, month=1, day=1, hour=12)
-    population["step_size"] = timedelta(days=28)
+    population["event_step_size"] = timedelta(days=28)
     population["event_time"] = pd.Timestamp(year=2045, month=1, day=1, hour=12) + timedelta(
         days=28
     )

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -206,10 +206,7 @@ def test_SimulationContext_initialize_simulants(SimulationContext, base_config, 
     assert len(pop) == pop_size
     assert sim._clock.time == current_time
 
-    assert np.all(
-        sim._clock.simulant_next_event_times(pop.index)
-        == sim._clock.event_time
-    )
+    assert np.all(sim._clock.simulant_next_event_times(pop.index) == sim._clock.event_time)
     assert np.all(sim._clock.simulant_step_sizes(pop.index) == sim._clock.step_size)
 
 
@@ -238,10 +235,7 @@ def test_SimulationContext_step(SimulationContext, log, base_config, components)
     assert listener.collect_metrics_called
 
     assert sim._clock.time == current_time + step_size
-    assert np.all(
-        sim._clock.simulant_next_event_times(pop.index)
-        == sim._clock.event_time
-    )
+    assert np.all(sim._clock.simulant_next_event_times(pop.index) == sim._clock.event_time)
     assert np.all(sim._clock.simulant_step_sizes(pop.index) == sim._clock.step_size)
 
 

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -208,7 +208,7 @@ def test_SimulationContext_initialize_simulants(SimulationContext, base_config, 
 
     assert np.all(
         sim._clock.simulant_next_event_times(pop.index)
-        == sim._clock.time + sim._clock.step_size
+        == sim._clock.event_time
     )
     assert np.all(sim._clock.simulant_step_sizes(pop.index) == sim._clock.step_size)
 
@@ -240,7 +240,7 @@ def test_SimulationContext_step(SimulationContext, log, base_config, components)
     assert sim._clock.time == current_time + step_size
     assert np.all(
         sim._clock.simulant_next_event_times(pop.index)
-        == sim._clock.time + sim._clock.step_size
+        == sim._clock.event_time
     )
     assert np.all(sim._clock.simulant_step_sizes(pop.index) == sim._clock.step_size)
 

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -30,7 +30,7 @@ def test_align_times(SimulationContext, base_config, components):
         len(
             sim._clock.aligned_pop(
                 sim.get_population().index,
-                sim._clock.time + sim._clock.step_size,
+                sim._clock.event_time,
             )
         )
         == pop_size
@@ -42,7 +42,7 @@ def test_align_times(SimulationContext, base_config, components):
         len(
             sim._clock.aligned_pop(
                 sim.get_population().index,
-                sim._clock.time + sim._clock.step_size,
+                sim._clock.event_time,
             )
         )
         == pop_size
@@ -52,7 +52,7 @@ def test_align_times(SimulationContext, base_config, components):
     sim.step()
     # No simulants should be aligned after a step size adjustment
     assert sim._clock.aligned_pop(
-        sim.get_population().index, sim._clock.time + sim._clock.step_size
+        sim.get_population().index, sim._clock.event_time
     ).empty
 
     sim.step()
@@ -61,7 +61,7 @@ def test_align_times(SimulationContext, base_config, components):
         len(
             sim._clock.aligned_pop(
                 sim.get_population().index,
-                sim._clock.time + sim._clock.step_size,
+                sim._clock.event_time,
             )
         )
         == pop_size
@@ -82,7 +82,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
         len(
             sim._clock.aligned_pop(
                 sim.get_population().index,
-                sim._clock.time + sim._clock.step_size,
+                sim._clock.event_time,
             )
         )
         == pop_size - 1
@@ -100,7 +100,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
         len(
             sim._clock.aligned_pop(
                 sim.get_population().index,
-                sim._clock.time + sim._clock.step_size,
+                sim._clock.event_time,
             )
         )
         == pop_size
@@ -122,7 +122,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
         len(
             sim._clock.aligned_pop(
                 sim.get_population().index,
-                sim._clock.time + sim._clock.step_size,
+                sim._clock.event_time,
             )
         )
         == pop_size

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -24,12 +24,12 @@ def test_align_times(SimulationContext, base_config, components):
     sim = SimulationContext(base_config, components)
     sim.setup()
     sim.initialize_simulants()
-    pop_size = len(sim._population.get_population(True))
+    pop_size = len(sim.get_population())
     # After initialization, all simulants should be aligned to event times
     assert (
         len(
             sim._clock.aligned_pop(
-                sim._population.get_population(True).index,
+                sim.get_population().index,
                 sim._clock.time + sim._clock.step_size,
             )
         )
@@ -41,7 +41,7 @@ def test_align_times(SimulationContext, base_config, components):
     assert (
         len(
             sim._clock.aligned_pop(
-                sim._population.get_population(True).index,
+                sim.get_population().index,
                 sim._clock.time + sim._clock.step_size,
             )
         )
@@ -52,7 +52,7 @@ def test_align_times(SimulationContext, base_config, components):
     sim.step()
     # No simulants should be aligned after a step size adjustment
     assert sim._clock.aligned_pop(
-        sim._population.get_population(True).index, sim._clock.time + sim._clock.step_size
+        sim.get_population().index, sim._clock.time + sim._clock.step_size
     ).empty
 
     sim.step()
@@ -60,7 +60,7 @@ def test_align_times(SimulationContext, base_config, components):
     assert (
         len(
             sim._clock.aligned_pop(
-                sim._population.get_population(True).index,
+                sim.get_population().index,
                 sim._clock.time + sim._clock.step_size,
             )
         )
@@ -73,7 +73,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     listener = [c for c in components if "listener" in c.args][0]
     sim.setup()
     sim.initialize_simulants()
-    pop_size = len(sim._population.get_population(True))
+    pop_size = len(sim.get_population())
 
     # Check that the 0th simulant won't step forward
     sim._population._population.step_size[0] *= 2
@@ -81,7 +81,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     assert (
         len(
             sim._clock.aligned_pop(
-                sim._population.get_population(True).index,
+                sim.get_population().index,
                 sim._clock.time + sim._clock.step_size,
             )
         )
@@ -99,7 +99,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     assert (
         len(
             sim._clock.aligned_pop(
-                sim._population.get_population(True).index,
+                sim.get_population().index,
                 sim._clock.time + sim._clock.step_size,
             )
         )
@@ -121,7 +121,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     assert (
         len(
             sim._clock.aligned_pop(
-                sim._population.get_population(True).index,
+                sim.get_population().index,
                 sim._clock.time + sim._clock.step_size,
             )
         )

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -51,7 +51,9 @@ def test_align_times(SimulationContext, base_config, components):
 
     sim.step()
     # No simulants should be aligned after a step size adjustment
-    assert sim._clock.get_active_population(sim.get_population().index, sim._clock.event_time).empty
+    assert sim._clock.get_active_population(
+        sim.get_population().index, sim._clock.event_time
+    ).empty
 
     sim.step()
     # Now they should be aligned again

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -87,16 +87,15 @@ def test_unequal_steps(SimulationContext, base_config, components):
         )
         == pop_size - 1
     )
-    
+
     # Show that now that the next_event_time is updated, 0th simulant isn't included in events
     sim.step()
     assert 0 not in listener.time_step_prepare_index
     assert 0 not in listener.time_step_index
     assert 0 not in listener.time_step_cleanup_index
     assert 0 not in listener.collect_metrics_index
-    
 
-    #Check that everybody will step forward next step
+    # Check that everybody will step forward next step
     assert (
         len(
             sim._clock.aligned_pop(
@@ -118,7 +117,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     sim._population._population.step_size[7] /= 2
     # Do a step just to update the next_event_time
     sim.step()
-    #Check that next step, we will still update all
+    # Check that next step, we will still update all
     assert (
         len(
             sim._clock.aligned_pop(

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -28,7 +28,7 @@ def test_align_times(SimulationContext, base_config, components):
     # After initialization, all simulants should be aligned to event times
     assert (
         len(
-            sim._clock.aligned_pop(
+            sim._clock.get_active_population(
                 sim.get_population().index,
                 sim._clock.event_time,
             )
@@ -40,7 +40,7 @@ def test_align_times(SimulationContext, base_config, components):
     # After one step (and no step adjustments, simulants should still be aligned)
     assert (
         len(
-            sim._clock.aligned_pop(
+            sim._clock.get_active_population(
                 sim.get_population().index,
                 sim._clock.event_time,
             )
@@ -51,13 +51,13 @@ def test_align_times(SimulationContext, base_config, components):
 
     sim.step()
     # No simulants should be aligned after a step size adjustment
-    assert sim._clock.aligned_pop(sim.get_population().index, sim._clock.event_time).empty
+    assert sim._clock.get_active_population(sim.get_population().index, sim._clock.event_time).empty
 
     sim.step()
     # Now they should be aligned again
     assert (
         len(
-            sim._clock.aligned_pop(
+            sim._clock.get_active_population(
                 sim.get_population().index,
                 sim._clock.event_time,
             )
@@ -78,7 +78,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     sim.step()
     assert (
         len(
-            sim._clock.aligned_pop(
+            sim._clock.get_active_population(
                 sim.get_population().index,
                 sim._clock.event_time,
             )
@@ -96,7 +96,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     # Check that everybody will step forward next step
     assert (
         len(
-            sim._clock.aligned_pop(
+            sim._clock.get_active_population(
                 sim.get_population().index,
                 sim._clock.event_time,
             )
@@ -118,7 +118,7 @@ def test_unequal_steps(SimulationContext, base_config, components):
     # Check that next step, we will still update all
     assert (
         len(
-            sim._clock.aligned_pop(
+            sim._clock.get_active_population(
                 sim.get_population().index,
                 sim._clock.event_time,
             )

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -51,9 +51,7 @@ def test_align_times(SimulationContext, base_config, components):
 
     sim.step()
     # No simulants should be aligned after a step size adjustment
-    assert sim._clock.aligned_pop(
-        sim.get_population().index, sim._clock.event_time
-    ).empty
+    assert sim._clock.aligned_pop(sim.get_population().index, sim._clock.event_time).empty
 
     sim.step()
     # Now they should be aligned again

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -88,10 +88,8 @@ def test_unequal_steps(SimulationContext, base_config, components):
 
     # Show that now that the next_event_time is updated, 0th simulant isn't included in events
     sim.step()
-    assert 0 not in listener.time_step_prepare_index
-    assert 0 not in listener.time_step_index
-    assert 0 not in listener.time_step_cleanup_index
-    assert 0 not in listener.collect_metrics_index
+    for index in listener.event_indexes.values():
+        assert 0 not in index
 
     # Check that everybody will step forward next step
     assert (
@@ -105,10 +103,8 @@ def test_unequal_steps(SimulationContext, base_config, components):
     )
     # Check that they are actually included in events
     sim.step()
-    assert 0 in listener.time_step_prepare_index
-    assert 0 in listener.time_step_index
-    assert 0 in listener.time_step_cleanup_index
-    assert 0 in listener.collect_metrics_index
+    for index in listener.event_indexes.values():
+        assert 0 in index
     # Revert change to 0
     sim._population._population.step_size[0] /= 2
     # Still step forward even with a non-integer step size
@@ -127,7 +123,5 @@ def test_unequal_steps(SimulationContext, base_config, components):
     )
     # Check that we actually include 7 in events
     sim.step()
-    assert 7 in listener.time_step_prepare_index
-    assert 7 in listener.time_step_index
-    assert 7 in listener.time_step_cleanup_index
-    assert 7 in listener.collect_metrics_index
+    for index in listener.event_indexes.values():
+        assert 7 in index

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -2,14 +2,21 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from vivarium.framework.values import ValuesManager, list_combiner, union_post_processor, rescale_post_processor
+from vivarium.framework.values import (
+    ValuesManager,
+    list_combiner,
+    rescale_post_processor,
+    union_post_processor,
+)
 
 
 @pytest.fixture
 def manager(mocker):
     manager = ValuesManager()
     builder = mocker.MagicMock()
-    builder.time.simulant_step_sizes = lambda: lambda idx: pd.Series(pd.Timedelta(days=3), index=idx)
+    builder.time.simulant_step_sizes = lambda: lambda idx: pd.Series(
+        pd.Timedelta(days=3), index=idx
+    )
     manager.setup(builder)
     return manager
 
@@ -63,7 +70,8 @@ def test_returned_series_name(manager):
         source=lambda idx: pd.Series(0.0, index=idx),
     )
     assert value(pd.Index(range(10))).name == "test"
-    
+
+
 def test_rescale_postprocessor(manager):
     index = pd.Index(range(10))
 
@@ -73,4 +81,3 @@ def test_rescale_postprocessor(manager):
         preferred_post_processor=rescale_post_processor,
     )
     assert np.all(value(index) == 0.5 * 3 / 365)
-    

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -2,13 +2,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from vivarium.framework.utilities import from_yearly
 from vivarium.framework.values import (
     ValuesManager,
     list_combiner,
     rescale_post_processor,
     union_post_processor,
 )
-from vivarium.framework.utilities import from_yearly
 
 
 @pytest.fixture

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -14,7 +14,7 @@ from vivarium.framework.values import (
 def manager(mocker):
     manager = ValuesManager()
     builder = mocker.MagicMock()
-    builder.time.simulant_step_sizes = lambda: lambda idx: pd.Series(
+    builder.time.simulant_step_sizes = lambda: lambda: lambda idx: pd.Series(
         pd.Timedelta(days=3), index=idx
     )
     manager.setup(builder)


### PR DESCRIPTION
## Individiual Clocks integration 
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4637

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Three primary changes:
exclude simulants from off-time events by filtering the time-aligned population
use the simulant step sizes in place of the global step in rescale post-processor
rename results manager "step size", since that is now the name of the local step column.

I also added an "event time" method in the time manager that just returns time + step_size; it's convenient in a number of places where i was otherwise calling X._clock.time + X._clock.step_size. Not sure if calling it "event time" is confusing, though.


### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
example sim runs without issue
Added tests to show that a simulant does get excluded from events (if they're supposed to be) and that the rescale post-processor properly uses the simulant step size when calculating rates. 
I've just changed step sizes by altering them directly and running a `.step()` to update the value (so that they will be excluded on the next step); it might be a bit nicer to fake a component to update the step size but this is more direct IMO
