### PR TITLE
Refactor/sbachmei/break up gather results

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -259,13 +259,9 @@ class SimulationContext:
                 f"Some configuration keys not used during run: {unused_config_keys}."
             )
 
-    def report(self, print_results: bool = True) -> Dict[str, Any]:
+    def report(self, results: Path, print_results: bool = True):
         self._lifecycle.set_state("report")
         metrics = self._values.get_value("metrics")(self.get_population().index)
-
-        # TODO [MIC-4994] - update with new results processing, e.g.
-        #   for measure, dataframe in self._results.metrics.items():
-        #       dataframe.to_csv(f"{results}/{measure}.csv")
         if print_results:
             self._logger.info("\n" + pformat(metrics))
             performance_metrics = self.get_performance_metrics()
@@ -274,8 +270,8 @@ class SimulationContext:
                 float_format=lambda x: f"{x:.2f}",
             )
             self._logger.info("\n" + performance_metrics)
-
-        return metrics
+        for measure, series in metrics.items():
+            series.to_csv(results / f"{measure}.csv")
 
     def get_performance_metrics(self) -> pd.DataFrame:
         timing_dict = self._lifecycle.timings

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -77,7 +77,7 @@ class ResultsManager(Manager):
                 _pop_filter,
                 stratification_names,
             ), observations in self._results_context.observations[event_name].items():
-                for measure, *_ in observations:
+                for measure, aggregator_sources, *_ in observations:
                     observation_stratifications = [
                         stratification
                         for stratification in self._results_context.stratifications
@@ -87,16 +87,20 @@ class ResultsManager(Manager):
                         stratification.name: stratification.categories
                         for stratification in observation_stratifications
                     }
-                    # Get the complete cartesian product of stratifications
-                    index_values = list(itertools.product(*stratification_values.values()))
+                    if stratification_values:
+                        # Create index of the complete stratifications
+                        idx = pd.MultiIndex.from_tuples(
+                            list(itertools.product(*stratification_values.values())),
+                            names=stratification_values.keys(),
+                        )
+                    else:
+                        idx = pd.Index(aggregator_sources, name=measure)
+                    # Initialize a zeros dataframe
                     self._metrics[measure] = pd.DataFrame(
                         data=0.0,
                         columns=["value"],
-                        index=pd.MultiIndex.from_tuples(
-                            index_values, names=stratification_values.keys()
-                        ),
+                        index=idx,
                     )
-                    self._metrics[measure].name = measure
 
     def on_time_step_prepare(self, event: Event):
         self.gather_results("time_step__prepare", event)
@@ -112,9 +116,11 @@ class ResultsManager(Manager):
 
     def gather_results(self, event_name: str, event: Event):
         population = self._prepare_population(event)
-        for results_group in self._results_context.gather_results(population, event_name):
+        for results_group, measure in self._results_context.gather_results(
+            population, event_name
+        ):
             if results_group is not None:
-                self._metrics[results_group.name] += results_group
+                self._metrics[measure] += results_group
 
     def set_default_stratifications(self, builder):
         default_stratifications = builder.configuration.stratification.default
@@ -257,9 +263,8 @@ class ResultsManager(Manager):
             population[pipeline.name] = pipeline(event.index)
         return population
 
-    def get_results(self, index, metrics):
+    def get_results(self, _index, metrics):
         # Shim for now to allow incremental transition to new results system.
-        # TODO [MIC-4994] Update for new results processing w/ dataframes
         metrics.update(self.metrics)
         return metrics
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -261,7 +261,7 @@ class DateTimeClock(SimulationClock):
                 "month": 7,
                 "day": 2,
             },
