### PR TITLE
Make Variable Clocks Backwards Compatible

### DIFF
--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -128,7 +128,7 @@ configuration by simply printing it.
                 model_override: 31
         step_size:
             model_override: 0.5
-        default_step_size:
+        standard_step_size:
             component_configs: None
     population:
         population_size:

--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -128,6 +128,8 @@ configuration by simply printing it.
                 model_override: 31
         step_size:
             model_override: 0.5
+        default_step_size:
+            component_configs: None
     population:
         population_size:
             model_override: 100000

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -237,7 +237,7 @@ class SimulationContext:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
-            pop_to_update = self._clock.get_active_population(
+            pop_to_update = self._clock.get_active_simulants(
                 self._population.get_population(True).index,
                 self._clock.event_time,
             )

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -241,7 +241,7 @@ class SimulationContext:
                 self._population.get_population(True).index,
                 self._clock.event_time,
             )
-            self.time_step_emitters[event](pop_to_update.index)
+            self.time_step_emitters[event](pop_to_update)
         self._clock.step_forward(self._population.get_population(True).index)
 
     def run(self) -> None:

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -191,6 +191,7 @@ class SimpleClock(SimulationClock):
             "start": 0,
             "end": 100,
             "step_size": 1,
+            "default_step_size": None,
         }
     }
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -64,7 +64,7 @@ class SimulationClock(Manager):
 
     @property
     def default_step_size(self) -> Timedelta:
-        """The minimum step size."""
+        """The default varied step size."""
         if not self._default_step_size:
             raise ValueError("No default step size provided")
         return self._default_step_size

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -142,15 +142,13 @@ class SimulationClock(Manager):
         self._clock_time += self.step_size
         if self._individual_clocks:
             update_index = self.get_active_simulants(index, self.time)
-            simulant_clocks_to_update = self._individual_clocks.get(update_index)
-            if not simulant_clocks_to_update.empty:
-                simulant_clocks_to_update["step_size"] = self._step_size_pipeline(
-                    update_index
+            clocks_to_update = self._individual_clocks.get(update_index)
+            if not clocks_to_update.empty:
+                clocks_to_update["step_size"] = self._step_size_pipeline(update_index)
+                clocks_to_update["next_event_time"] = (
+                    self.time + clocks_to_update["step_size"]
                 )
-                simulant_clocks_to_update["next_event_time"] = (
-                    self.time + simulant_clocks_to_update["step_size"]
-                )
-                self._individual_clocks.update(simulant_clocks_to_update)
+                self._individual_clocks.update(clocks_to_update)
             self._clock_step_size = self.simulant_next_event_times(index).min() - self.time
 
     def get_active_simulants(self, index: pd.Index, time: Time) -> pd.Index:

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -197,10 +197,12 @@ class SimpleClock(SimulationClock):
 
     def setup(self, builder):
         super().setup(builder)
-        self._clock_time = builder.configuration.time.start
-        self._stop_time = builder.configuration.time.end
-        self._minimum_step_size = builder.configuration.time.step_size
-        self._clock_step_size = self._minimum_step_size
+        time = builder.configuration.time
+        self._clock_time = time.start
+        self._stop_time = time.end
+        self._minimum_step_size = time.step_size
+        self._default_step_size = time.default_step_size if time.default_step_size else self._minimum_step_size
+        self._clock_step_size = self._default_step_size
 
     def __repr__(self):
         return "SimpleClock()"

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -250,7 +250,11 @@ class DateTimeClock(SimulationClock):
             days=time.step_size // 1, hours=(time.step_size % 1) * 24
         )
         self._standard_step_size = (
-            time.standard_step_size if time.standard_step_size else self._minimum_step_size
+            pd.Timedelta(
+                days=time.standard_step_size // 1, hours=(time.standard_step_size % 1) * 24
+            )
+            if time.standard_step_size
+            else self._minimum_step_size
         )
         self._clock_step_size = self._standard_step_size
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
     from vivarium.framework.population.population_view import PopulationView
     from vivarium.framework.event import Event
 
-from vivarium.manager import Manager
 from vivarium.framework.values import list_combiner
+from vivarium.manager import Manager
 
 Time = Union[pd.Timestamp, datetime, Number]
 Timedelta = Union[pd.Timedelta, timedelta, Number]
@@ -61,7 +61,7 @@ class SimulationClock(Manager):
         if not self._minimum_step_size:
             raise ValueError("No minimum step size provided")
         return self._minimum_step_size
-    
+
     @property
     def default_step_size(self) -> Timedelta:
         """The minimum step size."""
