### PR TITLE
bugfux handle single stratifications

### DIFF
--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -134,8 +134,7 @@ class ResultsManager(Manager):
 
                     # Initialize a zeros dataframe
                     df["value"] = 0.0
-                    df = df.set_index(stratification_names)
-                    self._metrics[measure] = df
+                    self._metrics[measure] = df.set_index(stratification_names)
 
         if unused_stratifications:
             self.logger.info(

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -84,7 +84,7 @@ class Hogwarts(Component):
             & (update["power_level"].isin(["50", "80"])),
             "house_points",
         ] = 1
-        # Quidditch wins are stratified by 'familiar' and 'power level'.
+        # Quidditch wins are stratified by 'familiar'.
         # Let's have each wizard with a banana slug familiar gain a point
         # on each time step.
         update.loc[update["familiar"] == "banana_slug", "quidditch_wins"] = 1
@@ -103,8 +103,6 @@ class HousePointsObserver(Component):
             aggregator=sum,
             requires_columns=[
                 "house_points",
-                # "student_house",
-                # "power_level",
             ],
         )
 
@@ -118,11 +116,9 @@ class FullyFilteredHousePointsObserver(Component):
             pop_filter="tracked==True & power_level=='one billion'",
             aggregator_sources=["house_points"],
             aggregator=sum,
-            # requires_columns=[
-            #     "house_points",
-            #     "student_house",
-            #     "power_level",
-            # ],
+            requires_columns=[
+                "house_points",
+            ],
         )
 
 
@@ -138,8 +134,6 @@ class QuidditchWinsObserver(Component):
             additional_stratifications=["familiar"],
             requires_columns=[
                 "quidditch_wins",
-                # "familiar",
-                # "power_level",
             ],
         )
 
@@ -155,24 +149,7 @@ class NoStratificationsQuidditchWinsObserver(Component):
             excluded_stratifications=["student_house", "power_level"],
             requires_columns=[
                 "quidditch_wins",
-                # "familiar",
-                # "power_level",
             ],
-        )
-
-
-class SingleStratificationQuidditchWinsObserver(Component):
-    def setup(self, builder: Builder) -> None:
-        builder.results.register_observation(
-            name="single_stratification_quidditch_wins",
-            aggregator_sources=["quidditch_wins"],
-            aggregator=sum,
-            excluded_stratifications=["power_level"],
-            # requires_columns=[
-            #     "quidditch_wins",
-            #     "familiar",
-            #     "power_level",
-            # ],
         )
 
 

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -92,6 +92,10 @@ class Hogwarts(Component):
 
 
 class HousePointsObserver(Component):
+    """Observer that is stratified by multiple columns (the defaults,
+    'student_house' and 'power_level')
+    """
+
     def setup(self, builder: Builder) -> None:
         builder.results.register_observation(
             name="house_points",
@@ -99,44 +103,50 @@ class HousePointsObserver(Component):
             aggregator=sum,
             requires_columns=[
                 "house_points",
-                "student_house",
-                "power_level",
+                # "student_house",
+                # "power_level",
             ],
         )
 
 
 class FullyFilteredHousePointsObserver(Component):
+    """Same as `HousePointsObserver but with a filter that leaves no simulants"""
+
     def setup(self, builder: Builder) -> None:
         builder.results.register_observation(
             name="house_points",
             pop_filter="tracked==True & power_level=='one billion'",
             aggregator_sources=["house_points"],
             aggregator=sum,
-            requires_columns=[
-                "house_points",
-                "student_house",
-                "power_level",
-            ],
+            # requires_columns=[
+            #     "house_points",
+            #     "student_house",
+            #     "power_level",
+            # ],
         )
 
 
 class QuidditchWinsObserver(Component):
+    """Observer that is stratified by a single column ('familiar')"""
+
     def setup(self, builder: Builder) -> None:
         builder.results.register_observation(
             name="quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
-            excluded_stratifications=["student_house"],
+            excluded_stratifications=["student_house", "power_level"],
             additional_stratifications=["familiar"],
             requires_columns=[
                 "quidditch_wins",
-                "familiar",
-                "power_level",
+                # "familiar",
+                # "power_level",
             ],
         )
 
 
 class NoStratificationsQuidditchWinsObserver(Component):
+    """Same as above but no stratifications at all"""
+
     def setup(self, builder: Builder) -> None:
         builder.results.register_observation(
             name="no_stratifications_quidditch_wins",
@@ -145,9 +155,24 @@ class NoStratificationsQuidditchWinsObserver(Component):
             excluded_stratifications=["student_house", "power_level"],
             requires_columns=[
                 "quidditch_wins",
-                "familiar",
-                "power_level",
+                # "familiar",
+                # "power_level",
             ],
+        )
+
+
+class SingleStratificationQuidditchWinsObserver(Component):
+    def setup(self, builder: Builder) -> None:
+        builder.results.register_observation(
+            name="single_stratification_quidditch_wins",
+            aggregator_sources=["quidditch_wins"],
+            aggregator=sum,
+            excluded_stratifications=["power_level"],
+            # requires_columns=[
+            #     "quidditch_wins",
+            #     "familiar",
+            #     "power_level",
+            # ],
         )
 
 

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from loguru import logger
 from pandas.api.types import CategoricalDtype
+
 from tests.framework.results.helpers import (
     BIN_BINNED_COLUMN,
     BIN_LABELS,
@@ -29,7 +30,6 @@ from tests.framework.results.helpers import (
     sorting_hat_vector,
     verify_stratification_added,
 )
-
 from vivarium.framework.results.manager import ResultsManager
 from vivarium.interface.interactive import InteractiveContext
 

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -313,14 +313,12 @@ def test_SimulationContext_report_output_format(tmpdir):
     assert set(zip(house_points["student_house"], house_points["power_level"])) == set(
         product(STUDENT_HOUSES, POWER_LEVELS)
     )
-    assert set(zip(quidditch_wins["familiar"], quidditch_wins["power_level"])) == set(
-        product(FAMILIARS, POWER_LEVELS)
-    )
+    assert set(quidditch_wins["familiar"]) == set(FAMILIARS)
     assert no_stratifications_quidditch_wins.shape[0] == 1
     assert (no_stratifications_quidditch_wins["stratification"] == "all").all()
     assert set(quidditch_wins.columns).difference(
         set(no_stratifications_quidditch_wins.columns)
-    ) == set(["familiar", "power_level"])
+    ) == set(["familiar"])
 
     # Set up filters for groups that scored points
     house_points_filter = (house_points["student_house"] == "gryffindor") & (


### PR DESCRIPTION
## Handle observers stratified by one column
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
There is a bug where if an observer is stratified by a single column,
the dtype of that single-layer MultiIndex is Categorical. But when there
are more than one columns to stratify by, the MultiIndex dtypes were
Object. This was breaking the updater method and returning NaN.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Modified the QuidditchWins observer to be stratified by a single
column and then updated all tests to pass.