-            "step_size": 1,
+            "step_size": 1,  # Days
             "standard_step_size": None,  # Days
         }
     }

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -144,6 +144,7 @@ def run(
     main = handle_exceptions(run_simulation, logger, with_debugger)
     finished_sim = main(model_specification, configuration=override_configuration)
     finished_sim.report(results_root)
+    breakpoint()
 
     # TODO [MIC-4982]: Save out required metrics for VCT to work
     # metrics = pd.DataFrame(finished_sim.report(), index=[0])

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -143,13 +143,13 @@ def run(
 
     main = handle_exceptions(run_simulation, logger, with_debugger)
     finished_sim = main(model_specification, configuration=override_configuration)
+    finished_sim.report(results_root)
 
-    # TODO [MIC-4994] finished_sim.report(results_root)
-    metrics = pd.DataFrame(finished_sim.report(), index=[0])
-    metrics["simulation_run_time"] = time() - start
-    metrics["random_seed"] = finished_sim.configuration.randomness.random_seed
-    metrics["input_draw"] = finished_sim.configuration.input_data.input_draw_number
-    metrics.to_hdf(results_root / "output.hdf", key="data")
+    # TODO [MIC-4982]: Save out required metrics for VCT to work
+    # metrics = pd.DataFrame(finished_sim.report(), index=[0])
+    # metrics["simulation_run_time"] = time() - start
+    # metrics["random_seed"] = finished_sim.configuration.randomness.random_seed
+    # metrics["input_draw"] = finished_sim.configuration.input_data.input_draw_number
 
 
 @simulate.command()

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from vivarium.framework.components.manager import Component
-from vivarium.framework.engine import Builder
+from vivarium.framework.engine import Builder, SimulationContext
 from vivarium.framework.population import SimulantData
 
 NAME = "hogwarts_house"
@@ -30,6 +30,11 @@ RECORDS = list(itertools.product(CATEGORIES, FAMILIARS, POWER_LEVELS, TRACKED_ST
 BASE_POPULATION = pd.DataFrame(data=RECORDS, columns=COL_NAMES)
 
 CONFIG = {
+    "time": {
+        "start": {"year": 2024, "month": 4, "day": 22},
+        "end": {"year": 2029, "month": 4, "day": 22},
+        "step_size": 365,  # Days
+    },
     "stratification": {
         "default": ["student_house", "power_level"],
     },

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -136,6 +136,21 @@ class QuidditchWinsObserver(Component):
         )
 
 
+class NoStratificationsQuidditchWinsObserver(Component):
+    def setup(self, builder: Builder) -> None:
+        builder.results.register_observation(
+            name="no_stratifications_quidditch_wins",
+            aggregator_sources=["quidditch_wins"],
+            aggregator=sum,
+            excluded_stratifications=["student_house", "power_level"],
+            requires_columns=[
+                "quidditch_wins",
+                "familiar",
+                "power_level",
+            ],
+        )
+
+
 class HogwartsResultsStratifier(Component):
     def setup(self, builder: Builder) -> None:
         builder.results.register_stratification(

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -264,9 +264,10 @@ def test_gather_results(
     )
 
     i = 0
-    for r in ctx.gather_results(population, event_name):
+    for result, _measure in ctx.gather_results(population, event_name):
         assert all(
-            math.isclose(result, expected_result, rel_tol=0.0001) for result in r.values
+            math.isclose(actual_result, expected_result, rel_tol=0.0001)
+            for actual_result in result.values
         )
         i += 1
     assert i == 1
@@ -339,7 +340,7 @@ def test_gather_results_partial_stratifications_in_results(
         event_name,
     )
 
-    for results in ctx.gather_results(population, event_name):
+    for results, _measure in ctx.gather_results(population, event_name):
         unladen_results = results.loc["unladen_swallow"]
         assert len(unladen_results) > 0
         assert (unladen_results["value"] == 0).all()
@@ -363,7 +364,7 @@ def test_gather_results_with_empty_pop_filter():
         event_name=event_name,
     )
 
-    for result in ctx.gather_results(population, event_name):
+    for result, _measure in ctx.gather_results(population, event_name):
         assert not result
 
 
@@ -384,7 +385,10 @@ def test_gather_results_with_no_stratifications():
     )
 
     assert len(ctx.stratifications) == 0
-    assert len(list(ctx.gather_results(population, event_name))) == 1
+    assert (
+        len(list(result for result, _measure in ctx.gather_results(population, event_name)))
+        == 1
+    )
 
 
 def test__bad_aggregator_return():
@@ -410,8 +414,8 @@ def test__bad_aggregator_return():
     )
 
     with pytest.raises(TypeError):
-        for r in ctx.gather_results(population, event_name):
-            print(r)
+        for result, _measure in ctx.gather_results(population, event_name):
+            print(result)
 
 
 def test__bad_aggregator_stratification():
@@ -437,5 +441,5 @@ def test__bad_aggregator_stratification():
     )
 
     with pytest.raises(KeyError, match="height"):
-        for r in ctx.gather_results(population, event_name):
-            print(r)
+        for result, _measure in ctx.gather_results(population, event_name):
+            print(result)

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -178,7 +178,7 @@ def mock__prepare_population(self, event):
     ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"],
 )
 def test_register_observation_when_options(when, mocker):
