### PR TITLE
Bugfix/sbachmei/mic 5000 fix register binned stratification

### DIFF
--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -101,7 +101,7 @@ class ResultsInterface:
         self,
         target: str,
         binned_column: str,
-        bins: List = [],
+        bin_edges: List = [],
         labels: List[str] = [],
         target_type: str = "column",
         **cut_kwargs,
@@ -114,11 +114,12 @@ class ResultsInterface:
             String name of the state table column or value pipeline used to stratify.
         binned_column
             String name of the column for the binned quantities.
-        bins
-            List of scalars defining the bin edges, passed to :meth: pandas.cut. Lists
-            `bins` and `labels` must be of equal length.
+        bin_edges
+            List of scalars defining the bin edges, passed to :meth: pandas.cut.
+            The length must be equal to the length of `labels` plus 1.
         labels
-            List of string labels for bins. Lists `bins` and `labels` must be of equal length.
+            List of string labels for bins. The length must be equal to the length
+            of `bin_edges` minus 1.
         target_type
             "column" or "value"
         **cut_kwargs
@@ -129,7 +130,7 @@ class ResultsInterface:
         None
         """
         self._manager.register_binned_stratification(
-            target, target_type, binned_column, bins, labels, **cut_kwargs
+            target, target_type, binned_column, bin_edges, labels, **cut_kwargs
         )
 
     def register_observation(

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -282,7 +282,7 @@ class ResultsManager(Manager):
 
         if len(bin_edges) != len(labels) + 1:
             raise ValueError(
-                f"The number of bin edges plus 1 ({len(bin_edges) +1}) does not "
+                f"The number of bin edges plus 1 ({len(bin_edges)+1}) does not "
                 f"match the number of labels ({len(labels)})"
             )
 

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -269,11 +269,15 @@ class ResultsManager(Manager):
             raise ValueError(
                 f"Bin length ({len(bins)}) does not match labels length ({len(labels)})"
             )
-        target_arg = "required_columns" if target_type == "column" else "required_values"
+        target_arg = "requires_columns" if target_type == "column" else "required_values"
         target_kwargs = {target_arg: [target]}
-        # FIXME [MIC-5000]: bins should not be passed into register_stratificaton as categories
+
         self.register_stratification(
-            binned_column, bins, _bin_data, is_vectorized=True, **target_kwargs
+            name=binned_column,
+            categories=labels,
+            mapper=_bin_data,
+            is_vectorized=True,
+            **target_kwargs,
         )
 
     def register_observation(

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -252,8 +252,8 @@ class ResultsManager(Manager):
         bin_edges
             List of scalars defining the bin edges, passed to :meth: pandas.cut.
             The length must equal the length of `labels` plus one.
-            Note that the bins are right edge inclusive and include the lowest,
-            e.g. bin edges [1, 2, 3] indicate groups [1, 2] and (2, 3].
+            Note that the bins are left edge inclusive, e.g. bin edges [1, 2, 3]
+            indicate groups [1, 2) and [2, 3).
         labels
             List of string labels for bins. The length must equal to the length
             of `bin_edges` minus one.
@@ -266,7 +266,9 @@ class ResultsManager(Manager):
         """
 
         def _bin_data(data: pd.Series) -> pd.Series:
-            return pd.cut(data, bin_edges, labels=labels, include_lowest=True, **cut_kwargs)
+            return pd.cut(
+                data, bin_edges, labels=labels, right=False, include_lowest=True, **cut_kwargs
+            )
 
         if len(bin_edges) != len(labels) + 1:
             raise ValueError(

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -235,7 +235,7 @@ class ResultsManager(Manager):
         target: str,
         target_type: str,
         binned_column: str,
-        bins: List[Union[int, float]],
+        bin_edges: List[Union[int, float]],
         labels: List[str],
         **cut_kwargs,
     ) -> None:
@@ -249,11 +249,14 @@ class ResultsManager(Manager):
             "column" or "value"
         binned_column
             String name of the column for the binned quantities.
-        bins
-            List of scalars defining the bin edges, passed to :meth: pandas.cut. Lists
-            `bins` and `labels` must be of equal length.
+        bin_edges
+            List of scalars defining the bin edges, passed to :meth: pandas.cut.
+            The length must equal the length of `labels` plus one.
+            Note that the bins are right edge inclusive and include the lowest,
+            e.g. bin edges [1, 2, 3] indicate groups [1, 2] and (2, 3].
         labels