@@ -174,8 +174,11 @@ class SimulationClock(Manager):
         """
 
         min_modified = pd.DataFrame(values).min(axis=0).fillna(self.default_step_size)
-         ## Rescale pipeline values to global minimum step size
-        discretized_step_sizes = np.floor(min_modified / self.minimum_step_size).replace(0,1) * self.minimum_step_size
+        ## Rescale pipeline values to global minimum step size
+        discretized_step_sizes = (
+            np.floor(min_modified / self.minimum_step_size).replace(0, 1)
+            * self.minimum_step_size
+        )
         ## Make sure we don't get zero
         return discretized_step_sizes
 
@@ -201,7 +204,9 @@ class SimpleClock(SimulationClock):
         self._clock_time = time.start
         self._stop_time = time.end
         self._minimum_step_size = time.step_size
-        self._default_step_size = time.default_step_size if time.default_step_size else self._minimum_step_size
+        self._default_step_size = (
+            time.default_step_size if time.default_step_size else self._minimum_step_size
+        )
         self._clock_step_size = self._default_step_size
 
     def __repr__(self):
@@ -240,7 +245,9 @@ class DateTimeClock(SimulationClock):
         self._minimum_step_size = pd.Timedelta(
             days=time.step_size // 1, hours=(time.step_size % 1) * 24
         )
-        self._default_step_size = time.default_step_size if time.default_step_size else self._minimum_step_size
+        self._default_step_size = (
+            time.default_step_size if time.default_step_size else self._minimum_step_size
+        )
         self._clock_step_size = self._default_step_size
 
     def __repr__(self):

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -64,10 +64,10 @@ class SimulationClock(Manager):
         return self._minimum_step_size
 
     @property
-    def default_step_size(self) -> Timedelta:
-        """The default varied step size."""
+    def standard_step_size(self) -> Timedelta:
+        """The standard varied step size."""
         if not self._standard_step_size:
-            raise ValueError("No default step size provided")
+            raise ValueError("No standard step size provided")
         return self._standard_step_size
 
     @property
@@ -178,7 +178,7 @@ class SimulationClock(Manager):
 
         """
 
-        min_modified = pd.DataFrame(values).min(axis=0).fillna(self.default_step_size)
+        min_modified = pd.DataFrame(values).min(axis=0).fillna(self.standard_step_size)
         ## Rescale pipeline values to global minimum step size
         discretized_step_sizes = (
             np.floor(min_modified / self.minimum_step_size).replace(0, 1)
@@ -211,7 +211,7 @@ class SimpleClock(SimulationClock):
         self._stop_time = time.end
         self._minimum_step_size = time.step_size
         self._standard_step_size = (
-            time.default_step_size if time.standard_step_size else self._minimum_step_size
+            time.standard_step_size if time.standard_step_size else self._minimum_step_size
         )
         self._clock_step_size = self._standard_step_size
 
@@ -252,7 +252,7 @@ class DateTimeClock(SimulationClock):
             days=time.step_size // 1, hours=(time.step_size % 1) * 24
         )
         self._standard_step_size = (
-            time.default_step_size if time.standard_step_size else self._minimum_step_size
+            time.standard_step_size if time.standard_step_size else self._minimum_step_size
         )
         self._clock_step_size = self._standard_step_size
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
 from vivarium.framework.values import list_combiner
 from vivarium.manager import Manager
 
-
 Time = Union[pd.Timestamp, datetime, Number]
 Timedelta = Union[pd.Timedelta, timedelta, Number]
 NumberLike = Union[np.ndarray, pd.Series, pd.DataFrame, Number]
@@ -145,8 +144,12 @@ class SimulationClock(Manager):
             update_index = self.get_active_simulants(index, self.time)
             simulant_clocks_to_update = self._individual_clocks.get(update_index)
             if not simulant_clocks_to_update.empty:
-                simulant_clocks_to_update["step_size"] = self._step_size_pipeline(update_index)
-                simulant_clocks_to_update["next_event_time"] = self.time + simulant_clocks_to_update["step_size"]
+                simulant_clocks_to_update["step_size"] = self._step_size_pipeline(
+                    update_index
+                )
+                simulant_clocks_to_update["next_event_time"] = (
+                    self.time + simulant_clocks_to_update["step_size"]
+                )
                 self._individual_clocks.update(simulant_clocks_to_update)
             self._clock_step_size = self.simulant_next_event_times(index).min() - self.time
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -110,7 +110,7 @@ def rescale_post_processor(value: NumberLike, manager: "ValuesManager") -> Numbe
         The annual rates rescaled to the size of the current time step size.
 
     """
-    if hasattr(value, "index") and manager.simulant_step_sizes(value.index) is not None:
+    if hasattr(value, "index"):
         time_step = manager.simulant_step_sizes(value.index).dt
     else:
         time_step = manager.step_size()

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -88,7 +88,7 @@ def list_combiner(value: List, mutator: Callable, *args: Any, **kwargs: Any) -> 
 
 
 def rescale_post_processor(
-    value: NumberLike, time_step: Union[pd.Timedelta, Callable]
+    value: NumberLike, manager: "ValuesManager"
 ) -> NumberLike:
     """Rescales annual rates to time-step appropriate rates.
 
