### PR TITLE
add typing to lookup table attribute

### DIFF
--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -342,7 +342,7 @@ class Component(ABC):
         self._sub_components: List["Component"] = []
         self.logger: Optional[Logger] = None
         self.population_view: Optional[PopulationView] = None
-        self.lookup_tables = {}
+        self.lookup_tables: Dict[str, LookupTable] = {}
 
     def setup_component(self, builder: "Builder") -> None:
         """


### PR DESCRIPTION
## Add typing to lookup table attribute
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: typing
- *JIRA issue*: N/A

### Changes and notes
Adds typing to the `component.lookup_tables` attribute 

### Testing
N/A