-            List of string labels for bins. Lists `bins` and `labels` must be of equal length.
+            List of string labels for bins. The length must equal to the length
+            of `bin_edges` minus one.
         **cut_kwargs
             Keyword arguments for :meth: pandas.cut.
 
@@ -263,12 +266,14 @@ class ResultsManager(Manager):
         """
 
         def _bin_data(data: pd.Series) -> pd.Series:
-            return pd.cut(data, bins, labels=labels, **cut_kwargs)
+            return pd.cut(data, bin_edges, labels=labels, include_lowest=True, **cut_kwargs)
 
-        if len(bins) != len(labels):
+        if len(bin_edges) != len(labels) + 1:
             raise ValueError(
-                f"Bin length ({len(bins)}) does not match labels length ({len(labels)})"
+                f"The number of bin edges plus 1 ({len(bin_edges) +1}) does not "
+                f"match the number of labels ({len(labels)})"
             )
+
         target_arg = "requires_columns" if target_type == "column" else "required_values"
         target_kwargs = {target_arg: [target]}
 

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -265,7 +265,10 @@ class ResultsManager(Manager):
         None
         """
 
-        def _bin_data(data: pd.Series) -> pd.Series:
+        def _bin_data(data: Union[pd.Series, pd.DataFrame]) -> pd.Series:
+            data = data.squeeze()
+            if not isinstance(data, pd.Series):
+                raise ValueError(f"Expected a Series, but got type {type(data)}.")
             return pd.cut(
                 data, bin_edges, labels=labels, right=False, include_lowest=True, **cut_kwargs
             )

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -22,8 +22,8 @@ STUDENT_HOUSES = pd.Series(["gryffindor", "slytherin", "ravenclaw"])
 
 BIN_BINNED_COLUMN = "silly_bin"
 BIN_SOURCE = "silly_level"
-BIN_LABELS = ["not", "meh", "somewhat", "very", "extra"]
-BIN_SILLY_BINS = [0, 20, 40, 60, 90]
+BIN_LABELS = ["meh", "somewhat", "very", "extra"]
+BIN_SILLY_BIN_EDGES = [0, 20, 40, 60, 90]
 
 COL_NAMES = ["house", "familiar", "power_level", "tracked"]
 FAMILIARS = ["owl", "cat", "gecko", "banana_slug", "unladen_swallow"]
@@ -187,6 +187,7 @@ class HogwartsResultsStratifier(Component):
             [str(lvl) for lvl in POWER_LEVELS],
             requires_columns=["power_level"],
         )
+        builder.results.register_binned_stratification("age", "age_group", bin_edges=[12])
 
 
 ##################

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -27,7 +27,9 @@ BIN_SILLY_BIN_EDGES = [0, 20, 40, 60, 90]
 
 COL_NAMES = ["house", "familiar", "power_level", "tracked"]
 FAMILIARS = ["owl", "cat", "gecko", "banana_slug", "unladen_swallow"]
-POWER_LEVELS = [i * 10 for i in range(5, 9)]
+POWER_LEVELS = [20, 40, 60, 80]
+POWER_LEVEL_BIN_EDGES = [0, 25, 50, 75, 100]
+POWER_LEVEL_GROUP_LABELS = ["low", "medium", "high", "very high"]
 TRACKED_STATUSES = [True, False]
 RECORDS = list(itertools.product(CATEGORIES, FAMILIARS, POWER_LEVELS, TRACKED_STATUSES))
 BASE_POPULATION = pd.DataFrame(data=RECORDS, columns=COL_NAMES)
@@ -39,7 +41,7 @@ HARRY_POTTER_CONFIG = {
         "step_size": 365,  # Days
     },
     "stratification": {
-        "default": ["student_house", "power_level"],
+        "default": ["student_house", "power_level_group"],
     },
 }
 
@@ -67,7 +69,7 @@ class Hogwarts(Component):
             {
                 "student_house": rng.choice(STUDENT_HOUSES, size=size),
                 "familiar": rng.choice(FAMILIARS, size=size),
-                "power_level": rng.choice([str(lvl) for lvl in POWER_LEVELS], size=size),
+                "power_level": rng.choice([lvl for lvl in POWER_LEVELS], size=size),
                 "house_points": 0,
                 "quidditch_wins": 0,
             },