@@ -112,16 +112,10 @@ def rescale_post_processor(
         The annual rates rescaled to the size of the current time step size.
 
     """
-    if isinstance(time_step, Callable):
-        if not hasattr(value, "index"):
-            ## TODO MIC-4665 - Accommodate non-indexed values by using global clock
-            ## Ideally with keyword args
-            raise ValueError(
-                "Using a rescale post-processor with individual clocks"
-                "requires a pipeline with indexed values."
-            )
-
-        time_step = time_step(value.index).dt
+    if hasattr(value, "index") and manager.simulant_step_sizes:
+        time_step = manager.simulant_step_sizes(value.index).dt
+    else:
+        time_step = manager.step_size()
     return from_yearly(value, time_step)
 
 
@@ -250,7 +244,7 @@ class Pipeline:
         for mutator in self.mutators:
             value = self.combiner(value, mutator, *args, **kwargs)
         if self.post_processor and not skip_post_processor:
-            return self.post_processor(value, self.manager.step_size())
+            return self.post_processor(value, self.manager)
         if isinstance(value, pd.Series):
             value.name = self.name
 
@@ -273,7 +267,8 @@ class ValuesManager(Manager):
 
     def setup(self, builder):
         self.logger = builder.logging.get_logger(self.name)
-        self.step_size = builder.time.simulant_step_sizes()
+        self.step_size = builder.time.step_size()
+        self.simulant_step_sizes = builder.time.simulant_step_sizes()
         builder.event.register_listener("post_setup", self.on_post_setup)
 
         self.resources = builder.resources

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -112,7 +112,7 @@ def rescale_post_processor(
         The annual rates rescaled to the size of the current time step size.
 
     """
-    if hasattr(value, "index") and manager.simulant_step_sizes:
+    if hasattr(value, "index") and manager.simulant_step_sizes(value.index) is not None:
         time_step = manager.simulant_step_sizes(value.index).dt
     else:
         time_step = manager.step_size()

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -87,9 +87,7 @@ def list_combiner(value: List, mutator: Callable, *args: Any, **kwargs: Any) -> 
     return value
 
 
-def rescale_post_processor(
-    value: NumberLike, manager: "ValuesManager"
-) -> NumberLike:
+def rescale_post_processor(value: NumberLike, manager: "ValuesManager") -> NumberLike:
     """Rescales annual rates to time-step appropriate rates.
 
     This should only be used with a simulation using a

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -206,9 +206,6 @@ def test_SimulationContext_initialize_simulants(SimulationContext, base_config, 
     assert len(pop) == pop_size
     assert sim._clock.time == current_time
 
-    assert np.all(sim._clock.simulant_next_event_times(pop.index) == sim._clock.event_time)
-    assert np.all(sim._clock.simulant_step_sizes(pop.index) == sim._clock.step_size)
-
 
 def test_SimulationContext_step(SimulationContext, log, base_config, components):
     sim = SimulationContext(base_config, components)
@@ -235,8 +232,6 @@ def test_SimulationContext_step(SimulationContext, log, base_config, components)
     assert listener.collect_metrics_called
 
     assert sim._clock.time == current_time + step_size
-    assert np.all(sim._clock.simulant_next_event_times(pop.index) == sim._clock.event_time)
-    assert np.all(sim._clock.simulant_step_sizes(pop.index) == sim._clock.step_size)
 
 
 def test_SimulationContext_finalize(SimulationContext, base_config, components):

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -147,7 +147,7 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
     assert sim._clock.step_size == pd.Timedelta(days=1)
     ## Ensure that we don't have a pop view (and by extension, don't vary clocks)
     ## If no components modify the step size.
-    assert bool(sim._clock.population_view) == varied_step_size
+    assert bool(sim._clock.individual_clocks) == varied_step_size
 
     for _ in range(2):
         # After initialization, all simulants should be aligned to event times

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -143,6 +143,8 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
     full_pop_index = sim.get_population().index
     assert sim._clock.time == get_time_stamp(sim.configuration.time.start)
     assert sim._clock.step_size == pd.Timedelta(days=1)
+    ## Ensure that we don't have a pop view (and by extension, don't vary clocks)
+    ## If no components modify the step size.
     assert bool(sim._clock.population_view) == varied_step_size
 
     for _ in range(2):

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -21,6 +21,7 @@ from .components.mocks import (
     MockGenericComponent,
 )
 
+
 @pytest.fixture
 def manager(mocker):
     manager = ValuesManager()
@@ -46,6 +47,7 @@ def components():
         MockComponentB("spoon", "antelope", 23),
     ]
 
+
 def validate_step_column_is_pipeline(sim):
     """Ensure that the pipeline and column step sizes are aligned"""
     step_pipeline = sim._values.get_value("simulant_step_size")(
@@ -53,7 +55,6 @@ def validate_step_column_is_pipeline(sim):
     )
     step_column = sim._population._population.step_size
     assert np.all(step_pipeline == step_column)
-
 
 
 def validate_index_aligned(sim, expected_active_simulants):
@@ -127,6 +128,7 @@ class StepModifier(MockGenericComponent):
         )
         return step_sizes
 
+
 @pytest.mark.parametrize("varied_step_size", [True, False])
 def test_basic_iteration(SimulationContext, base_config, components, varied_step_size):
     """Ensure that the basic iteration of the simulation works as expected.
@@ -137,7 +139,7 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
     if varied_step_size:
         components.append(StepModifier("step_modifier", 1, 1))
     sim = SimulationContext(base_config, components)
-    listener = [c for c in components if hasattr(c, 'args') and "listener" in c.args][0]
+    listener = [c for c in components if hasattr(c, "args") and "listener" in c.args][0]
     sim.setup()
     sim.initialize_simulants()
     full_pop_index = sim.get_population().index
@@ -156,13 +158,14 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
             sim, listener, expected_simulants=full_pop_index, expected_step_size_days=1
         )
 
