### PR TITLE
Align Step Sizes

### DIFF
--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -51,21 +51,20 @@ class SimulationClock(Manager):
         if not self._stop_time:
             raise ValueError("No stop time provided")
         return self._stop_time
-
+    
+    @property
+    def min_step_size(self) -> Timedelta:
+        """The minimum step size."""
+        if not self._min_step_size:
+            raise ValueError("No minimum step size provided")
+        return self._min_step_size
+    
     @property
     def step_size(self) -> Timedelta:
         """The size of the next time step."""
         if not self._clock_step_size:
             raise ValueError("No step size provided")
         return self._clock_step_size
-    
-    @property
-    def min_step_size(self) -> Timedelta:
-        """The minimum step size."""
-        if not self._min_step_size:
-            raise ValueError("No step size provided")
-        return self._min_step_size
-
 
     @property
     def event_time(self) -> Time:
@@ -75,8 +74,8 @@ class SimulationClock(Manager):
     def __init__(self):
         self._clock_time = None
         self._stop_time = None
-        self._clock_step_size = None
         self._min_step_size = None
+        self._clock_step_size = None
         self.population_view = None
 
     def setup(self, builder: "Builder"):
@@ -182,8 +181,8 @@ class SimpleClock(SimulationClock):
         super().setup(builder)
         self._clock_time = builder.configuration.time.start
         self._stop_time = builder.configuration.time.end
-        self._clock_step_size = builder.configuration.time.step_size
         self._min_step_size = builder.configuration.time.step_size
+        self._clock_step_size = self._min_step_size
 
     def __repr__(self):
         return "SimpleClock()"
@@ -217,10 +216,10 @@ class DateTimeClock(SimulationClock):
         time = builder.configuration.time
         self._clock_time = get_time_stamp(time.start)
         self._stop_time = get_time_stamp(time.end)