@@ -79,12 +81,12 @@ class Hogwarts(Component):
         update = self.population_view.get(pop_data.index)
         update["house_points"] = 0
         update["quidditch_wins"] = 0
-        # House points are stratified by 'student_house' and 'power_level'.
-        # Let's have each wizard of gryffindor and of level 50 and 80 gain a point
-        # on each time step.
+        # House points are stratified by 'student_house' and 'power_level_group'.
+        # Let's have each wizard of gryffindor and of power level 20 or 80
+        # gain a point on each time step.
         update.loc[
             (update["student_house"] == "gryffindor")
-            & (update["power_level"].isin(["50", "80"])),
+            & (update["power_level"].isin([20, 80])),
             "house_points",
         ] = 1
         # Quidditch wins are stratified by 'familiar'.
@@ -96,7 +98,7 @@ class Hogwarts(Component):
 
 class HousePointsObserver(StratifiedObserver):
     """Observer that is stratified by multiple columns (the defaults,
-    'student_house' and 'power_level')
+    'student_house' and 'power_level_group')
     """
 
     def register_observations(self, builder: Builder) -> None:
@@ -139,7 +141,7 @@ class QuidditchWinsObserver(StratifiedObserver):
             name="quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
-            excluded_stratifications=["student_house", "power_level"],
+            excluded_stratifications=["student_house", "power_level_group"],
             additional_stratifications=["familiar"],
             requires_columns=[
                 "quidditch_wins",
@@ -161,7 +163,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
             name="no_stratifications_quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
-            excluded_stratifications=["student_house", "power_level"],
+            excluded_stratifications=["student_house", "power_level_group"],
             requires_columns=[
                 "quidditch_wins",
             ],
@@ -182,10 +184,12 @@ class HogwartsResultsStratifier(Component):
         builder.results.register_stratification(
             "familiar", FAMILIARS, requires_columns=["familiar"]
         )
-        builder.results.register_stratification(
+        builder.results.register_binned_stratification(
             "power_level",
-            [str(lvl) for lvl in POWER_LEVELS],
-            requires_columns=["power_level"],
+            "power_level_group",
+            POWER_LEVEL_BIN_EDGES,
+            POWER_LEVEL_GROUP_LABELS,
+            "column",
         )
 
 

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -187,7 +187,6 @@ class HogwartsResultsStratifier(Component):
             [str(lvl) for lvl in POWER_LEVELS],
             requires_columns=["power_level"],
         )
-        builder.results.register_binned_stratification("age", "age_group", bin_edges=[12])
 
 
 ##################

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -207,7 +207,7 @@ def test__get_stratifications(
             ["power_level"],
             sum,
             ["house", "familiar"],
-            260,
+            200,
         ),
         (
             "wizard_time",
@@ -218,7 +218,7 @@ def test__get_stratifications(
             0.306555,
         ),
         ("wizard_count", "tracked==True", None, len, ["house"], 20),
-        ("power_level_total", "tracked==True", ["power_level"], sum, ["house"], 1300),
+        ("power_level_total", "tracked==True", ["power_level"], sum, ["house"], 1000),
         (
             "wizard_time",
             "tracked==True",

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -11,6 +11,7 @@ from tests.framework.results.helpers import (
     CATEGORIES,
     FAMILIARS,
     NAME,
+    POWER_LEVELS,
     SOURCES,
     sorting_hat_serial,
     sorting_hat_vector,
@@ -78,7 +79,7 @@ def test_add_stratification_raises(
 
 def _aggregate_state_person_time(x: pd.DataFrame) -> float:
     """Helper aggregator function for observation testing"""
-    return len(x) * (28 / 365.35)
+    return len(x) * (28 / 365.25)
 
 
 @pytest.mark.parametrize(
@@ -198,34 +199,28 @@ def test__get_stratifications(
 
 
 @pytest.mark.parametrize(
-    "name, pop_filter, aggregator_sources, aggregator, stratifications, expected_result",
+    "pop_filter, aggregator_sources, aggregator, stratifications",
     [
-        ("wizard_count", "tracked==True", None, len, ["house", "familiar"], 4),
+        ("tracked==True", None, len, ["house", "familiar"]),
         (
-            "power_level_total",
             "tracked==True",
             ["power_level"],
             sum,
             ["house", "familiar"],
-            200,
         ),
         (
-            "wizard_time",
             "tracked==True",
             [],
             _aggregate_state_person_time,
             ["house", "familiar"],
-            0.306555,
         ),
-        ("wizard_count", "tracked==True", None, len, ["house"], 20),
-        ("power_level_total", "tracked==True", ["power_level"], sum, ["house"], 1000),
+        ("tracked==True", None, len, ["house"]),
+        ("tracked==True", ["power_level"], sum, ["house"]),
         (
-            "wizard_time",
             "tracked==True",
             [],
             _aggregate_state_person_time,
             ["house"],
-            1.53277,
         ),
     ],
     ids=[
@@ -237,11 +232,9 @@ def test__get_stratifications(
         "custom_aggregator_one_stratification",
     ],
 )
-def test_gather_results(
-    name, pop_filter, aggregator_sources, aggregator, stratifications, expected_result
-):
-    """Test cases where every stratification is in gather_results. Checks for existence and correctness
-    of results"""
+def test_gather_results(pop_filter, aggregator_sources, aggregator, stratifications):
+    """Test cases where every stratification is in gather_results. Checks for
+    existence and correctness of results"""
     ctx = ResultsContext()
 
     # Generate population DataFrame
@@ -260,7 +253,7 @@ def test_gather_results(
     if "familiar" in stratifications:
         ctx.add_stratification("familiar", ["familiar"], FAMILIARS, None, True)
     ctx.add_observation(
-        name=name,
+        name="foo",
         pop_filter=pop_filter,
         aggregator_sources=aggregator_sources,
         aggregator=aggregator,
@@ -269,6 +262,20 @@ def test_gather_results(
         when=event_name,
         report=lambda: None,
     )
+
+    filtered_pop = population.query(pop_filter)
+    groups = filtered_pop.groupby(stratifications)
+    if aggregator == sum:
+        power_level_sums = groups[aggregator_sources].sum().squeeze()
+        assert len(power_level_sums.unique()) == 1
+        expected_result = power_level_sums.iat[0]
+    else:
+        group_sizes = groups.size()
+        assert len(group_sizes.unique()) == 1
+        num_stratifications = group_sizes.iat[0]
+        expected_result = (
+            num_stratifications if aggregator == len else num_stratifications * 28 / 365.25
+        )
 
     i = 0
     for result, _measure in ctx.gather_results(population, event_name):

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -9,7 +9,7 @@ from pandas.api.types import CategoricalDtype
 from tests.framework.results.helpers import (
     BIN_BINNED_COLUMN,
     BIN_LABELS,
-    BIN_SILLY_BINS,
+    BIN_SILLY_BIN_EDGES,
     BIN_SOURCE,
     CATEGORIES,
     FAMILIARS,
@@ -181,7 +181,7 @@ def test_duplicate_name_register_stratification(mocker):
 ##############################################
 
 
-def test_register_binned_stratification(mocker):
+def test_register_binned_stratification():
     mgr = ResultsManager()
     mgr.logger = logger
     assert len(mgr._results_context.stratifications) == 0
@@ -189,7 +189,7 @@ def test_register_binned_stratification(mocker):
         target=BIN_SOURCE,
         target_type="column",
         binned_column=BIN_BINNED_COLUMN,
-        bins=BIN_SILLY_BINS,
+        bin_edges=BIN_SILLY_BIN_EDGES,
         labels=BIN_LABELS,
     )
     assert len(mgr._results_context.stratifications) == 1
@@ -203,20 +203,20 @@ def test_register_binned_stratification(mocker):
 
 @pytest.mark.parametrize(
     "bins, labels",
-    [(BIN_SILLY_BINS, BIN_LABELS[2:]), (BIN_SILLY_BINS[2:], BIN_LABELS)],
-    ids=["more_bins_than_labels", "more_labels_than_bins"],
+    [(BIN_SILLY_BIN_EDGES, BIN_LABELS[1:]), (BIN_SILLY_BIN_EDGES[1:], BIN_LABELS)],
+    ids=["too_many_bins", "too_many_labels"],
 )
 def test_register_binned_stratification_raises_bins_labels_mismatch(bins, labels):
     mgr = ResultsManager()
     with pytest.raises(
         ValueError,
-        match=r"Bin length \(\d+\) does not match labels length \(\d+\)",
+        match=r"The number of bin edges plus 1 \(\d+\) does not match the number of labels \(\d+\)",
     ):
         mgr.register_binned_stratification(
             target=BIN_SOURCE,
             target_type="column",
             binned_column=BIN_BINNED_COLUMN,
-            bins=bins,
+            bin_edges=bins,
             labels=labels,
         )
 

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -199,9 +199,8 @@ def test_register_binned_stratification():
     assert strat.sources == [BIN_SOURCE]
     assert strat.categories == BIN_LABELS
     # Cannot access the mapper because it's in local scope, so check __repr__
-    assert (
-        "function ResultsManager.register_binned_stratification.<locals>._bin_data"
-        in strat.mapper.__repr__()
+    assert "function ResultsManager.register_binned_stratification.<locals>._bin_data" in str(
+        strat.mapper
     )
 
 

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -1,6 +1,7 @@
 import re
 from types import MethodType
 
+import numpy as np
 import pandas as pd
 import pytest
 from loguru import logger
@@ -219,6 +220,24 @@ def test_register_binned_stratification_raises_bins_labels_mismatch(bins, labels
             bin_edges=bins,
             labels=labels,
         )
+
+
+def test_binned_stratification_mapper():
+    mgr = ResultsManager()
+    mgr.logger = logger
+    mgr.register_binned_stratification(
+        target=BIN_SOURCE,
+        target_type="column",
+        binned_column=BIN_BINNED_COLUMN,
+        bin_edges=BIN_SILLY_BIN_EDGES,
+        labels=BIN_LABELS,
+    )
+    strat = mgr._results_context.stratifications[0]
+    data = pd.Series([-np.inf] + BIN_SILLY_BIN_EDGES + [np.inf])
+    groups = strat.mapper(data)
+    expected_groups = pd.Series([np.nan] + BIN_LABELS + [np.nan] * 2)
+    assert (groups.isna() == expected_groups.isna()).all()
+    assert (groups[groups.notna()] == expected_groups[expected_groups.notna()]).all()
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -198,8 +198,11 @@ def test_register_binned_stratification():
     assert strat.name == BIN_BINNED_COLUMN
     assert strat.sources == [BIN_SOURCE]
     assert strat.categories == BIN_LABELS
-    # Cannot access the mapper because it's in local scope, so just check something is there
-    assert strat.mapper is not None
+    # Cannot access the mapper because it's in local scope, so check __repr__
+    assert (
+        "function ResultsManager.register_binned_stratification.<locals>._bin_data"
+        in strat.mapper.__repr__()
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -9,7 +9,7 @@ import pytest
 from tests.framework.results.helpers import (
     FAMILIARS,
     HARRY_POTTER_CONFIG,
-    POWER_LEVELS,
+    POWER_LEVEL_GROUP_LABELS,
     STUDENT_HOUSES,
     Hogwarts,
     HogwartsResultsStratifier,
@@ -330,8 +330,8 @@ def test_SimulationContext_report_output_format(base_config, tmpdir):
 
     # Check that each dataset includes the entire cartesian product of stratifications
     # (or, when no stratifications, just a single "all" row)
-    assert set(zip(house_points["student_house"], house_points["power_level"])) == set(
-        product(STUDENT_HOUSES, POWER_LEVELS)
+    assert set(zip(house_points["student_house"], house_points["power_level_group"])) == set(
+        product(STUDENT_HOUSES, POWER_LEVEL_GROUP_LABELS)
     )
     assert set(quidditch_wins["familiar"]) == set(FAMILIARS)
     assert no_stratifications_quidditch_wins.shape[0] == 1
@@ -342,7 +342,7 @@ def test_SimulationContext_report_output_format(base_config, tmpdir):
 
     # Set up filters for groups that scored points
     house_points_filter = (house_points["student_house"] == "gryffindor") & (
-        house_points["power_level"].isin([50, 80])
+        house_points["power_level_group"].isin(["low", "very high"])
     )
     quidditch_wins_filter = quidditch_wins["familiar"] == "banana_slug"
     no_strats_quidditch_wins_filter = (


### PR DESCRIPTION
## Bugfix register_binned_stratification

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5000

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> `ResultsManager.register_binned_stratification()` was broken in several
ways:
- passes labels in as categories (previously was incorrectly passing in bin edges)
- fixes the labels vs bin edge length check
- fixes tests that were mocking over important functionality
- adds new testing
- updates the helper power_level stratification to be of binned type
- Add documentation and comments to better define what the
  expectation is when passing in bin edges (also updated the argument
  from "bins" to "bin_edges" to better reflect the expectation.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass

