### PR TITLE
Docs bug fixes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,11 @@ version: 2
 
 # Configure the python version and environment construction run before
 # docs are built.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 python:
-  version: 3.8
   install:
       # This runs pip install .[docs] from the project root.
     - method: pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.2 - 01/29/24**
+
+ - Fix broken readthedocs build
+
 **2.3.1 - 01/09/24**
 
  - Update PyPI to 2FA with trusted publisher

--- a/docs/source/api_reference/index.rst
+++ b/docs/source/api_reference/index.rst
@@ -4,7 +4,7 @@ API Reference
 .. automodule:: vivarium
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *


### PR DESCRIPTION
## Fix broken build on readthedocs
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix/documentation

### Changes and notes
- Updated the .readthedocs.yaml per this thread: https://github.com/openedx/edx-cookiecutters/issues/416 
- Also reduced the depth of the API reference tree to make it easier to read (this part has been tested locally)

### Testing
Need to merge to main to see if it works.