### PR TITLE
Mic 3081/parse metrics without stratification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.4 - 02/23/24**
+
+  - Fixes parsing in results manager to remove trailing underscore
+
 **2.3.3 - 01/29/24**
 
  - Improve readability of api reference docs

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -74,7 +74,7 @@ class ResultsManager(Manager):
     def on_post_setup(self, event: Event):
         # update self._metrics to have all output keys
         def create_measure_specific_keys(measure: str, stratifications: List[str]) -> None:
-            measure_str = f"MEASURE_{measure}_"
+            measure_str = f"MEASURE_{measure}"
             individual_stratification_strings = [
                 [
                     f"{stratification.name.upper()}_{category}"
@@ -88,7 +88,12 @@ class ResultsManager(Manager):
             for complete_stratifications in itertools.product(
                 *individual_stratification_strings
             ):
-                key = measure_str + "_".join(complete_stratifications)
+                key = (
+                    measure_str + "_" + "_".join(complete_stratifications)
+                    if complete_stratifications
+                    else measure_str
+                )
+                breakpoint()
                 self._metrics[key] = 0
 
         for event in self._results_context.observations:

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -93,7 +93,6 @@ class ResultsManager(Manager):
                     if complete_stratifications
                     else measure_str
                 )
-                breakpoint()
                 self._metrics[key] = 0
 
         for event in self._results_context.observations:


### PR DESCRIPTION
## Mic 3081/parse metrics without stratification

### Updates parsing of measure string and stratifications in results manager to remove trailing underscore
- *Category*: Other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-3081

### Changes and notes
-updates measure string and parsing in results manager to remove trailing underscore

### Testing
Ran simulation and saw expected measure keys for results manager with and without stratification.

