### PR TITLE
Improve LookupTable configuration

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -24,6 +24,7 @@ py:class vivarium.framework.time.Timedelta
 
 # layered_config_tree
 py:class layered_config_tree.main.LayeredConfigTree
+py:exc layered_config_tree.exceptions.ConfigurationError
 
 # TODO: Need to revisit this. Nitpicking here to avoid failing builds on 3.8 and 3.9 in state_machine and testing_utils
 py:class Logger

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "layered_config_tree>=1.0.1",
+        "layered_config_tree>=1.0.2",
         "numpy",
         "pandas",
         "pyyaml>=5.1",

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -579,6 +579,7 @@ class Component(ABC):
         -------
         None
         """
+        self.get_value_columns = builder.data.value_columns()
         if (
             self.name in builder.configuration
             and "data_sources" in builder.configuration[self.name]
@@ -597,8 +598,9 @@ class Component(ABC):
     def build_lookup_table(
         self,
         builder: "Builder",
-        # TODO: replace with LookupTableData
+        # todo: replace with LookupTableData
         data_source: Union[str, float, int, pd.DataFrame],
+        # todo: MIC-5029 remove argument when this is implemented
         value_columns: Optional[Iterable[str]] = None,
     ) -> LookupTable:
         """
@@ -634,7 +636,7 @@ class Component(ABC):
         if isinstance(data, pd.DataFrame):
             all_columns = set(data.columns)
             if value_columns is None:
-                value_columns = set(builder.data.get_value_columns(data_source))
+                value_columns = set(self.get_value_columns(data))
             else:
                 value_columns = set(value_columns)
 

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -366,7 +366,7 @@ class Component(ABC):
         None
         """
         self.logger = builder.logging.get_logger(self.name)
-        self.build_lookup_tables(builder)
+        self.build_all_lookup_tables(builder)
         self.setup(builder)
         self._set_population_view(builder)
         self._register_post_setup_listener(builder)
@@ -559,9 +559,9 @@ class Component(ABC):
             if hasattr(self, parameter_name)
         }
 
-    def build_lookup_tables(self, builder: "Builder") -> None:
+    def build_all_lookup_tables(self, builder: "Builder") -> None:
         """
-        Builds lookup tables for this component.
+        Builds all lookup tables for this component.
 
         This method builds lookup tables for this component based on the data
         sources specified in the configuration. If no data sources are specified,

--- a/src/vivarium/framework/artifact/hdf.py
+++ b/src/vivarium/framework/artifact/hdf.py
@@ -352,9 +352,8 @@ def _write_pandas_data(path: Path, entity_key: EntityKey, data: Union[PandasObj]
 
     with pd.HDFStore(str(path), complevel=9) as store:
         store.put(entity_key.path, data, format="table", data_columns=data_columns)
-        store.get_storer(
-            entity_key.path
-        ).attrs.metadata = metadata  # NOTE: must use attrs. write this up
+        # NOTE: must use attrs. write this up
+        store.get_storer(entity_key.path).attrs.metadata = metadata
 
 
 def _write_json_blob(path: Path, entity_key: EntityKey, data: Any):

--- a/src/vivarium/framework/artifact/manager.py
+++ b/src/vivarium/framework/artifact/manager.py
@@ -10,7 +10,7 @@ for handling complex data bound up in a data artifact.
 
 import re
 from pathlib import Path
-from typing import Any, List, Sequence, Union
+from typing import Any, Callable, List, Sequence, Union
 
 import pandas as pd
 from layered_config_tree import LayeredConfigTree
@@ -103,12 +103,22 @@ class ArtifactManager(Manager):
             else data
         )
 
-    def get_value_columns(self, entity_key: str) -> List[str]:
+    def value_columns(self) -> Callable[[Union[str, pd.DataFrame]], List[str]]:
         """
-        Returns the value columns for the given entity key.
-        # todo improve docstring
+        Returns a function that returns the value columns for the given input.
+
+        The function can be called with either a string or a pandas DataFrame.
+        If a string is provided, it is interpreted as an artifact key, and the
+        value columns for the data stored at that key are returned.
+
+        Currently, the returned function will always return ["value"].
+
+        Returns
+        -------
+        Callable[[Union[str, pandas.core.generic.PandasObject]], List[str]]
+            A function that returns the value columns for the given input.
         """
-        return [self._default_value_column]
+        return lambda _: [self._default_value_column]
 
     def __repr__(self):
         return "ArtifactManager()"
