### PR TITLE
Mic-4973/component-config-lookup-table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.4.0 - 04/10/24**
+
+  - Add functionality to Component to configure lookup tables
+
 **2.3.7 - 03/21/24**
   
   - Add deprecation warning to import ConfigTree from the config_tree package

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -79,7 +79,7 @@ class Component(ABC):
         categorical_columns: List[str] = [],
         skip_build: bool = False,
         key_name: str = None,
-        **kwargs,
+        **kwargs: Dict[str, Any],
     ) -> dict:
         config = {
             "value": value,

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -16,6 +16,9 @@ class MockComponentA(Component):
         self.args = args
         self.builder_used_for_setup = None
 
+    def create_lookup_tables(self, builder):
+        return {}
+
     def __eq__(self, other: Any) -> bool:
         return type(self) == type(other) and self.name == other.name
 
@@ -37,6 +40,9 @@ class MockComponentB(Component):
     def setup(self, builder: Builder) -> None:
         self.builder_used_for_setup = builder
         builder.value.register_value_modifier("metrics", self.metrics)
+
+    def create_lookup_tables(self, builder):
+        return {}
 
     def metrics(self, _, metrics):
         if "test" in metrics:

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -380,38 +380,36 @@ def test_component_lookup_table_configuration(hdf_file_path):
         {
             "input_data": {"artifact_path": hdf_file_path},
             component.name: {
-                "lookup_tables": {
-                    "favorite_team": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=["test_column_1"],
-                        continuous_columns=[],
-                        key_name="simulants.favorite_team",
-                    ),
-                    "favorite_scalar": Component.build_lookup_table_config(
-                        value=0.4,
-                    ),
-                    "favorite_color": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=["test_column_2"],
-                        continuous_columns=["test_column_3"],
-                        key_name="simulants.favorite_color",
-                    ),
-                    "baking_time": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=["test_column_1", "test_column_2"],
-                        continuous_columns=["test_column_3"],
-                        key_name="simulants.baking_time",
-                        skip_build=True,
-                    ),
-                    "favorite_number": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=[],
-                        continuous_columns=["test_column_3"],
-                        key_name="simulants.favorite_number",
-                    ),
-                },
+                "favorite_team": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=["test_column_1"],
+                    continuous_columns=[],
+                    key_name="simulants.favorite_team",
+                ),
+                "favorite_scalar": Component.build_lookup_table_config(
+                    value=0.4,
+                ),
+                "favorite_color": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=["test_column_2"],
+                    continuous_columns=["test_column_3"],
+                    key_name="simulants.favorite_color",
+                ),
+                "baking_time": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=["test_column_1", "test_column_2"],
+                    continuous_columns=["test_column_3"],
+                    key_name="simulants.baking_time",
+                    build_lookup_table=False,
+                ),
+                "favorite_number": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=[],
+                    continuous_columns=["test_column_3"],
+                    key_name="simulants.favorite_number",
+                ),
             },
-        }
+        },
     )
     sim.setup()
 
@@ -439,14 +437,12 @@ def test_component_lookup_table_configuration(hdf_file_path):
         (
             # Overlapping columns
             {
-                "lookup_tables": {
-                    "favorite_color": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=["test_column_2"],
-                        continuous_columns=["test_column_2", "test_column_3"],
-                        key_name="simulants.favorite_color",
-                    ),
-                },
+                "favorite_color": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=["test_column_2"],
+                    continuous_columns=["test_column_2", "test_column_3"],
+                    key_name="simulants.favorite_color",
+                ),
             },
             "There should be no overlap between",
             ValueError,
@@ -454,14 +450,12 @@ def test_component_lookup_table_configuration(hdf_file_path):
         (
             # Wrong key for artifact
             {
-                "lookup_tables": {
-                    "favorite_color": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=["test_column_1"],
-                        continuous_columns=[],
-                        key_name="simulants.favorite_team",
-                    ),
-                },
+                "favorite_color": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=["test_column_1"],
+                    continuous_columns=[],
+                    key_name="simulants.favorite_team",
+                ),
             },
             "simulants.favorite_team should be in",
             ArtifactException,
@@ -469,14 +463,12 @@ def test_component_lookup_table_configuration(hdf_file_path):
         (
             # Columns not in artifact data
             {
-                "lookup_tables": {
-                    "favorite_color": Component.build_lookup_table_config(
-                        value="data",
-                        categorical_columns=["test_column_1"],
-                        continuous_columns=["test_column_3"],
-                        key_name="simulants.favorite_color",
-                    ),
-                },
+                "favorite_color": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=["test_column_1"],
+                    continuous_columns=["test_column_3"],
+                    key_name="simulants.favorite_color",
+                ),
             },
             "The columns supplied",
             ValueError,

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -27,6 +27,40 @@ class ColumnCreator(Component):
 
 
 class LookupCreator(ColumnCreator):
