### PR TITLE
Integrate MNCH implementation learnings

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -238,7 +238,7 @@ class SimulationContext:
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.get_active_simulants(
-                self._population.get_population(False).index, self._clock.event_time
+                self._population.get_population(True).index, self._clock.event_time
             )
             self.time_step_emitters[event](pop_to_update)
         self._clock.step_forward(self._population.get_population(False).index)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -237,8 +237,7 @@ class SimulationContext:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
             pop_to_update = self._clock.get_active_simulants(
-                self._population.get_population(False).index,
-                self._clock.event_time
+                self._population.get_population(False).index, self._clock.event_time
             )
             self._logger.debug("Event: %s" % event)
             self._logger.debug("Updating population: %s" % len(pop_to_update))

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -235,12 +235,13 @@ class SimulationContext:
 
     def step(self) -> None:
         self._logger.debug(self._clock.time)
-        for event in self.time_step_events:
-            self._lifecycle.set_state(event)
-            pop_to_update = self._clock.get_active_simulants(
+        pop_to_update = self._clock.get_active_simulants(
                 self._population.get_population(True).index,
                 self._clock.event_time,
             )
+        self._logger.debug("Updating population: %s" % len(pop_to_update))
+        for event in self.time_step_events:
+            self._lifecycle.set_state(event)
             self.time_step_emitters[event](pop_to_update)
         self._clock.step_forward(self._population.get_population(False).index)
 

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -242,7 +242,7 @@ class SimulationContext:
                 self._clock.event_time,
             )
             self.time_step_emitters[event](pop_to_update)
-        self._clock.step_forward(self._population.get_population(True).index)
+        self._clock.step_forward(self._population.get_population(False).index)
 
     def run(self) -> None:
         while self._clock.time < self._clock.stop_time:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -236,11 +236,13 @@ class SimulationContext:
     def step(self) -> None:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
+            self._logger.debug(f"Event: {event}")
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.get_active_simulants(
                 self.get_population().index,
                 self._clock.event_time,
             )
+            self._logger.debug(f"Updating: {len(pop_to_update)}")
             self.time_step_emitters[event](pop_to_update)
         self._clock.step_forward(self.get_population().index)
 

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -231,17 +231,18 @@ class SimulationContext:
         self._clock.step_backward()
         population_size = pop_params.population_size
         self.simulant_creator(population_size, {"sim_state": "setup"})
-        self._clock.step_forward(self._population.get_population(True).index)
+        self._clock.step_forward(self.get_population().index)
 
     def step(self) -> None:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.get_active_simulants(
-                self._population.get_population(True).index, self._clock.event_time
+                self.get_population().index, 
+                self._clock.event_time,
             )
             self.time_step_emitters[event](pop_to_update)
-        self._clock.step_forward(self._population.get_population(False).index)
+        self._clock.step_forward(self.get_population().index)
 
     def run(self) -> None:
         while self._clock.time < self._clock.stop_time:
@@ -249,7 +250,7 @@ class SimulationContext:
 
     def finalize(self) -> None:
         self._lifecycle.set_state("simulation_end")
