### PR TITLE
Move "untracked" simulants to the end

### DIFF
--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -180,7 +180,7 @@ class SimulationClock(Manager):
         if index.empty or not self._individual_clocks:
             return index
         next_event_times = self.simulant_next_event_times(index)
-        return next_event_times.loc[next_event_times <= time].index
+        return next_event_times[next_event_times <= time].index
 
     def move_simulants_to_end(self, index: pd.Index) -> None:
         if self._individual_clocks and index.any():

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -42,6 +42,10 @@ class SimulationClock(Manager):
     @property
     def columns_created(self) -> List[str]:
         return ["next_event_time", "step_size"]
+    
+    @property
+    def columns_required(self) -> List[str]:
+        return ["tracked"]
 
     @property
     def time(self) -> Time:
@@ -106,7 +110,7 @@ class SimulationClock(Manager):
             self.on_initialize_simulants, creates_columns=self.columns_created
         )
         builder.event.register_listener("post_setup", self.on_post_setup)
-        self._individual_clocks = builder.population.get_view(columns=self.columns_created)
+        self._individual_clocks = builder.population.get_view(columns=self.columns_created + self.columns_required)
 
     def on_post_setup(self, event: "Event") -> None:
         if not self._step_size_pipeline.mutators:
@@ -150,6 +154,7 @@ class SimulationClock(Manager):
             clocks_to_update = self._individual_clocks.get(update_index)
             if not clocks_to_update.empty:
                 clocks_to_update["step_size"] = self._step_size_pipeline(update_index)
+                clocks_to_update.loc[clocks_to_update["tracked"] == False, "step_size"] = self.stop_time - self.time
                 clocks_to_update["next_event_time"] = (
                     self.time + clocks_to_update["step_size"]
                 )
@@ -161,7 +166,7 @@ class SimulationClock(Manager):
         if not self._individual_clocks:
             return index
         next_event_times = self.simulant_next_event_times(index)
-        return next_event_times[next_event_times <= time].index
+        return next_event_times.loc[next_event_times <= time].index
 
     def step_size_post_processor(self, values: List[NumberLike], _) -> pd.Series:
         """Computes the largest feasible step size for each simulant. This is the smallest component-modified

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -479,13 +479,13 @@ def test_move_simulants_to_end(SimulationContext, base_config):
     sim.initialize_simulants()
     full_pop_index = get_full_pop_index(sim)
     odds = get_index_by_parity(full_pop_index, "odds")
-
+    evens = get_index_by_parity(full_pop_index, "evens")
     take_step_and_validate(sim, listener, full_pop_index, expected_step_size_days=3)
     assert step_modifier_component.ts_pipeline_value.index.equals(full_pop_index)
-
-    ## We untracked even simulants during the last timestep.
-    ## Give them a step size of 5, but show that this has no effect on the next event time.
-    step_modifier_component.step_modifier_even = 5
+    assert np.all(
+        sim._clock.simulant_next_event_times(evens)
+        == sim._clock.stop_time + sim._clock.minimum_step_size
+    )
 
     for _ in range(2):
         take_step_and_validate(sim, listener, odds, expected_step_size_days=3)


### PR DESCRIPTION
## Move "untracked" simulants to the end
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature/bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4743

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We want to be able to set dead simulants' next event time to the end of the simulation. An easy way to do this would be by setting all untracked simulants to the end; in practice, setting a simulant to be untracked at all is a can of worms.
What I decided to do is just create an interface method that takes an index and tells the time manager to set those simulants' next event time to the stop time (plus a minimum timestep). I just made a (private) instance variable that is a pandas index which can be updated through the interface method; I figured that the information doesn't need to be cached or accessed outside of the time manager, so there is no need to put it into the state table.

I also made it so that formally "untracked" simulants now are included in each event index etc, so there is nothing distinguishing them from normal simulants (consistent with non-variable time steps).

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Added new test, updated the one that explicitly sets untracked column