### PR TITLE
Add Time Interface Step Size Modifier

### DIFF
--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -99,7 +99,9 @@ class SimulationClock(Manager):
             preferred_combiner=list_combiner,
             preferred_post_processor=self.step_size_post_processor,
         )
-        self.modify_step_size = partial(builder.value.register_value_modifier, self._pipeline_name)
+        self.register_step_modifier = partial(
+            builder.value.register_value_modifier, self._pipeline_name
+        )
         builder.population.initializes_simulants(
             self.on_initialize_simulants, creates_columns=self.columns_created
         )
@@ -187,6 +189,7 @@ class SimulationClock(Manager):
         )
         ## Make sure we don't get zero
         return discretized_step_sizes
+
 
 class SimpleClock(SimulationClock):
     """A unitless step-count based simulation clock."""
@@ -293,7 +296,7 @@ class TimeInterface:
     ) -> None:
         """Registers a step size modifier.
         modifier
-            Modifier of the step size pipeline. Modifiers can take an index 
+            Modifier of the step size pipeline. Modifiers can take an index
             and should return a series of step sizes.
         requires_columns
             A list of the state table columns that already need to be present
@@ -304,8 +307,7 @@ class TimeInterface:
             before the  modifier is called.
         requires_streams
             A list of the randomness streams that need to be properly sourced
-            before the modifier is called.
-"""
-        return self._manager.modify_step_size(
+            before the modifier is called."""
+        return self._manager.register_step_modifier(
             modifier, requires_columns, requires_values, requires_streams
         )

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -284,7 +284,7 @@ class TimeInterface:
         """Gets a callable that returns the simulant step sizes."""
         return self._manager.simulant_step_sizes
 
-    def modify_step_size(
+    def register_step_modifier(
         self,
         modifier: Callable[[pd.Index], pd.Series],
         requires_columns: List[str] = (),

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -295,6 +295,9 @@ class TimeInterface:
         requires_streams: List[str] = (),
     ) -> None:
         """Registers a step size modifier.
+        
+        Parameters
+        ----------
         modifier
             Modifier of the step size pipeline. Modifiers can take an index
             and should return a series of step sizes.

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -295,7 +295,7 @@ class TimeInterface:
         requires_streams: List[str] = (),
     ) -> None:
         """Registers a step size modifier.
-        
+
         Parameters
         ----------
         modifier

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -292,7 +292,7 @@ class TimeInterface:
         requires_streams: List[str] = (),
     ) -> None:
         """Registers a step size modifier.
-        modifier :
+        modifier
             Modifier of the step size pipeline. Modifiers can take an index 
             and should return a series of step sizes.
         requires_columns

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -145,7 +145,7 @@ class StepModifier(MockGenericComponent):
 
     def setup(self, builder) -> None:
         super().setup(builder)