@@ -153,11 +163,20 @@ class ArtifactInterface:
         """
         return self._manager.load(entity_key, **column_filters)
 
-    def get_value_columns(self, entity_key: str) -> List[str]:
+    def value_columns(self) -> Callable[[Union[str, pd.DataFrame]], List[str]]:
         """
-        # todo add docstring
+        Returns a function that returns the value columns for the given input.
+
+        The function can be called with either a string or a pandas DataFrame.
+        If a string is provided, it is interpreted as an artifact key, and the
+        value columns for the data stored at that key are returned.
+
+        Returns
+        -------
+        Callable[[Union[str, pandas.core.generic.PandasObject]], List[str]]
+            A function that returns the value columns for the given input.
         """
-        return self._manager.get_value_columns(entity_key)
+        return self._manager.value_columns()
 
     def __repr__(self):
         return "ArtifactManagerInterface()"

--- a/src/vivarium/framework/artifact/manager.py
+++ b/src/vivarium/framework/artifact/manager.py
@@ -10,7 +10,7 @@ for handling complex data bound up in a data artifact.
 
 import re
 from pathlib import Path
-from typing import Any, Sequence, Union
+from typing import Any, List, Sequence, Union
 
 import pandas as pd
 from layered_config_tree import LayeredConfigTree
@@ -31,6 +31,9 @@ class ArtifactManager(Manager):
             "input_draw_number": None,
         }
     }
+
+    def __init__(self):
+        self._default_value_column = "value"
 
     @property
     def name(self):
@@ -93,12 +96,19 @@ class ArtifactManager(Manager):
             data = data.reset_index()
             draw_col = [c for c in data if "draw" in c]
             if draw_col:
-                data = data.rename(columns={draw_col[0]: "value"})
+                data = data.rename(columns={draw_col[0]: self._default_value_column})
         return (
             filter_data(data, self.config_filter_term, **column_filters)
             if isinstance(data, pd.DataFrame)
             else data
         )
+
+    def get_value_columns(self, entity_key: str) -> List[str]:
+        """
+        Returns the value columns for the given entity key.
+        # todo improve docstring
+        """
+        return [self._default_value_column]
 
     def __repr__(self):
         return "ArtifactManager()"
@@ -142,6 +152,12 @@ class ArtifactInterface:
             The data associated with the given key filtered down to the requested subset.
         """
         return self._manager.load(entity_key, **column_filters)
+
+    def get_value_columns(self, entity_key: str) -> List[str]:
+        """
+        # todo add docstring
+        """
+        return self._manager.get_value_columns(entity_key)
 
     def __repr__(self):
         return "ArtifactManagerInterface()"

--- a/tests/framework/components/mocks.py
+++ b/tests/framework/components/mocks.py
@@ -16,9 +16,6 @@ class MockComponentA(Component):
         self.args = args
         self.builder_used_for_setup = None
 
-    def create_lookup_tables(self, builder):
-        return {}
-
     def __eq__(self, other: Any) -> bool:
         return type(self) == type(other) and self.name == other.name
 
@@ -40,9 +37,6 @@ class MockComponentB(Component):
     def setup(self, builder: Builder) -> None:
         self.builder_used_for_setup = builder
         builder.value.register_value_modifier("metrics", self.metrics)
-
-    def create_lookup_tables(self, builder):
-        return {}
 
     def metrics(self, _, metrics):
         if "test" in metrics:

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -451,23 +451,27 @@ def test_component_lookup_table_configuration(hdf_file_path):
     [
         (
             {"favorite_color": "key.not.in.artifact"},
+            "Error building lookup table 'favorite_color'. "
             "Failed to find key 'key.not.in.artifact' in artifact.",
             ConfigurationError,
         ),
         (
             {"favorite_color": "not.a.real.module::load_color"},
+            "Error building lookup table 'favorite_color'. "
             "Unable to find module 'not.a.real.module'",
             ConfigurationError,
         ),
         (
             {"favorite_color": "self::non_existent_loader_function"},
-            "There is no method 'non_existent_loader_function' for the component "
+            "Error building lookup table 'favorite_color'. There is no method "
+            "'non_existent_loader_function' for the component "
             "single_lookup_creator.",
             ConfigurationError,
         ),
         (
-            {"favorite_color": "pandas::non_existent_loader_function"},
-            "There is no method 'non_existent_loader_function' for the module 'pandas'.",
+            {"favorite_color": "vivarium::non_existent_loader_function"},
+            "Error building lookup table 'favorite_color'. There is no method "
+            "'non_existent_loader_function' for the module 'vivarium'.",
             ConfigurationError,
         ),
     ],

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -2,11 +2,12 @@ from typing import Dict, List, Optional
 
 import pandas as pd
 import pytest