+
 def test_empty_active_pop(SimulationContext, base_config, components):
     """Make sure that if we have no active simulants, we still take a step, given
     by the minimum step size."""
     base_config["time"]["step_size"] = 1
     components.append(StepModifier("step_modifier", 1, 1))
     sim = SimulationContext(base_config, components)
-    listener = [c for c in components if hasattr(c, 'args') and "listener" in c.args][0]
+    listener = [c for c in components if hasattr(c, "args") and "listener" in c.args][0]
     sim.setup()
     sim.initialize_simulants()
     full_pop_index = sim.get_population().index

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -143,6 +143,7 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
     full_pop_index = sim.get_population().index
     assert sim._clock.time == get_time_stamp(sim.configuration.time.start)
     assert sim._clock.step_size == pd.Timedelta(days=1)
+    assert bool(sim._clock.population_view) == varied_step_size
 
     for _ in range(2):
         # After initialization, all simulants should be aligned to event times

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -21,7 +21,6 @@ from .components.mocks import (
     MockGenericComponent,
 )
 
-
 @pytest.fixture
 def manager(mocker):
     manager = ValuesManager()
@@ -60,8 +59,8 @@ def validate_index_aligned(sim, expected_active_simulants):
     )
 
     assert np.all(step_pipeline == step_column)
-    assert active_simulants.index.equals(expected_active_simulants)
-    assert active_simulants.index.difference(expected_active_simulants).empty
+    assert active_simulants.equals(expected_active_simulants)
+    assert active_simulants.difference(expected_active_simulants).empty
 
 
 def validate_event_indexes(listener, expected_simulants):
@@ -132,8 +131,9 @@ def test_basic_iteration(SimulationContext, base_config, components):
     be updated, and the pipeline step value should always match the column step value.
     """
     base_config["time"]["step_size"] = 1
+    components.append(StepModifier("step_modifier", 1, 1))
     sim = SimulationContext(base_config, components)
-    listener = [c for c in components if "listener" in c.args][0]
+    listener = [c for c in components if hasattr(c, 'args') and "listener" in c.args][0]
     sim.setup()
     sim.initialize_simulants()
     full_pop_index = sim.get_population().index
@@ -152,8 +152,9 @@ def test_empty_active_pop(SimulationContext, base_config, components):
     """Make sure that if we have no active simulants, we still take a step, given
     by the minimum step size."""
     base_config["time"]["step_size"] = 1
+    components.append(StepModifier("step_modifier", 1, 1))
     sim = SimulationContext(base_config, components)
-    listener = [c for c in components if "listener" in c.args][0]
+    listener = [c for c in components if hasattr(c, 'args') and "listener" in c.args][0]
     sim.setup()
     sim.initialize_simulants()
     full_pop_index = sim.get_population().index

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -301,7 +301,7 @@ def test_uneven_steps(SimulationContext, base_config):
 
 def test_partial_modification(SimulationContext, base_config):
     """Test that if we have one modifier that doesn't apply to all simulants,
-    we choose the default value for unmodified simulants.
+    we choose the standard value for unmodified simulants.
     """
 
     base_config["time"]["step_size"] = 1

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -79,25 +79,37 @@ def take_step(sim):
     new_time = sim._clock.time
     return new_time - old_time
 
+
 def full_pop_index(sim):
     return sim.get_population().index
 
+
 def get_index_by_parity(index, parity):
-    if parity == 'evens':
+    if parity == "evens":
         return index[index % 2 == 0]
-    elif parity == 'odds':
+    elif parity == "odds":
         return index[index % 2 == 1]
     else:
         return index
+
 
 def get_pop_by_parity(sim, parity):
     pop = sim.get_population()
     return pop.loc[get_index_by_parity(pop.index, parity)]
 
+
 def pipeline_by_parity(sim, step_modifiers, parity):
-    if parity == 'all':
-        return pd.concat([pipeline_by_parity(sim, step_modifiers, 'evens'), pipeline_by_parity(sim, step_modifiers, 'odds')]).sort_index()
-    return pd.Series(from_yearly(1.75, pd.Timedelta(days=step_modifiers[parity])), index=get_index_by_parity(full_pop_index(sim), parity))
+    if parity == "all":
+        return pd.concat(
+            [
+                pipeline_by_parity(sim, step_modifiers, "evens"),
+                pipeline_by_parity(sim, step_modifiers, "odds"),
+            ]
+        ).sort_index()
+    return pd.Series(
+        from_yearly(1.75, pd.Timedelta(days=step_modifiers[parity])),
+        index=get_index_by_parity(full_pop_index(sim), parity),
+    )
 
 
 def take_step_and_validate(sim, listener, expected_simulants, expected_step_size_days):
@@ -120,10 +132,14 @@ class StepModifier(MockGenericComponent):
     to the step that was actually taken.
     """
 