-        self.end_emitter(self._population.get_population(True).index)
+        self.end_emitter(self.get_population().index)
         unused_config_keys = self.configuration.unused_keys()
         if unused_config_keys:
             self._logger.warning(
@@ -259,7 +260,7 @@ class SimulationContext:
     def report(self, print_results: bool = True) -> Dict[str, Any]:
         self._lifecycle.set_state("report")
         metrics = self._values.get_value("metrics")(
-            self._population.get_population(True).index
+            self.get_population().index
         )
         if print_results:
             self._logger.info("\n" + pformat(metrics))

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -236,12 +236,10 @@ class SimulationContext:
     def step(self) -> None:
         self._logger.debug(self._clock.time)
         for event in self.time_step_events:
+            self._lifecycle.set_state(event)
             pop_to_update = self._clock.get_active_simulants(
                 self._population.get_population(False).index, self._clock.event_time
             )
-            self._logger.debug("Event: %s" % event)
-            self._logger.debug("Updating population: %s" % len(pop_to_update))
-            self._lifecycle.set_state(event)
             self.time_step_emitters[event](pop_to_update)
         self._clock.step_forward(self._population.get_population(False).index)
 

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -235,12 +235,13 @@ class SimulationContext:
 
     def step(self) -> None:
         self._logger.debug(self._clock.time)
-        pop_to_update = self._clock.get_active_simulants(
-                self._population.get_population(True).index,
-                self._clock.event_time,
-            )
-        self._logger.debug("Updating population: %s" % len(pop_to_update))
         for event in self.time_step_events:
+            pop_to_update = self._clock.get_active_simulants(
+                self._population.get_population(False).index,
+                self._clock.event_time
+            )
+            self._logger.debug("Event: %s" % event)
+            self._logger.debug("Updating population: %s" % len(pop_to_update))
             self._lifecycle.set_state(event)
             self.time_step_emitters[event](pop_to_update)
         self._clock.step_forward(self._population.get_population(False).index)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -238,7 +238,7 @@ class SimulationContext:
         for event in self.time_step_events:
             self._lifecycle.set_state(event)
             pop_to_update = self._clock.get_active_simulants(
-                self.get_population().index, 
+                self.get_population().index,
                 self._clock.event_time,
             )
             self.time_step_emitters[event](pop_to_update)
@@ -259,9 +259,7 @@ class SimulationContext:
 
     def report(self, print_results: bool = True) -> Dict[str, Any]:
         self._lifecycle.set_state("report")
-        metrics = self._values.get_value("metrics")(
-            self.get_population().index
-        )
+        metrics = self._values.get_value("metrics")(self.get_population().index)
         if print_results:
             self._logger.info("\n" + pformat(metrics))
             performance_metrics = self.get_performance_metrics()

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -261,7 +261,7 @@ class DateTimeClock(SimulationClock):
             if time.standard_step_size
             else self._minimum_step_size
         )
-        self._clock_step_size = self._standard_step_size
+        self._clock_step_size = self._minimum_step_size
 
     def __repr__(self):
         return "DateTimeClock()"

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -165,7 +165,7 @@ class SimulationClock(Manager):
             return index
         return (
             self._individual_clocks.subview(["next_event_time", "tracked"])
-            .get(index,f"(next_event_time <= {time} or not tracked")
+            .get(index, f"(next_event_time <= {time} or not tracked")
             .index
         )
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -158,7 +158,7 @@ class SimulationClock(Manager):
 
     def get_active_simulants(self, index: pd.Index, time: Time) -> pd.Index:
         """Gets population that is aligned with global clock"""
-        if not self._individual_clocks:
+        if index.empty or not self._individual_clocks:
             return index
         next_event_times = self.simulant_next_event_times(index)
         return next_event_times[next_event_times <= time].index

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -43,9 +43,6 @@ class SimulationClock(Manager):
     def columns_created(self) -> List[str]:
         return ["next_event_time", "step_size"]
 
-    @property
-    def columns_required(self) -> List[str]:
-        return ["tracked"]
 
     @property
     def time(self) -> Time:
@@ -110,9 +107,8 @@ class SimulationClock(Manager):
             self.on_initialize_simulants, creates_columns=self.columns_created
         )
         builder.event.register_listener("post_setup", self.on_post_setup)
-        self._individual_clocks = builder.population.get_view(
-            columns=self.columns_created + self.columns_required
-        )
+        ## Doesn't include tracked!
+        self._individual_clocks = builder.population.get_view(columns=self.columns_created)
 
     def on_post_setup(self, event: "Event") -> None:
         if not self._step_size_pipeline.mutators:
@@ -170,8 +166,8 @@ class SimulationClock(Manager):
         if not self._individual_clocks:
             return index
         return (
-            self._individual_clocks.subview(["next_event_time", "tracked"])
-            .get(index, f"(next_event_time <= {time} or not tracked")
+            self._individual_clocks.subview(["next_event_time"])
+            .get(index, query=f"next_event_time <= str({time}) or tracked == True")
             .index
         )
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -145,7 +145,7 @@ class SimulationClock(Manager):
     def step_forward(self, index: pd.Index) -> None:
         """Advances the clock by the current step size, and updates aligned simulant clocks."""
         self._clock_time += self.step_size
-        if self._individual_clocks:
+        if self._individual_clocks and index.any():
             update_index = self.get_active_simulants(index, self.time)
             clocks_to_update = self._individual_clocks.get(update_index)
             if not clocks_to_update.empty:
@@ -158,7 +158,7 @@ class SimulationClock(Manager):
 
     def get_active_simulants(self, index: pd.Index, time: Time) -> pd.Index:
         """Gets population that is aligned with global clock"""