-        self._clock_step_size = pd.Timedelta(
+        self._min_step_size = pd.Timedelta(
             days=time.step_size // 1, hours=(time.step_size % 1) * 24
         )
-        self._min_step_size = self._clock_step_size
+        self._clock_step_size = self._min_step_size
 
     def __repr__(self):
         return "DateTimeClock()"

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -123,10 +123,8 @@ class SimulationClock(Manager):
         self._clock_time += self.step_size
         pop_to_update = self.get_active_population(index, self.time)
         if not pop_to_update.empty:
-            pop_to_update["next_event_time"] = self.time + self.step_size_pipeline(
-                pop_to_update.index
-            )
             pop_to_update["step_size"] = self.step_size_pipeline(pop_to_update.index)
+            pop_to_update["next_event_time"] = self.time + pop_to_update["step_size"]
             self.population_view.update(pop_to_update)
         self._clock_step_size = self.simulant_next_event_times(index).min() - self.time
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -158,7 +158,7 @@ class SimulationClock(Manager):
         min_modified = pd.DataFrame(modifiers).min(axis=0).astype("timedelta64[ns]")
         raw_step_sizes = pd.DataFrame([source, min_modified]).max(axis=0)
         ## Rescale pipeline values to global step size
-        return np.ceil(raw_step_sizes / source) * source
+        return np.floor(raw_step_sizes / source) * source
 
 
 class SimpleClock(SimulationClock):

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -237,9 +237,9 @@ class TimeInterface:
         return lambda: self._manager.step_size
 
     def simulant_next_event_times(self) -> Callable[[pd.Index], pd.Series]:
-        """Gets a callable that returns the current simulation step size."""
+        """Gets a callable that returns the next event times for simulants."""
         return lambda: self._manager.simulant_next_event_times
 
     def simulant_step_sizes(self) -> Callable[[pd.Index], pd.Series]:
-        """Gets a callable that returns the current simulation step size."""
+        """Gets a callable that returns the simulant step sizes."""
         return lambda: self._manager.simulant_step_sizes

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
+    from vivarium.framework.population.population_view import PopulationView
 
 from vivarium.framework.values import list_combiner
 from vivarium.manager import Manager
@@ -73,11 +74,11 @@ class SimulationClock(Manager):
         return self.time + self.step_size
 
     def __init__(self):
-        self._clock_time = None
-        self._stop_time = None
-        self._minimum_step_size = None
-        self._clock_step_size = None
-        self.population_view = None
+        self._clock_time: Time = None
+        self._stop_time: Time = None
+        self._minimum_step_size: Timedelta = None
+        self._clock_step_size: Timedelta = None
+        self.population_view: PopulationView = None
 
     def setup(self, builder: "Builder"):
         self.step_size_pipeline = builder.value.register_value_producer(

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -71,13 +71,14 @@ def take_step(sim):
 
 class StepModifier(MockGenericComponent):
     """This mock component modifies the step size of simulants based on their index
-        Odd simulants get one step size, and even simulants get another.
-        
-        There is also a test pipeline that is registered, whose value is cached to
-        self.ts_pipeline_value every timestep. This is meant to ensure that the 
-        value of a pipeline on a previous timestep was appropriately rescaled
-        to the step that was actually taken.
+    Odd simulants get one step size, and even simulants get another.
+
+    There is also a test pipeline that is registered, whose value is cached to
+    self.ts_pipeline_value every timestep. This is meant to ensure that the
+    value of a pipeline on a previous timestep was appropriately rescaled
+    to the step that was actually taken.
     """
+
     def __init__(self, name, step_modifier_even, step_modifier_odd):
         super().__init__(name)
         self.step_modifier_even = step_modifier_even

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -166,7 +166,7 @@ def test_empty_active_pop(SimulationContext, base_config, components):
 
 
 @pytest.mark.parametrize(
-    "step_modifier_even,step_modifier_odd", [(0.5, 0.5), (1, 1), (2, 2), (3.5, 4)]
+    "step_modifier_even,step_modifier_odd", [(0.5, 0.5), (1, 1), (2, 2), (4.5, 4)]
 )
 def test_skip_iterations(
     SimulationContext, base_config, step_modifier_even, step_modifier_odd
@@ -178,7 +178,7 @@ def test_skip_iterations(
         base_config,
         [StepModifier("step_modifier", step_modifier_even, step_modifier_odd), listener],
     )
-    quantized_step = math.ceil(step_modifier_even)
+    quantized_step = math.floor(max([step_modifier_even, 1]))
     sim.setup()
     sim.initialize_simulants()
     pop_size = len(sim.get_population())
@@ -283,8 +283,8 @@ def test_step_size_post_processor(manager):
     odds = value.iloc[lambda x: x.index % 2 == 1]
 
     ## The second modifier shouldn't have an effect
-    assert np.all(evens == pd.Timedelta(days=8))
-    assert np.all(odds == pd.Timedelta(days=6))
+    assert np.all(evens == pd.Timedelta(days=6))
+    assert np.all(odds == pd.Timedelta(days=4))
 
     manager.register_value_modifier(
         "test_step_size", modifier=lambda idx: pd.Series(pd.Timedelta(days=0.5), index=idx)

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -156,14 +156,7 @@ def test_step_pipeline_with_modifier(SimulationContext, base_config, step_modifi
 
     ## Go through a couple simulant step cycles
     for _ in range(2):
-        for _ in range(math.ceil(step_modifier) - 1):
-            ## Nobody Should update here.
-            ## We subtract  a step for the last step of the modified range
-            sim.step()
-            assert np.all(step_pipeline(sim) == step_column(sim))
-            assert active_simulants(sim).empty
-
-        ## Everyone should update again
+        ## Everyone should update, but the step size should change
         sim.step()
         assert np.all(step_pipeline(sim) == step_column(sim))
         assert len(active_simulants(sim)) == pop_size


### PR DESCRIPTION
## Align Step Sizes
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4638

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
I aligned the clocks in the following manner:
add a "min step size" property, so the global step size can change dynamically
adjust the step size post processor to rectify to multiples of the minimum step size
modify the clock step so that the next time step will always go to the smallest next event time.

I also moved around the step postprocessor to be a static method, which i neglected to do in the previous ticket.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Added (and somewhat condensed) test coverage to show that pipeline calls have correct values, steps are skipped as appropriate, and uneven step modifiers produce the correct multiple of steps.