+from layered_config_tree.exceptions import ConfigurationError
 
 from vivarium import Artifact, Component, InteractiveContext
-from vivarium.framework.artifact import ArtifactException
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
+from vivarium.framework.lookup.table import ScalarTable
 from vivarium.framework.population import SimulantData
 
 
@@ -29,41 +30,24 @@ class ColumnCreator(Component):
 class LookupCreator(ColumnCreator):
     CONFIGURATION_DEFAULTS = {
         "lookup_creator": {
-            "favorite_team": Component.build_lookup_table_config(
-                value="data",
-                categorical_columns=["test_column_1"],
-                continuous_columns=[],
-                key_name="simulants.favorite_team",
-            ),
-            "favorite_scalar": Component.build_lookup_table_config(
-                value=0.4,
-            ),
-            "favorite_color": Component.build_lookup_table_config(
-                value="data",
-                categorical_columns=["test_column_2"],
-                continuous_columns=["test_column_3"],
-                key_name="simulants.favorite_color",
-            ),
-            "favorite_number": Component.build_lookup_table_config(
-                value="data",
-                categorical_columns=[],
-                continuous_columns=["test_column_3"],
-                key_name="simulants.favorite_number",
-            ),
-            # This is not in the class property so will not get created automatically
-            "baking_time": Component.build_lookup_table_config(
-                value="data",
-                categorical_columns=["test_column_1", "test_column_2"],
-                continuous_columns=["test_column_3"],
-                key_name="simulants.baking_time",
-                build_lookup_table=False,
-            ),
-        },
+            "data_sources": {
+                "favorite_team": "simulants.favorite_team",
+                "favorite_scalar": 0.4,
+                "favorite_color": "simulants.favorite_color",
+                "favorite_number": "simulants.favorite_number",
+                "baking_time": "self::load_baking_time",
+                "cooling_time": "tests.framework.components.test_component::load_cooling_time",
+            },
+        }
     }
 
-    @property
-    def standard_lookup_tables(self) -> List[str]:
-        return ["favorite_team", "favorite_color", "favorite_number", "favorite_scalar"]
+    @staticmethod
+    def load_baking_time(_builder: Builder) -> float:
+        return 0.5
+
+
+def load_cooling_time(builder: Builder) -> pd.DataFrame:
+    return builder.data.load("cooling.time")
 
 
 class SingleLookupCreator(ColumnCreator):
@@ -411,10 +395,14 @@ def test_component_lookup_table_configuration(hdf_file_path):
             "test_column_3_end": [1, 2, 3],
         }
     ).set_index(["test_column_2", "test_column_3_start", "test_column_3_end"])
+    cooling_time = pd.DataFrame(
+        {"value": [0.1, 0.9, 0.2], "test_column_1": [1, 2, 3]}
+    ).set_index("test_column_1")
     artifact_data = {
         "simulants.favorite_team": favorite_team,
         "simulants.favorite_color": favorite_color,
         "simulants.favorite_number": favorite_number,
+        "cooling.time": cooling_time,
     }
     artifact = Artifact(hdf_file_path)
     for key, data in artifact_data.items():
@@ -430,82 +418,68 @@ def test_component_lookup_table_configuration(hdf_file_path):
     sim.setup()
 
     # Assertions for specific lookup tables
+    expected_tables = {
+        "favorite_team",
+        "favorite_color",
+        "favorite_number",
+        "favorite_scalar",
+        "baking_time",
+        "cooling_time",
+    }
+    assert expected_tables == set(component.lookup_tables.keys())
+
+    # Check for correct columns in lookup tables
     assert component.lookup_tables["favorite_team"].key_columns == ["test_column_1"]
     assert not component.lookup_tables["favorite_team"].parameter_columns
     assert component.lookup_tables["favorite_color"].key_columns == ["test_column_2"]
     assert component.lookup_tables["favorite_color"].parameter_columns == ["test_column_3"]
