### PR TITLE
Improve readability of api reference docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.3 - 01/29/24**
+
+ - Improve readability of api reference docs
+
 **2.3.2 - 01/29/24**
 
  - Fix broken readthedocs build

--- a/docs/source/api_reference/framework/artifact/index.rst
+++ b/docs/source/api_reference/framework/artifact/index.rst
@@ -5,7 +5,7 @@ Data Artifact Management
 .. automodule:: vivarium.framework.artifact
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/framework/components/index.rst
+++ b/docs/source/api_reference/framework/components/index.rst
@@ -5,7 +5,7 @@ Component Management
 .. automodule:: vivarium.framework.components
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/framework/index.rst
+++ b/docs/source/api_reference/framework/index.rst
@@ -5,7 +5,7 @@ The Vivarium Framework
 .. automodule:: vivarium.framework
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/framework/logging/index.rst
+++ b/docs/source/api_reference/framework/logging/index.rst
@@ -1,7 +1,7 @@
 .. automodule:: vivarium.framework.logging
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/framework/lookup/index.rst
+++ b/docs/source/api_reference/framework/lookup/index.rst
@@ -1,7 +1,7 @@
 .. automodule:: vivarium.framework.lookup
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/framework/population/index.rst
+++ b/docs/source/api_reference/framework/population/index.rst
@@ -5,7 +5,7 @@ Population Management
 .. automodule:: vivarium.framework.population
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/framework/randomness/index.rst
+++ b/docs/source/api_reference/framework/randomness/index.rst
@@ -5,7 +5,7 @@ Random Number Generation
 .. automodule:: vivarium.framework.randomness
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *

--- a/docs/source/api_reference/interface/index.rst
+++ b/docs/source/api_reference/interface/index.rst
@@ -5,7 +5,7 @@ Interface
 .. automodule:: vivarium.interface
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *


### PR DESCRIPTION
## Improve readability of api reference docs
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: documentation
- *JIRA issue*: N/A

### Changes and notes
- reduce the toctree depth to 1 for all api docs 

### Testing
Built docs locally