### PR TITLE
Update metrics for better support

### DIFF
--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import pandas as pd
@@ -135,7 +137,7 @@ class ResultsInterface:
         name: str,
         pop_filter: str = "tracked==True",
         aggregator_sources: Optional[List[str]] = None,
-        aggregator: Callable[[pd.DataFrame], float] = len,
+        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]] = len,
         requires_columns: List[str] = [],
         requires_values: List[str] = [],
         additional_stratifications: List[str] = [],

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -179,11 +179,9 @@ class ResultsManager(Manager):
                     )
 
     def gather_results(self, event_name: str, event: Event) -> None:
-        """Update the existing metrics with new results. Typically, a results
-        group has a single column (i.e. the values of some stratified measure);
-        the metrics are initialized as such. It is possible, however, to return a
-        DataFrame with multiple columns, in which case we special-case and initialize
-        with 0 and update with the results group.
+        """Update the existing metrics with new results. Any columns in the
+        results group that are not already in the metrics are initialized
+        with 0.0.
         """
         population = self._prepare_population(event)
         for results_group, measure in self._results_context.gather_results(
@@ -195,7 +193,9 @@ class ResultsManager(Manager):
                         f"There is a results group {results_group} but no corresponding measure"
                     )
                 # Look for extra columns in the results_group and initialize with 0.
-                extra_cols = list(set(results_group.columns) - {METRICS_COLUMN})
+                extra_cols = list(
+                    set(results_group.columns) - set(self._metrics[measure].columns)
+                )
                 if extra_cols:
                     self._metrics[measure][extra_cols] = 0.0
                 for col in results_group.columns:

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -179,6 +179,12 @@ class ResultsManager(Manager):
                     )
 
     def gather_results(self, event_name: str, event: Event) -> None:
+        """Update the existing metrics with new results. Typically, a results
+        group has a single column (i.e. the values of some stratified measure);
+        the metrics are initialized as such. It is possible, however, to return a
+        DataFrame with multiple columns, in which case we special-case and initialize
+        with 0 and update with the results group.
+        """
         population = self._prepare_population(event)
         for results_group, measure in self._results_context.gather_results(
             population, event_name
@@ -188,7 +194,12 @@ class ResultsManager(Manager):
                     raise ValueError(
                         f"There is a results group {results_group} but no corresponding measure"
                     )
-                self._metrics[measure] += results_group
+                # Look for extra columns in the results_group and initialize with 0.
+                extra_cols = list(set(results_group.columns) - {METRICS_COLUMN})
+                if extra_cols:
+                    self._metrics[measure][extra_cols] = 0.0
+                for col in results_group.columns:
+                    self._metrics[measure][col] += results_group[col]
 
     def set_default_stratifications(self, builder: Builder) -> None:
         default_stratifications = builder.configuration.stratification.default
@@ -302,7 +313,7 @@ class ResultsManager(Manager):
         name: str,
         pop_filter: str,
         aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], float],
+        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
         requires_columns: List[str],
         requires_values: List[str],
         additional_stratifications: List[str],

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Union
 
 import pandas as pd
 
@@ -21,6 +23,6 @@ class Observation:
     pop_filter: str
     stratifications: Tuple[str, ...]
     aggregator_sources: Optional[List[str]]
-    aggregator: Callable[[pd.DataFrame], float]
+    aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]]
     when: str
     report: Callable[[str, pd.DataFrame], None]

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -60,6 +60,8 @@ class Hogwarts(Component):
             "power_level",
             "house_points",
             "quidditch_wins",
+            "spell_power",
+            "potion_power",
         ]
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
@@ -75,6 +77,9 @@ class Hogwarts(Component):
             },
             index=pop_data.index,
         )
+        # Assume power level components are evenly split
+        initialization_data["spell_power"] = initialization_data["power_level"] / 2
+        initialization_data["potion_power"] = initialization_data["power_level"] / 2
         self.population_view.update(initialization_data)
 
     def on_time_step(self, pop_data: SimulantData) -> None:
@@ -174,6 +179,25 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
         dataframe_to_csv(
             measure, results, Path(self.results_dir), self.random_seed, self.input_draw
         )
+
+
+class MagicalAttributesObserver(StratifiedObserver):
+    """Observer whose aggregator returns a pd.Series instead of a float (which in
+    turn results in metrics dataframe with multiple columns instead of just one
+    'value' column)
+    """
+
+    def register_observations(self, builder: Builder) -> None:
+        builder.results.register_observation(
+            name="magical_attributes",
+            aggregator=self._get_magical_attributes,
+            excluded_stratifications=["student_house"],
+            report=lambda *_: None,
+        )
+
+    def _get_magical_attributes(self, _: pd.DataFrame) -> pd.Series:
+        """Increase each level by one per time step"""
+        return pd.Series([1.0, 1.0], ["spell_power", "potion_power"])
 
 
 class HogwartsResultsStratifier(Component):

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -517,13 +517,11 @@ def test__get_groups(stratifications, values):
         ((), ["power_level", "tracked"], sum),
     ],
 )
-def test__format(stratifications, aggregator_sources, aggregator):
+def test__aggregate(stratifications, aggregator_sources, aggregator):
     """Test that we are aggregating correctly. There are some nuances here:
