### PR TITLE
Document how to remove components from an interactive simulation

### DIFF
--- a/docs/source/tutorials/running_a_simulation/interactive.rst
+++ b/docs/source/tutorials/running_a_simulation/interactive.rst
@@ -97,16 +97,6 @@ distributed with ``vivarium``.
    p = get_model_specification_path()
    sim = InteractiveContext(p)
 
-If you are working with a real model, you won't have this convenience function.
-Typically, our models are pip-installable and laid out such that their model specification can
-be found like so:
-
-.. code-block:: python
-
-    import my_vivarium_model
-    p = my_vivarium_model.__file__.replace('__init__.py', 'model_specifications/model_spec.yaml')
-    sim = InteractiveContext(p)
-
 The ``sim`` object produced here is all set up and ready to run if you want
 to jump directly to the :ref:`running the simulation <interactive_run>`
 section.

--- a/docs/source/tutorials/running_a_simulation/interactive.rst
+++ b/docs/source/tutorials/running_a_simulation/interactive.rst
@@ -348,9 +348,7 @@ Removing components
 Currently, there isn't a way to use the above approach to *remove* components from
 an existing model (without using private attributes).
 
-This is a very common use case, because often when we run an interactive simulation,
-we don't need any of the simulation's observers.
-However, removing components should be done with care: if you remove a component without
+Removing components should be done with care: if you remove a component without
 removing other components that depend on it, the simulation will break!
 
 You can remove components by creating a model specification and editing it *before* creating

--- a/docs/source/tutorials/running_a_simulation/interactive.rst
+++ b/docs/source/tutorials/running_a_simulation/interactive.rst
@@ -273,9 +273,9 @@ population size to be smaller so the simulation takes less time to run.
     # Setting attributes ensures you are updating existing keys, rather than
     # creating new ones
     sim.configuration.population.population_size = 1_000
-    # .update can be more concise -- but note that this will not warn you if you
-    # are adding new keys, e.g. due to a typo!
-    sim.configuration.update({'population': {'population_size': 1_000}})
+    # .update can be a more concise alternative -- but note that this will not
+    # warn you if you are adding new keys, e.g. due to a typo!
+    # sim.configuration.update({'population': {'population_size': 1_000}})
 
 We then need to call the
 :meth:`vivarium.framework.engine.SimulationContext.setup` method on the

--- a/docs/source/tutorials/running_a_simulation/interactive.rst
+++ b/docs/source/tutorials/running_a_simulation/interactive.rst
@@ -350,8 +350,10 @@ an existing model (without using private attributes).
 
 This is a very common use case, because often when we run an interactive simulation,
 we don't need any of the simulation's observers.
+However, removing components should be done with care: if you remove a component without
+removing other components that depend on it, the simulation will break!
 
-This can be achieved by creating a model specification and editing it *before* creating
+You can remove components by creating a model specification and editing it *before* creating
 the InteractiveContext:
 
 .. testcode::


### PR DESCRIPTION
## Document how to remove components from an interactive simulation

### Description
- *Category*: documentation
- *JIRA issue*: None

### Changes and notes

This is a common use case, and has previously been achieved by researchers performing an editable install and then editing the YAML file directly, which is brittle.

### Testing

Ran doctests.