-    def __init__(self, name, step_modifier_even, step_modifier_odd=None, modified_simulants='all'):
+    def __init__(
+        self, name, step_modifier_even, step_modifier_odd=None, modified_simulants="all"
+    ):
         super().__init__(name)
         self.step_modifier_even = step_modifier_even
-        self.step_modifier_odd = step_modifier_odd if step_modifier_odd else step_modifier_even
+        self.step_modifier_odd = (
+            step_modifier_odd if step_modifier_odd else step_modifier_even
+        )
         self.modified_simulants = modified_simulants
         self.ts_pipeline_value = None
 
@@ -244,6 +260,7 @@ def test_skip_iterations(
             expected_step_size_days=expected_step_size,
         )
 
+
 def test_uneven_steps(SimulationContext, base_config):
     """Test that if we have a mix of step sizes, we take steps in accordance
     to reach all simulants' next event times in the fewest steps.
@@ -251,7 +268,7 @@ def test_uneven_steps(SimulationContext, base_config):
 
     base_config["time"]["step_size"] = 1
     listener = Listener("listener")
-    step_modifiers = {'evens': 3, 'odds': 7}
+    step_modifiers = {"evens": 3, "odds": 7}
     step_modifier_component = StepModifier(
         "step_modifier", step_modifiers["evens"], step_modifiers["odds"]
     )
@@ -281,6 +298,7 @@ def test_uneven_steps(SimulationContext, base_config):
         assert sample_pipeline.index.equals(get_pop_by_parity(sim, group).index)
         assert np.all(sample_pipeline == pipeline_by_parity(sim, step_modifiers, group))
 
+
 def test_partial_modification(SimulationContext, base_config):
     """Test that if we have one modifier that doesn't apply to all simulants,
     we choose the default value for unmodified simulants.
@@ -289,9 +307,9 @@ def test_partial_modification(SimulationContext, base_config):
     base_config["time"]["step_size"] = 1
     listener = Listener("listener")
     ## Define odds for validation, but don't pass it into the step modifier