-    assert (
-        not component.lookup_tables["favorite_scalar"].key_columns
-        and not component.lookup_tables["favorite_scalar"].parameter_columns
-    )
-    assert component.lookup_tables["favorite_scalar"].data == 0.4
+    assert isinstance(component.lookup_tables["favorite_scalar"], ScalarTable)
+    assert isinstance(component.lookup_tables["baking_time"], ScalarTable)
+    assert component.lookup_tables["cooling_time"].key_columns == ["test_column_1"]
+    assert not component.lookup_tables["cooling_time"].parameter_columns
 
-    # Component level asswertions for lookup tables
-    assert "baking_time" not in component.lookup_tables.keys()
-    assert set(
-        ["favorite_team", "favorite_color", "favorite_number", "favorite_scalar"]
-    ) == set(component.lookup_tables.keys())
+    # Check for correct data in lookup tables
+    assert component.lookup_tables["favorite_team"].data.equals(favorite_team.reset_index())
+    assert component.lookup_tables["favorite_color"].data.equals(favorite_color.reset_index())
+    assert component.lookup_tables["favorite_scalar"].data == 0.4
+    assert component.lookup_tables["baking_time"].data == 0.5
+    assert component.lookup_tables["cooling_time"].data.equals(cooling_time.reset_index())
 
 
 @pytest.mark.parametrize(
     "configuration, match, error_type",
     [
         (
-            # Overlapping columns
-            {
-                "favorite_color": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=["test_column_2"],
-                    continuous_columns=["test_column_2", "test_column_3"],
-                    key_name="simulants.favorite_color",
-                ),
-            },
-            "There should be no overlap between",
-            ValueError,
+            {"favorite_color": "key.not.in.artifact"},
+            "Failed to find key 'key.not.in.artifact' in artifact.",
+            ConfigurationError,
         ),
         (
-            # Wrong key for artifact
-            {
-                "favorite_color": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=["test_column_1"],
-                    continuous_columns=[],
-                    key_name="simulants.favorite_team",
-                ),
-            },
-            "simulants.favorite_team should be in",
-            ArtifactException,
+            {"favorite_color": "not.a.real.module::load_color"},
+            "Unable to find module 'not.a.real.module'",
+            ConfigurationError,
         ),
         (
-            # Columns not in artifact data
-            {
-                "favorite_color": Component.build_lookup_table_config(
-                    value="data",
-                    categorical_columns=["test_column_1"],
-                    continuous_columns=["test_column_3"],
-                    key_name="simulants.favorite_color",
-                ),
-            },
-            "The columns supplied",
-            ValueError,
+            {"favorite_color": "self::non_existent_loader_function"},
+            "There is no method 'non_existent_loader_function' for the component "
+            "single_lookup_creator.",
+            ConfigurationError,
+        ),
+        (
+            {"favorite_color": "pandas::non_existent_loader_function"},
+            "There is no method 'non_existent_loader_function' for the module 'pandas'.",
+            ConfigurationError,
         ),
     ],
 )
 def test_failing_component_lookup_table_configurations(
     configuration, match, error_type, hdf_file_path
 ):
-
-    data = pd.DataFrame(
-        {"value": ["color_1", "color_2", "color_3"], "test_column_1": [1, 2, 3]}
-    ).set_index("test_column_1")
-    artifact = Artifact(hdf_file_path)
-    artifact.write("simulants.favorite_color", data)
-
     component = SingleLookupCreator()
     sim = InteractiveContext(components=[component], setup=False)
     override_config = {
         "input_data": {"artifact_path": hdf_file_path},
-        component.name: configuration,
+        component.name: {"data_sources": configuration},
     }
     sim.configuration.update(override_config)
     with pytest.raises(error_type, match=match):

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -174,6 +174,7 @@ def test_flatten_with_nested_sub_components():
 
 def test_setup_components(mocker):
     builder = mocker.Mock()
+    builder.configuration = {}
     mock_a = MockComponentA("test_a")
     mock_b = MockComponentB("test_b")
     components = OrderedComponentSet(mock_a, mock_b)


### PR DESCRIPTION
## Enable components to configure lookup table creation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5010

### Changes and notes
- Create methods to build lookup-tables automatically
- Enable config to specify a scalar value, a function to load data, or an artifact key to query
- Add method on `ArtifactInterface` to get default value column
  - for now this is trivial, but after MIC-5029 it will be meaningful

### Testing
- Added integration tests
- Implemented this feature in two components of VPH