+    CONFIGURATION_DEFAULTS = {
+        "lookup_creator": {
+            "favorite_team": Component.build_lookup_table_config(
+                value="data",
+                categorical_columns=["test_column_1"],
+                continuous_columns=[],
+                key_name="simulants.favorite_team",
+            ),
+            "favorite_scalar": Component.build_lookup_table_config(
+                value=0.4,
+            ),
+            "favorite_color": Component.build_lookup_table_config(
+                value="data",
+                categorical_columns=["test_column_2"],
+                continuous_columns=["test_column_3"],
+                key_name="simulants.favorite_color",
+            ),
+            "favorite_number": Component.build_lookup_table_config(
+                value="data",
+                categorical_columns=[],
+                continuous_columns=["test_column_3"],
+                key_name="simulants.favorite_number",
+            ),
+            # This is not in the class property so will not get created automatically
+            "baking_time": Component.build_lookup_table_config(
+                value="data",
+                categorical_columns=["test_column_1", "test_column_2"],
+                continuous_columns=["test_column_3"],
+                key_name="simulants.baking_time",
+                build_lookup_table=False,
+            ),
+        },
+    }
+
     @property
     def standard_lookup_tables(self) -> List[str]:
         return ["favorite_team", "favorite_color", "favorite_number", "favorite_scalar"]
@@ -391,37 +425,6 @@ def test_component_lookup_table_configuration(hdf_file_path):
     sim.configuration.update(
         {
             "input_data": {"artifact_path": hdf_file_path},
-            component.name: {
-                "favorite_team": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=["test_column_1"],
-                    continuous_columns=[],
-                    key_name="simulants.favorite_team",
-                ),
-                "favorite_scalar": Component.build_lookup_table_config(
-                    value=0.4,
-                ),
-                "favorite_color": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=["test_column_2"],
-                    continuous_columns=["test_column_3"],
-                    key_name="simulants.favorite_color",
-                ),
-                "favorite_number": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=[],
-                    continuous_columns=["test_column_3"],
-                    key_name="simulants.favorite_number",
-                ),
-                # This is not in the class property so will not get created automatically
-                "baking_time": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=["test_column_1", "test_column_2"],
-                    continuous_columns=["test_column_3"],
-                    key_name="simulants.baking_time",
-                    build_lookup_table=False,
-                ),
-            },
         },
     )
     sim.setup()

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -26,6 +26,18 @@ class ColumnCreator(Component):
         self.population_view.update(initialization_data)
 
 
+class LookupCreator(ColumnCreator):
+    @property
+    def standard_lookup_tables(self) -> List[str]:
+        return ["favorite_team", "favorite_color", "favorite_number", "favorite_scalar"]
+
+
+class SingleLookupCreator(ColumnCreator):
+    @property
+    def standard_lookup_tables(self) -> List[str]:
+        return ["favorite_color"]
+
+
 class ColumnRequirer(Component):
     @property
     def columns_required(self) -> List[str]:
@@ -374,7 +386,7 @@ def test_component_lookup_table_configuration(hdf_file_path):
     for key, data in artifact_data.items():
         artifact.write(key, data)
 
-    component = ColumnCreator()
+    component = LookupCreator()
     sim = InteractiveContext(components=[component], setup=False)
     sim.configuration.update(
         {
@@ -395,18 +407,19 @@ def test_component_lookup_table_configuration(hdf_file_path):
                     continuous_columns=["test_column_3"],
                     key_name="simulants.favorite_color",
                 ),
+                "favorite_number": Component.build_lookup_table_config(
+                    value="data",
+                    categorical_columns=[],
+                    continuous_columns=["test_column_3"],
+                    key_name="simulants.favorite_number",
+                ),
+                # This is not in the class property so will not get created automatically
                 "baking_time": Component.build_lookup_table_config(
                     value="data",
                     categorical_columns=["test_column_1", "test_column_2"],
                     continuous_columns=["test_column_3"],
                     key_name="simulants.baking_time",
                     build_lookup_table=False,
-                ),
-                "favorite_number": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=[],
-                    continuous_columns=["test_column_3"],
-                    key_name="simulants.favorite_number",
                 ),
             },
         },
@@ -485,7 +498,7 @@ def test_failing_component_lookup_table_configurations(
     artifact = Artifact(hdf_file_path)
     artifact.write("simulants.favorite_color", data)
 
-    component = ColumnCreator()
+    component = SingleLookupCreator()
     sim = InteractiveContext(components=[component], setup=False)
     override_config = {
         "input_data": {"artifact_path": hdf_file_path},


### PR DESCRIPTION
## Mic-4973/component-config-lookup-table

### Adds functionality in Component to configure and automatically create lookup tables
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4973

### Changes and notes
-adds methods in component to build and create lookup tables from user configurations.

### Testing
All tests pass. Successfully ran simulation with custom configuration