-    step_modifiers = {'evens': 3, 'odds': 1}
+    step_modifiers = {"evens": 3, "odds": 1}
     step_modifier_component = StepModifier(
-        "step_modifier", step_modifiers["evens"], modified_simulants='evens'
+        "step_modifier", step_modifiers["evens"], modified_simulants="evens"
     )
     sim = SimulationContext(
         base_config,
@@ -317,7 +335,8 @@ def test_partial_modification(SimulationContext, base_config):
         sample_pipeline = step_modifier_component.ts_pipeline_value
         assert sample_pipeline.index.equals(get_pop_by_parity(sim, group).index)
         assert np.all(sample_pipeline == pipeline_by_parity(sim, step_modifiers, group))
-        
+
+
 def test_multiple_modifiers(SimulationContext, base_config):
     """Test that if we have a mix of step sizes, we take steps in accordance
     to reach all simulants' next event times in the fewest steps.
@@ -325,12 +344,15 @@ def test_multiple_modifiers(SimulationContext, base_config):
 
     base_config["time"]["step_size"] = 1
     listener = Listener("listener")
-    step_modifiers = {'evens': 3, 'odds': 7}
+    step_modifiers = {"evens": 3, "odds": 7}
     step_modifier_A = StepModifier(
-        "step_modifier_A", step_modifiers["evens"], modified_simulants='evens'
+        "step_modifier_A", step_modifiers["evens"], modified_simulants="evens"
     )
     step_modifier_B = StepModifier(
-        "step_modifier_B", step_modifiers["evens"], step_modifiers["odds"], modified_simulants='odds'
+        "step_modifier_B",
+        step_modifiers["evens"],
+        step_modifiers["odds"],
+        modified_simulants="odds",
     )
     sim = SimulationContext(
         base_config,

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -59,7 +59,7 @@ def validate_step_column_is_pipeline(sim):
 
 def validate_index_aligned(sim, expected_active_simulants):
     """Ensure that the active simulants are as expected BEFORE a step"""
-    active_simulants = sim._clock.get_active_population(
+    active_simulants = sim._clock.get_active_simulants(
         sim.get_population().index, sim._clock.event_time
     )
 
@@ -147,7 +147,7 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
     assert sim._clock.step_size == pd.Timedelta(days=1)
     ## Ensure that we don't have a pop view (and by extension, don't vary clocks)
     ## If no components modify the step size.
-    assert bool(sim._clock.individual_clocks) == varied_step_size
+    assert bool(sim._clock._individual_clocks) == varied_step_size
 
     for _ in range(2):
         # After initialization, all simulants should be aligned to event times
@@ -282,7 +282,7 @@ def test_step_size_post_processor(manager):
     whichever is larger."""
     index = pd.Index(range(10))
     clock = SimulationClock()
-    clock._default_step_size = clock._minimum_step_size = pd.Timedelta(days=2)
+    clock._standard_step_size = clock._minimum_step_size = pd.Timedelta(days=2)
 
     pipeline = manager.register_value_producer(
         "test_step_size",

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -154,6 +154,12 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
         # After a step (and no step adjustments), simulants should still be aligned
         if varied_step_size:
             validate_step_column_is_pipeline(sim)
+            assert np.all(
+                sim._clock.simulant_next_event_times(full_pop_index) == sim._clock.event_time
+            )
+            assert np.all(
+                sim._clock.simulant_step_sizes(full_pop_index) == sim._clock.step_size
+            )
         take_step_and_validate(
             sim, listener, expected_simulants=full_pop_index, expected_step_size_days=1
         )

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -79,6 +79,26 @@ def take_step(sim):
     new_time = sim._clock.time
     return new_time - old_time
 
+def full_pop_index(sim):
+    return sim.get_population().index
+
+def get_index_by_parity(index, parity):
+    if parity == 'evens':
+        return index[index % 2 == 0]
+    elif parity == 'odds':
+        return index[index % 2 == 1]
+    else:
+        return index
+
+def get_pop_by_parity(sim, parity):
+    pop = sim.get_population()
+    return pop.loc[get_index_by_parity(pop.index, parity)]
+
+def pipeline_by_parity(sim, step_modifiers, parity):
+    if parity == 'all':
+        return pd.concat([pipeline_by_parity(sim, step_modifiers, 'evens'), pipeline_by_parity(sim, step_modifiers, 'odds')]).sort_index()
+    return pd.Series(from_yearly(1.75, pd.Timedelta(days=step_modifiers[parity])), index=get_index_by_parity(full_pop_index(sim), parity))
+
 
 def take_step_and_validate(sim, listener, expected_simulants, expected_step_size_days):
     """Take a step, and ensure that we included the right simulants, with the right step size"""
@@ -100,17 +120,18 @@ class StepModifier(MockGenericComponent):
     to the step that was actually taken.
     """
 
-    def __init__(self, name, step_modifier_even, step_modifier_odd):
+    def __init__(self, name, step_modifier_even, step_modifier_odd=None, modified_simulants='all'):
         super().__init__(name)
         self.step_modifier_even = step_modifier_even
-        self.step_modifier_odd = step_modifier_odd
+        self.step_modifier_odd = step_modifier_odd if step_modifier_odd else step_modifier_even
+        self.modified_simulants = modified_simulants
         self.ts_pipeline_value = None
 
     def setup(self, builder) -> None:
         super().setup(builder)
         builder.value.register_value_modifier("simulant_step_size", self.modify_step)
         self.rate_pipeline = builder.value.register_value_producer(
-            "test_rate",
+            f"test_rate_{self.name}",
             source=lambda idx: pd.Series(1.75, index=idx),
             preferred_post_processor=rescale_post_processor,
         )
@@ -119,13 +140,14 @@ class StepModifier(MockGenericComponent):
         self.ts_pipeline_value = self.rate_pipeline(event.index)
 
     def modify_step(self, index):
-        step_sizes = pd.Series(pd.Timedelta(1), index=index)
-        step_sizes.iloc[lambda x: x.index % 2 == 0] = pd.Timedelta(
+        step_sizes = pd.Series(pd.Timedelta(days=1), index=index)
+        step_sizes.loc[get_index_by_parity(index, "evens")] = pd.Timedelta(
             days=self.step_modifier_even
         )
-        step_sizes.iloc[lambda x: x.index % 2 == 1] = pd.Timedelta(
+        step_sizes.loc[get_index_by_parity(index, "odds")] = pd.Timedelta(
             days=self.step_modifier_odd
         )
+        step_sizes = step_sizes.loc[get_index_by_parity(index, self.modified_simulants)]
         return step_sizes
 
 
@@ -137,7 +159,7 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
     """
     base_config["time"]["step_size"] = 1
     if varied_step_size:
-        components.append(StepModifier("step_modifier", 1, 1))
+        components.append(StepModifier("step_modifier", 1))
     sim = SimulationContext(base_config, components)
     listener = [c for c in components if hasattr(c, "args") and "listener" in c.args][0]
     sim.setup()
@@ -169,7 +191,7 @@ def test_empty_active_pop(SimulationContext, base_config, components):
     """Make sure that if we have no active simulants, we still take a step, given
     by the minimum step size."""
     base_config["time"]["step_size"] = 1
-    components.append(StepModifier("step_modifier", 1, 1))
+    components.append(StepModifier("step_modifier", 1))
     sim = SimulationContext(base_config, components)
     listener = [c for c in components if hasattr(c, "args") and "listener" in c.args][0]
     sim.setup()
@@ -222,7 +244,6 @@ def test_skip_iterations(
             expected_step_size_days=expected_step_size,
         )
 
-
 def test_uneven_steps(SimulationContext, base_config):
     """Test that if we have a mix of step sizes, we take steps in accordance
     to reach all simulants' next event times in the fewest steps.
@@ -230,10 +251,9 @@ def test_uneven_steps(SimulationContext, base_config):
 
     base_config["time"]["step_size"] = 1
     listener = Listener("listener")
-    step_modifier_even = 3
-    step_modifier_odd = 7
+    step_modifiers = {'evens': 3, 'odds': 7}
     step_modifier_component = StepModifier(
-        "step_modifier", step_modifier_even, step_modifier_odd
+        "step_modifier", step_modifiers["evens"], step_modifiers["odds"]
     )
     sim = SimulationContext(
         base_config,
@@ -246,21 +266,6 @@ def test_uneven_steps(SimulationContext, base_config):
     ## 9, etc.
     correct_step_sizes = [3, 3, 1, 2, 3, 2, 1, 3, 3]
     groups = ["evens", "evens", "odds", "evens", "evens", "odds", "evens", "evens", "all"]
-    test = {
-        "evens": sim.get_population().iloc[lambda x: x.index % 2 == 0].index,
-        "odds": sim.get_population().iloc[lambda x: x.index % 2 == 1].index,
-        "all": sim.get_population().index,
-    }
-    pipeline_values = {
-        "evens": pd.Series(from_yearly(1.75, pd.Timedelta(days=3)), index=test["evens"]),
-        "odds": pd.Series(from_yearly(1.75, pd.Timedelta(days=7)), index=test["odds"]),
-        "all": pd.concat(
-            [
-                pd.Series(from_yearly(1.75, pd.Timedelta(days=3)), index=test["evens"]),
-                pd.Series(from_yearly(1.75, pd.Timedelta(days=7)), index=test["odds"]),
-            ]
-        ).sort_index(),
-    }
 
     ## Ensure that steps and active simulants are correct through one cycle of 21
     for correct_step_size, group in zip(correct_step_sizes, groups):
@@ -268,13 +273,86 @@ def test_uneven_steps(SimulationContext, base_config):
         take_step_and_validate(
             sim,
             listener,
-            expected_simulants=test[group],
+            expected_simulants=get_pop_by_parity(sim, group).index,
             expected_step_size_days=correct_step_size,
         )
 
         sample_pipeline = step_modifier_component.ts_pipeline_value
-        assert sample_pipeline.index.equals(test[group])
-        assert np.all(sample_pipeline == pipeline_values[group])
+        assert sample_pipeline.index.equals(get_pop_by_parity(sim, group).index)
+        assert np.all(sample_pipeline == pipeline_by_parity(sim, step_modifiers, group))
+
+def test_partial_modification(SimulationContext, base_config):
+    """Test that if we have one modifier that doesn't apply to all simulants,
+    we choose the default value for unmodified simulants.
+    """
+
+    base_config["time"]["step_size"] = 1
+    listener = Listener("listener")
+    ## Define odds for validation, but don't pass it into the step modifier
+    step_modifiers = {'evens': 3, 'odds': 1}
+    step_modifier_component = StepModifier(
+        "step_modifier", step_modifiers["evens"], modified_simulants='evens'
+    )
+    sim = SimulationContext(
+        base_config,
+        [step_modifier_component, listener],
+    )
+
+    sim.setup()
+    sim.initialize_simulants()
+    ## We should update odds with default each time, and update evens every third step.
+    correct_step_sizes = [1, 1, 1, 1, 1, 1, 1, 1, 1]
+    groups = ["odds", "odds", "all", "odds", "odds", "all", "odds", "odds", "all"]
+
+    ## Ensure that steps and active simulants are correct through one cycle of 21
+    for correct_step_size, group in zip(correct_step_sizes, groups):
+        validate_step_column_is_pipeline(sim)
+        take_step_and_validate(
+            sim,
+            listener,
+            expected_simulants=get_pop_by_parity(sim, group).index,
+            expected_step_size_days=correct_step_size,
+        )
+
+        sample_pipeline = step_modifier_component.ts_pipeline_value
+        assert sample_pipeline.index.equals(get_pop_by_parity(sim, group).index)
+        assert np.all(sample_pipeline == pipeline_by_parity(sim, step_modifiers, group))
+        
+def test_multiple_modifiers(SimulationContext, base_config):
+    """Test that if we have a mix of step sizes, we take steps in accordance
+    to reach all simulants' next event times in the fewest steps.
+    """
+
+    base_config["time"]["step_size"] = 1
+    listener = Listener("listener")
+    step_modifiers = {'evens': 3, 'odds': 7}
+    step_modifier_A = StepModifier(
+        "step_modifier_A", step_modifiers["evens"], modified_simulants='evens'
+    )
+    step_modifier_B = StepModifier(
+        "step_modifier_B", step_modifiers["evens"], step_modifiers["odds"], modified_simulants='odds'
+    )
+    sim = SimulationContext(
+        base_config,
+        [step_modifier_A, step_modifier_B, listener],
+    )
+
+    sim.setup()
+    sim.initialize_simulants()
+    ## With step sizes of 3 and 7, we need 3 steps, then 3 more, then one to get 7, then two more to get
+    ## 9, etc.
+    correct_step_sizes = [3, 3, 1, 2, 3, 2, 1, 3, 3]
+    groups = ["evens", "evens", "odds", "evens", "evens", "odds", "evens", "evens", "all"]
+
+    ## Ensure that steps and active simulants are correct through one cycle of 21
+    for correct_step_size, group in zip(correct_step_sizes, groups):
+        validate_step_column_is_pipeline(sim)
+        take_step_and_validate(
+            sim,
+            listener,
+            expected_simulants=get_pop_by_parity(sim, group).index,
+            expected_step_size_days=correct_step_size,
+        )
 
 
 def test_step_size_post_processor(manager):

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -10,11 +10,13 @@ from vivarium.framework.values import (
     union_post_processor,
 )
 
+
 @pytest.fixture
 def static_step():
     step_size = lambda: lambda: pd.Timedelta(days=6)
     simulant_step_sizes = lambda: lambda idx: None
     return step_size, simulant_step_sizes
+
 
 @pytest.fixture
 def variable_step():
@@ -24,12 +26,14 @@ def variable_step():
     )
     return step_size, simulant_step_sizes
 
+
 @pytest.fixture
 def manager(mocker):
     manager = ValuesManager()
     builder = mocker.MagicMock()
     manager.setup(builder)
     return manager
+
 
 @pytest.fixture
 def manager_with_step_size(mocker, request):
@@ -92,7 +96,8 @@ def test_returned_series_name(manager):
     )
     assert value(pd.Index(range(10))).name == "test"
 
-@pytest.mark.parametrize('manager_with_step_size', ['static_step'], indirect=True)
+
+@pytest.mark.parametrize("manager_with_step_size", ["static_step"], indirect=True)
 def test_rescale_post_processor_static(manager_with_step_size):
     index = pd.Index(range(10))
 
@@ -102,8 +107,9 @@ def test_rescale_post_processor_static(manager_with_step_size):
         preferred_post_processor=rescale_post_processor,
     )
     assert np.all(pipeline(index) == from_yearly(0.75, pd.Timedelta(days=6)))
-    
-@pytest.mark.parametrize('manager_with_step_size', ['variable_step'], indirect=True)
+
+
+@pytest.mark.parametrize("manager_with_step_size", ["variable_step"], indirect=True)
 def test_rescale_post_processor_variable(manager_with_step_size):
     index = pd.Index(range(10))
 

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -13,18 +13,14 @@ from vivarium.framework.values import (
 
 @pytest.fixture
 def static_step():
-    step_size = lambda: lambda: pd.Timedelta(days=6)
-    simulant_step_sizes = lambda: lambda idx: None
-    return step_size, simulant_step_sizes
+    return lambda idx: None
 
 
 @pytest.fixture
 def variable_step():
-    step_size = lambda: lambda: pd.Timedelta(days=6)
-    simulant_step_sizes = lambda: lambda idx: pd.Series(
+    return lambda idx: pd.Series(
         [pd.Timedelta(days=3) if i % 2 == 0 else pd.Timedelta(days=5) for i in idx], index=idx
     )
-    return step_size, simulant_step_sizes
 
 
 @pytest.fixture
@@ -39,9 +35,8 @@ def manager(mocker):
 def manager_with_step_size(mocker, request):
     manager = ValuesManager()
     builder = mocker.MagicMock()
-    step_size, simulant_step_sizes = request.getfixturevalue(request.param)
-    builder.time.step_size = step_size
-    builder.time.simulant_step_sizes = simulant_step_sizes
+    builder.time.step_size = lambda: lambda: pd.Timedelta(days=6)
+    builder.time.simulant_step_sizes = lambda: request.getfixturevalue(request.param)
     manager.setup(builder)
     return manager
 

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -13,7 +13,7 @@ from vivarium.framework.values import (
 
 @pytest.fixture
 def static_step():
-    return lambda idx: None
+    return lambda idx: pd.Series(pd.Timedelta(days=6), index=idx)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Make Variable Clocks Backwards Compatible
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4665

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
--Added default step size, which defaults to "minimum step size" if not set. This is so that we can have, say, a minimum varied step size of 1 day, but "most" people get 16 days, for example.
I don't like the name at all; the quandary is that `step_size` in the default configuration is (and probably should be) the minimum step size, but we also need a default step size, which is different. Perhaps something like "default_varied_step_size"?? or something?? or maybe it is better after all to make `step_size` the _default_ size, and optionally specify a separate minimum step size in the configuration.

--Made it so that if no components modify the step size pipeline, revert to a global clock.

--did some light refactoring to keep everything sensible

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Added tests to make sure we can accomodate either static or variable time stepping