-        builder.value.register_value_modifier("simulant_step_size", self.modify_step)
+        builder.time.modify_step_size(self.modify_step)
         self.rate_pipeline = builder.value.register_value_producer(
             f"test_rate_{self.name}",
             source=lambda idx: pd.Series(1.75, index=idx),

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -417,13 +417,14 @@ def test_step_size_post_processor(builder):
     clock.setup(builder)
 
     ## Add modifier that set the step size to 7 for even indices and 5 for odd indices
-    clock.register_step_modifier(lambda idx: pd.Series(
+    clock.register_step_modifier(
+        lambda idx: pd.Series(
             [pd.Timedelta(days=7) if i % 2 == 0 else pd.Timedelta(days=5) for i in idx],
             index=idx,
-        ))
-    ## Add modifier that sets the step size to 9 for all simulants
-    clock.register_step_modifier(lambda idx: pd.Series(pd.Timedelta(days=9), index=idx)
+        )
     )
+    ## Add modifier that sets the step size to 9 for all simulants
+    clock.register_step_modifier(lambda idx: pd.Series(pd.Timedelta(days=9), index=idx))
     value = clock._step_size_pipeline(index)
     evens = value.iloc[lambda x: x.index % 2 == 0]
     odds = value.iloc[lambda x: x.index % 2 == 1]
@@ -432,7 +433,6 @@ def test_step_size_post_processor(builder):
     assert np.all(evens == pd.Timedelta(days=6))
     assert np.all(odds == pd.Timedelta(days=4))
 
-    clock.register_step_modifier(lambda idx: pd.Series(pd.Timedelta(days=0.5), index=idx)
-    )
+    clock.register_step_modifier(lambda idx: pd.Series(pd.Timedelta(days=0.5), index=idx))
     value = clock._step_size_pipeline(index)
     assert np.all(value == pd.Timedelta(days=2))

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -23,14 +23,13 @@ from .components.mocks import (
 
 
 @pytest.fixture
-def manager(mocker):
-    manager = ValuesManager()
+def builder(mocker):
     builder = mocker.MagicMock()
-    builder.time.simulant_step_sizes = lambda: lambda: lambda idx: pd.Series(
-        [pd.Timedelta(days=3) if i % 2 == 0 else pd.Timedelta(days=5) for i in idx], index=idx
-    )
+    manager = ValuesManager()
     manager.setup(builder)
-    return manager
+    builder.value.register_value_producer = manager.register_value_producer
+    builder.value.register_value_modifier = manager.register_value_modifier
+    return builder
 
 
 @pytest.fixture()
@@ -409,33 +408,23 @@ def test_multiple_modifiers(SimulationContext, base_config):
         )
 
 
-def test_step_size_post_processor(manager):
+def test_step_size_post_processor(builder):
     """Test that step size post-processor chooses the minimum modified step, or minimum global step,
     whichever is larger."""
     index = pd.Index(range(10))
     clock = SimulationClock()
     clock._standard_step_size = clock._minimum_step_size = pd.Timedelta(days=2)
-
-    pipeline = manager.register_value_producer(
-        "test_step_size",
-        source=lambda idx: [pd.Series(np.nan, index=idx).astype("timedelta64[ns]")],
-        preferred_combiner=list_combiner,
-        preferred_post_processor=clock.step_size_post_processor,
-    )
+    clock.setup(builder)
 
     ## Add modifier that set the step size to 7 for even indices and 5 for odd indices
-    manager.register_value_modifier(
-        "test_step_size",
-        modifier=lambda idx: pd.Series(
+    clock.register_step_modifier(lambda idx: pd.Series(
             [pd.Timedelta(days=7) if i % 2 == 0 else pd.Timedelta(days=5) for i in idx],
             index=idx,
-        ),
-    )
+        ))
     ## Add modifier that sets the step size to 9 for all simulants
-    manager.register_value_modifier(
-        "test_step_size", modifier=lambda idx: pd.Series(pd.Timedelta(days=9), index=idx)
+    clock.register_step_modifier(lambda idx: pd.Series(pd.Timedelta(days=9), index=idx)
     )
-    value = pipeline(index)
+    value = clock._step_size_pipeline(index)
     evens = value.iloc[lambda x: x.index % 2 == 0]
     odds = value.iloc[lambda x: x.index % 2 == 1]
 
@@ -443,8 +432,7 @@ def test_step_size_post_processor(manager):
     assert np.all(evens == pd.Timedelta(days=6))
     assert np.all(odds == pd.Timedelta(days=4))
 
-    manager.register_value_modifier(
-        "test_step_size", modifier=lambda idx: pd.Series(pd.Timedelta(days=0.5), index=idx)
+    clock.register_step_modifier(lambda idx: pd.Series(pd.Timedelta(days=0.5), index=idx)
     )
-    value = pipeline(index)
+    value = clock._step_size_pipeline(index)
     assert np.all(value == pd.Timedelta(days=2))

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -145,7 +145,7 @@ class StepModifier(MockGenericComponent):
 
     def setup(self, builder) -> None:
         super().setup(builder)
-        builder.time.modify_step_size(self.modify_step)
+        builder.time.register_step_modifier(self.modify_step)
         self.rate_pipeline = builder.value.register_value_producer(
             f"test_rate_{self.name}",
             source=lambda idx: pd.Series(1.75, index=idx),


### PR DESCRIPTION
## Add Time Interface Step Size Modifier
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4702

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Replace the builder.value.register_value_modifier for step size modification with a time interface method (just wrapping the value method) to highlight the special status of this particular pipeline.

I also adjusted the post processor test, to rely less on the values manager.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
modified test coverage still passes.