-      - If aggregator_resources is provided, then simply .apply it to the groups passed in.
-      - If no aggregator_resources are provided, then we want a full aggregation of the groups.
-      - _aggregate can return either a pd.Series or a pd.DataFrame of any number of columns
-
-    Note that the groups can be either a pandas DataFrame or a DataFrameGroupBy.
+    - If aggregator_resources is provided, then simply .apply it to the groups passed in.
+    - If no aggregator_resources are provided, then we want a full aggregation of the groups.
+    - _aggregate can return either a pd.Series or a pd.DataFrame of any number of columns
     """
     groups = ResultsContext()._get_groups(
         stratifications=stratifications, filtered_pop=BASE_POPULATION

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -419,7 +419,7 @@ def test_gather_results_with_no_stratifications():
     )
 
 
-def test__bad_aggregator_stratification():
+def test_bad_aggregator_stratification():
     """Test if an exception gets raised when a stratification that doesn't
     exist is attempted to be used, as expected."""
     ctx = ResultsContext()
@@ -517,7 +517,7 @@ def test__get_groups(stratifications, values):
         ((), ["power_level", "tracked"], sum),
     ],
 )
-def test__aggregate(stratifications, aggregator_sources, aggregator):
+def test__format(stratifications, aggregator_sources, aggregator):
     """Test that we are aggregating correctly. There are some nuances here:
       - If aggregator_resources is provided, then simply .apply it to the groups passed in.
       - If no aggregator_resources are provided, then we want a full aggregation of the groups.
@@ -571,24 +571,13 @@ def test__aggregate(stratifications, aggregator_sources, aggregator):
         ),
     ],
 )
-def test__coerce_to_dataframe(aggregates):
-    new_aggregates = ResultsContext()._coerce_to_dataframe(aggregates=aggregates)
+def test__format(aggregates):
+    new_aggregates = ResultsContext()._format(aggregates=aggregates)
     assert isinstance(new_aggregates, pd.DataFrame)
     if isinstance(aggregates, pd.Series):
-        assert new_aggregates.equals(aggregates.to_frame())
+        assert new_aggregates.equals(aggregates.to_frame("value"))
     else:
         assert new_aggregates.equals(aggregates)
-
-
-def test__coerce_to_dataframe_raises():
-    with pytest.raises(
-        TypeError,
-        match=(
-            f"The aggregator return value is of type {type(1)} while a pd.Series "
-            "or pd.DataFrame is expected."
-        ),
-    ):
-        ResultsContext()._coerce_to_dataframe(aggregates=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -23,6 +23,7 @@ from tests.framework.results.helpers import (
     Hogwarts,
     HogwartsResultsStratifier,
     HousePointsObserver,
+    MagicalAttributesObserver,
     NoStratificationsQuidditchWinsObserver,
     QuidditchWinsObserver,
     mock_get_value,
@@ -480,3 +481,17 @@ def test_update_metrics_no_stratifications():
     pop = sim.get_population()
     results = sim._results.metrics["no_stratifications_quidditch_wins"]
     assert results.loc["all"][METRICS_COLUMN] == pop["quidditch_wins"].sum() * 2
+
+
+def test_update_metrics_extra_columns():
+    """Test that metrics are updated correctly when the aggregator return
+    contains multiple columns (i.e. not just a single 'value' column)
+    """
+    components = [Hogwarts(), HogwartsResultsStratifier(), MagicalAttributesObserver()]
+    sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
+    sim.step()
+    results = sim._results.metrics["magical_attributes"]
+    assert (results[["spell_power", "potion_power"]].values == [1, 1]).all()
+    sim.step()
+    results = sim._results.metrics["magical_attributes"]
+    assert (results[["spell_power", "potion_power"]].values == [2, 2]).all()


### PR DESCRIPTION
## Support metrics dataframes of any number of columns
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5062

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This PR implements required changes to update vph's DisabilityObserver
to register a single ylds observation instead of one per cause. Two major
things are done here to that end:

1. We allow for the observation.aggregator to return a pd.Series or a float
instead of just a float. This is required in order to allow for a metrics
dataframe of any number of columns (instead of just a pd.Series or
1-col dataframe)
2. Special-case handling in the event that the metrics indeed has
more than a single column. This can happen when we want to stratify
result by more than just registered stratifications, e.g. the 
DisabilityObserver wants to stratify yld results by disease, but disease
can't be a proper stratification because a simulant can have more than
one at a time.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tests pass