-    """Test the full interface lifecycle of adding an observation and simulatean event."""
+    """Test the full interface lifecycle of adding an observation and simulation event."""
     # Create interface
     mgr = ResultsManager()
     results_interface = ResultsInterface(mgr)

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -20,6 +20,7 @@ from tests.framework.results.helpers import (
     Hogwarts,
     HogwartsResultsStratifier,
     HousePointsObserver,
+    NoStratificationsQuidditchWinsObserver,
     QuidditchWinsObserver,
     mock_get_value,
     sorting_hat_serial,
@@ -263,7 +264,7 @@ def test_metrics_initialized_as_empty_dict(mocker):
     assert mgr.metrics == {}
 
 
-def test_stratified_metrics_initialized_as_zeros_dataframes():
+def test_stratified_metrics_initialization():
     """Test that matrics are being initialized correctly. We expect a dictionary
     of pd.DataFrames. Each key of the dictionary is an observed measure name and
     the corresponding value is a zeroed-out multiindex pd.DataFrame of that observer's
@@ -283,7 +284,6 @@ def test_stratified_metrics_initialized_as_zeros_dataframes():
     for metric in metrics:
         result = metrics[metric]
         assert isinstance(result, pd.DataFrame)
-        assert result.name == metric
         assert (result["value"] == 0).all()
     STUDENT_HOUSES_LIST = list(STUDENT_HOUSES)
     POWER_LEVELS_STR = [str(lvl) for lvl in POWER_LEVELS]
@@ -299,6 +299,21 @@ def test_stratified_metrics_initialized_as_zeros_dataframes():
             names=["familiar", "power_level"],
         )
     )
+
+
+def test_no_stratified_metrics_initialization():
+    """Test that if no stratifications are registered then we initialize a
+    single-row DataFrame with 'value' of zero and index labeled 'all'
+    """
+    components = [QuidditchWinsObserver(), HousePointsObserver(), Hogwarts()]
+    sim = InteractiveContext(configuration=CONFIG, components=components)
+    metrics = sim._results.metrics
+    for metric in metrics:
+        result = metrics[metric]
+        assert isinstance(result, pd.DataFrame)
+        assert result.shape == (1, 1)
+        assert result["value"].iat[0] == 0
+        assert result.index.equals(pd.Index([metric]))
 
 
 def test_update_monotonically_increasing_metrics():
@@ -363,3 +378,18 @@ def test_update_metrics_fully_filtered_pop():
     # The FullyFilteredHousePointsObserver filters the population to a bogus
     # power level and so we should not be observing anything
     assert (sim._results.metrics["house_points"]["value"] == 0).all()
+    sim.step()
+    assert (sim._results.metrics["house_points"]["value"] == 0).all()
+
+
+def test_update_metrics_no_stratifications():
+    components = [Hogwarts(), NoStratificationsQuidditchWinsObserver()]
+    sim = InteractiveContext(configuration=CONFIG, components=components)
+    sim.step()
+    pop = sim.get_population()
+    results = sim._results.metrics["no_stratifications_quidditch_wins"]
+    assert results.loc["quidditch_wins"]["value"] == pop["quidditch_wins"].sum()
+    sim.step()
+    pop = sim.get_population()
+    results = sim._results.metrics["no_stratifications_quidditch_wins"]
+    assert results.loc["quidditch_wins"]["value"] == pop["quidditch_wins"].sum() * 2

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import pandas as pd
 import pytest
 
 from tests.helpers import Listener, MockComponentA, MockComponentB
@@ -243,14 +244,16 @@ def test_SimulationContext_finalize(SimulationContext, base_config, components):
     assert listener.simulation_end_called
 
 
-def test_SimulationContext_report(SimulationContext, base_config, components):
-    # TODO [MIC-4994] Update with new results processing
+def test_SimulationContext_report(SimulationContext, base_config, components, tmpdir):
     sim = SimulationContext(base_config, components)
     sim.setup()
     sim.initialize_simulants()
     sim.run()
     sim.finalize()
-    metrics = sim.report()
-    assert metrics["test"] == len(
+    sim.report(tmpdir)
+
+    metrics = pd.read_csv(tmpdir / "test.csv")
+    assert len(metrics["test"].unique())
+    assert metrics["test"].iat[0] == len(
         [c for c in sim._component_manager._components if isinstance(c, MockComponentB)]
     )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -47,11 +47,13 @@ class MockComponentB(Component):
     def create_lookup_tables(self, builder):
         return {}
 
-    def metrics(self, _, metrics) -> pd.Series:
+    def metrics(self, _, metrics) -> pd.DataFrame:
         if "test" in metrics:
-            metrics["test"] += 1
+            metrics["test"]["value"] += 1
         else:
-            metrics["test"] = pd.Series(1, name="test")
+            metrics["test"] = pd.DataFrame(
+                {"value": [1], "stratification_1": ["one"], "stratification_2": ["two"]}
+            ).set_index(["stratification_1", "stratification_2"])
         return metrics
 
     def __eq__(self, other: Any) -> bool:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -47,11 +47,11 @@ class MockComponentB(Component):
     def create_lookup_tables(self, builder):
         return {}
 
-    def metrics(self, _, metrics):
+    def metrics(self, _, metrics) -> pd.Series:
         if "test" in metrics:
             metrics["test"] += 1
         else:
-            metrics["test"] = 1
+            metrics["test"] = pd.Series(1, name="test")
         return metrics
 
     def __eq__(self, other: Any) -> bool:


### PR DESCRIPTION
## Implement an Observation dataclass

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
When working on implementing a `report` Callable when registering an 
observation, I was struggling with the current layout. This PR
does not add any new features but simply implements an 
Observation container where the attributes are what was previously
being appended to the `ResultsContext.observations` defaultdict.

A following PR will implement the actual request which was to
provide a report Callable with each registered observation.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