-        if not self._individual_clocks:
+        if index.empty or not self._individual_clocks:
             return index
         next_event_times = self.simulant_next_event_times(index)
         return next_event_times[next_event_times <= time].index

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -44,6 +44,10 @@ class SimulationClock(Manager):
         return ["next_event_time", "step_size"]
 
     @property
+    def columns_required(self) -> List[str]:
+        return ["tracked"]
+
+    @property
     def time(self) -> Time:
         """The current simulation time."""
         if not self._clock_time:

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -110,7 +110,7 @@ class SimulationClock(Manager):
             self.on_initialize_simulants, creates_columns=self.columns_created
         )
         builder.event.register_listener("post_setup", self.on_post_setup)
-        self._individual_clocks = builder.population.get_view(columns=self.columns_created)
+        self._individual_clocks = builder.population.get_view(columns=self.columns_created + self.columns_required)
 
     def on_post_setup(self, event: "Event") -> None:
         if not self._step_size_pipeline.mutators:

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -110,7 +110,9 @@ class SimulationClock(Manager):
             self.on_initialize_simulants, creates_columns=self.columns_created
         )
         builder.event.register_listener("post_setup", self.on_post_setup)
-        self._individual_clocks = builder.population.get_view(columns=self.columns_created + self.columns_required)
+        self._individual_clocks = builder.population.get_view(
+            columns=self.columns_created + self.columns_required
+        )
 
     def on_post_setup(self, event: "Event") -> None:
         if not self._step_size_pipeline.mutators:

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -163,10 +163,9 @@ class SimulationClock(Manager):
         """Gets population that is aligned with global clock"""
         if not self._individual_clocks:
             return index
-        query = f"(next_event_time <= {time} or not tracked"
         return (
             self._individual_clocks.subview(["next_event_time", "tracked"])
-            .get(index, query)
+            .get(index,f"(next_event_time <= {time} or not tracked")
             .index
         )
 

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -111,10 +111,15 @@ def rescale_post_processor(value: NumberLike, manager: "ValuesManager") -> Numbe
 
     """
     if hasattr(value, "index"):
-        time_step = manager.simulant_step_sizes(value.index).astype('timedelta64[ns]').dt
+        return value.mul(
+            manager.simulant_step_sizes(value.index)
+            .astype("timedelta64[ns]")
+            .dt.total_seconds()
+            / (60 * 60 * 24 * 365.0),
+            axis=0,
+        )
     else:
-        time_step = manager.step_size()
-    return from_yearly(value, time_step)
+        return from_yearly(value, manager.step_size())
 
 
 def union_post_processor(values: List[NumberLike], _) -> NumberLike:

--- a/src/vivarium/framework/values.py
+++ b/src/vivarium/framework/values.py
@@ -111,7 +111,7 @@ def rescale_post_processor(value: NumberLike, manager: "ValuesManager") -> Numbe
 
     """
     if hasattr(value, "index"):
-        time_step = manager.simulant_step_sizes(value.index).dt
+        time_step = manager.simulant_step_sizes(value.index).astype('timedelta64[ns]').dt
     else:
         time_step = manager.step_size()
     return from_yearly(value, time_step)

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -220,7 +220,9 @@ def test_basic_iteration(SimulationContext, base_config, components, varied_step
             assert np.all(
                 sim._clock.simulant_next_event_times(full_pop_index) == sim._clock.event_time
             )
-            assert np.all(sim._clock.simulant_step_sizes(full_pop_index) == sim._clock.step_size)
+            assert np.all(
+                sim._clock.simulant_step_sizes(full_pop_index) == sim._clock.step_size
+            )
         take_step_and_validate(
             sim, listener, expected_simulants=full_pop_index, expected_step_size_days=1
         )


### PR DESCRIPTION
## Integrate MNCH implementation learnings
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
misc
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4719

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
1. Add some checks for empty indices
2. Ensure that rescale pipeline doesn't blow up
3. Figure out how to properly deal with Tracked / Untracked / Dead/ Alive simulants. Including untracked or dead simulants in the step_forward() call will cause a lot of erroneous timesteps

(3) has a basically two options. Either we sort of commit to not including tracked simulants in event indexes, in which case we basically lose the ability to retrack simulants (to the extent that that matters)
Or, we propagate untracked simulants to events and figure out an appropriate (separate) way to deal with their next event times. 
I opted for the former for the time being, under the assumption that we'll want to revamp the way tracked/untracked works at some point in the near-ish future anyway. 
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Combo of tested in MNCH and new test coverage added
