### PR TITLE
strengthen error message

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -83,8 +83,15 @@ class ResultsContext:
         None
 
         """
-        if len([s.name for s in self.stratifications if s.name == name]):
-            raise ValueError(f"Name `{name}` is already used")
+        already_used = [
+            stratification
+            for stratification in self.stratifications
+            if stratification.name == name
+        ]
+        if already_used:
+            raise ValueError(
+                f"Stratification name '{name}' is already used: {str(already_used[0])}."
+            )
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
         self.stratifications.append(stratification)
 

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Union, cast
+from typing import Callable, List, Optional, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -37,6 +37,13 @@ class Stratification:
     categories: List[str]
     mapper: Optional[Callable[[Union[pd.Series[str], pd.DataFrame]], pd.Series[str]]] = None
     is_vectorized: bool = False
+
+    def __str__(self) -> str:
+        return (
+            f"Stratification '{self.name}' with sources {self.sources}, "
+            f"categories {self.categories}, mapper {self.mapper.__name__}, "
+            f"and is_vectorized {self.is_vectorized}"
+        )
 
     def __post_init__(self) -> None:
         if self.mapper is None:

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -41,8 +41,7 @@ class Stratification:
     def __str__(self) -> str:
         return (
             f"Stratification '{self.name}' with sources {self.sources}, "
-            f"categories {self.categories}, mapper {self.mapper.__name__}, "
-            f"and is_vectorized {self.is_vectorized}"
+            f"categories {self.categories}, and mapper {self.mapper.__name__}"
         )
 
     def __post_init__(self) -> None:

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -77,6 +77,14 @@ def test_add_stratification_raises(
         raise ctx.add_stratification(name, sources, categories, mapper, is_vectorized)
 
 
+def test_add_stratifcation_duplicate_name_raises():
+    ctx = ResultsContext()
+    ctx.add_stratification(NAME, SOURCES, CATEGORIES, sorting_hat_vector, True)
+    with pytest.raises(ValueError, match=f"Stratification name '{NAME}' is already used: "):
+        # register a different stratification but w/ the same name
+        ctx.add_stratification(NAME, [], [], None, False)
+
+
 def _aggregate_state_person_time(x: pd.DataFrame) -> float:
     """Helper aggregator function for observation testing"""
     return len(x) * (28 / 365.25)
@@ -140,8 +148,8 @@ def test_add_observation(
 def test_double_add_observation(
     name, pop_filter, aggregator, additional_stratifications, excluded_stratifications, when
 ):
-    """Tests a double add of the same stratification, this should result in one additional observation being added to
-    the context."""
+    """Tests a double add of the same stratification, this should result in one
+    additional observation being added to the context."""
     ctx = ResultsContext()
     ctx._default_stratifications = ["age", "sex"]
     assert len(ctx.observations) == 0

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -168,15 +168,6 @@ def test_register_stratification_with_column_and_pipelines(
     )
 
 
-def test_duplicate_name_register_stratification(mocker):
-    mgr = ResultsManager()
-    builder = mocker.Mock()
-    mgr.setup(builder)
-    mgr.register_stratification(NAME, CATEGORIES, sorting_hat_serial, False, SOURCES, [])
-    with pytest.raises(ValueError, match=f"Name `{NAME}` is already used"):
-        mgr.register_stratification(NAME, CATEGORIES, sorting_hat_vector, True, SOURCES, [])
-
-
 ##############################################
 # Tests for `register_binned_stratification` #
 ##############################################


### PR DESCRIPTION
## Give details of stratification with duplicate name

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This adds a Stratification __str__ (which admittedly isn't a whole lot different than
the default) and uses that in the error message when trying to register a stratification
with a name that already exists.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Moved the test from test_manager to test_context and slightly strengthened
it by adding a pytest.raises(..., match=) pattern

