### PR TITLE
Feature/sbachmei/mic 4982 update for psimulate requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
         "tables",
         "networkx",
         "loguru",
+        "pyarrow",
         # Type stubs
         "pandas-stubs",
     ]

--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -207,13 +207,6 @@ class DiseaseModel(Machine):
     def delete_cause_specific_mortality(self, index: pd.Index, rates: pd.Series) -> pd.Series:
         return rates - self.cause_specific_mortality_rate(index)
 
-    def metrics(self, index: pd.Index, metrics: Dict[str, Any]):
-        pop = self.population_view.get(index, query="alive == 'alive'")
-        metrics[self.state_column + "_prevalent_cases"] = len(
-            pop[pop[self.state_column] != self.initial_state]
-        )
-        return metrics
-
 
 class SISDiseaseModel(Component):
     configuration_defaults = {

--- a/src/vivarium/examples/disease_model/observer.py
+++ b/src/vivarium/examples/disease_model/observer.py
@@ -30,18 +30,3 @@ class Observer(Component):
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         self.life_expectancy = builder.configuration.mortality.life_expectancy
-
-    ##################################
-    # Pipeline sources and modifiers #
-    ##################################
-
-    def metrics(self, index: pd.Index, metrics: Dict) -> Dict:
-        pop = self.population_view.get(index)
-        metrics["total_population_alive"] = len(pop[pop.alive == "alive"])
-        metrics["total_population_dead"] = len(pop[pop.alive == "dead"])
-
-        metrics["years_of_life_lost"] = (
-            self.life_expectancy - pop.age[pop.alive == "dead"]
-        ).sum()
-
-        return metrics

--- a/src/vivarium/framework/results/__init__.py
+++ b/src/vivarium/framework/results/__init__.py
@@ -1,3 +1,3 @@
 from vivarium.framework.results.interface import ResultsInterface
-from vivarium.framework.results.manager import METRICS_COLUMN, ResultsManager
+from vivarium.framework.results.manager import VALUE_COLUMN, ResultsManager
 from vivarium.framework.results.observer import Observer, StratifiedObserver

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -104,7 +104,7 @@ class ResultsContext:
         additional_stratifications: List[str],
         excluded_stratifications: List[str],
         when: str,
-        format_results: Callable[[str, pd.DataFrame], pd.DataFrame],
+        formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
     ) -> None:
         stratifications = self._get_stratifications(
             additional_stratifications, excluded_stratifications
@@ -116,7 +116,7 @@ class ResultsContext:
             aggregator_sources=aggregator_sources,
             aggregator=aggregator,
             when=when,
-            format_results=format_results,
+            formatter=formatter,
         )
         self.observations[when][(pop_filter, stratifications)].append(observation)
 

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -104,7 +104,7 @@ class ResultsContext:
         additional_stratifications: List[str],
         excluded_stratifications: List[str],
         when: str,
-        report: Callable[[str, pd.DataFrame], None],
+        format_results: Callable[[str, pd.DataFrame], pd.DataFrame],
     ) -> None:
         stratifications = self._get_stratifications(
             additional_stratifications, excluded_stratifications
@@ -116,7 +116,7 @@ class ResultsContext:
             aggregator_sources=aggregator_sources,
             aggregator=aggregator,
             when=when,
-            report=report,
+            format_results=format_results,
         )
         self.observations[when][(pop_filter, stratifications)].append(observation)
 

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -143,7 +143,9 @@ class ResultsInterface:
         additional_stratifications: List[str] = [],
         excluded_stratifications: List[str] = [],
         when: str = "collect_metrics",
-        report: Callable[[str, pd.DataFrame], None] = lambda measure, results: None,
+        format_results: Callable[
+            [str, pd.DataFrame], pd.DataFrame
+        ] = lambda measure, results: results,
     ) -> None:
         """Provide the results system all the information it needs to perform the observation.
 
@@ -171,8 +173,8 @@ class ResultsInterface:
         when
             String name of the phase of a time-step the observation should happen. Valid values are:
             `"time_step__prepare"`, `"time_step"`, `"time_step__cleanup"`, `"collect_metrics"`.
-        report
-            A function that handles reporting of the final observations at the end of the simulation.
+        format_results
+            A function that handles formatting of the final observations at the end of the simulation.
 
         Returns
         ------
@@ -188,5 +190,5 @@ class ResultsInterface:
             additional_stratifications,
             excluded_stratifications,
             when,
-            report,
+            format_results,
         )

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -143,7 +143,7 @@ class ResultsInterface:
         additional_stratifications: List[str] = [],
         excluded_stratifications: List[str] = [],
         when: str = "collect_metrics",
-        format_results: Callable[
+        formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,
     ) -> None:
@@ -173,7 +173,7 @@ class ResultsInterface:
         when
             String name of the phase of a time-step the observation should happen. Valid values are:
             `"time_step__prepare"`, `"time_step"`, `"time_step__cleanup"`, `"collect_metrics"`.
-        format_results
+        formatter
             A function that handles formatting of the final observations at the end of the simulation.
 
         Returns
@@ -190,5 +190,5 @@ class ResultsInterface:
             additional_stratifications,
             excluded_stratifications,
             when,
-            format_results,
+            formatter,
         )

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -62,7 +62,7 @@ class ResultsManager(Manager):
                 for observation in observations:
                     measure = observation.name
                     results = self._raw_results[measure].copy()
-                    formatted[measure] = observation.format_results(
+                    formatted[measure] = observation.formatter(
                         measure=measure, results=results
                     )
         return formatted
@@ -315,7 +315,7 @@ class ResultsManager(Manager):
         additional_stratifications: List[str],
         excluded_stratifications: List[str],
         when: str,
-        format_results: Callable[[str, pd.DataFrame], pd.DataFrame],
+        formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
     ) -> None:
         self.logger.debug(f"Registering observation {name}")
         self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
@@ -327,7 +327,7 @@ class ResultsManager(Manager):
             additional_stratifications,
             excluded_stratifications,
             when,
-            format_results,
+            formatter,
         )
         self._add_resources(requires_columns, SourceType.COLUMN)
         self._add_resources(requires_values, SourceType.VALUE)

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
 
 
-METRICS_COLUMN = "value"
+VALUE_COLUMN = "value"
 
 
 class SourceType(Enum):
@@ -44,7 +44,7 @@ class ResultsManager(Manager):
     }
 
     def __init__(self) -> None:
-        self._metrics: defaultdict[str, pd.DataFrame] = defaultdict()
+        self._raw_results: defaultdict[str, pd.DataFrame] = defaultdict()
         self._results_context = ResultsContext()
         self._required_columns = {"tracked"}
         self._required_values: set[Pipeline] = set()
@@ -55,9 +55,17 @@ class ResultsManager(Manager):
         """The name of this ResultsManager."""
         return self._name
 
-    @property
-    def metrics(self) -> defaultdict[str, pd.DataFrame]:
-        return self._metrics.copy()
+    def get_results(self) -> Dict[str, pd.DataFrame]:
+        formatted = {}
+        for observation_details in self._results_context.observations.values():
+            for observations in observation_details.values():
+                for observation in observations:
+                    measure = observation.name
+                    results = self._raw_results[measure].copy()
+                    formatted[measure] = observation.format_results(
+                        measure=measure, results=results
+                    )
+        return formatted
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: "Builder") -> None:
@@ -71,14 +79,13 @@ class ResultsManager(Manager):
         builder.event.register_listener("time_step", self.on_time_step)
         builder.event.register_listener("time_step__cleanup", self.on_time_step_cleanup)
         builder.event.register_listener("collect_metrics", self.on_collect_metrics)
-        builder.event.register_listener("report", self.on_report)
 
         self.get_value = builder.value.get_value
 
         self.set_default_stratifications(builder)
 
     def on_post_setup(self, _: Event) -> None:
-        """Initialize self._metrics with 0s DataFrame' for each measure and all stratifications"""
+        """Initialize results with 0s DataFrame' for each measure and all stratifications"""
         registered_stratifications = self._results_context.stratifications
         registered_stratification_names = set(
             stratification.name for stratification in registered_stratifications
@@ -136,8 +143,8 @@ class ResultsManager(Manager):
                         )
 
                     # Initialize a zeros dataframe
-                    df[METRICS_COLUMN] = 0.0
-                    self._metrics[measure] = df.set_index(stratification_names)
+                    df[VALUE_COLUMN] = 0.0
+                    self._raw_results[measure] = df.set_index(stratification_names)
 
         if unused_stratifications:
             self.logger.info(
@@ -167,18 +174,9 @@ class ResultsManager(Manager):
     def on_collect_metrics(self, event: Event) -> None:
         self.gather_results("collect_metrics", event)
 
-    def on_report(self, event: Event) -> None:
-        metrics = event.user_data["metrics"]
-        for observation_details in self._results_context.observations.values():
-            for observations in observation_details.values():
-                for observation in observations:
-                    observation.report(
-                        measure=observation.name, results=metrics[observation.name]
-                    )
-
     def gather_results(self, event_name: str, event: Event) -> None:
-        """Update the existing metrics with new results. Any columns in the
-        results group that are not already in the metrics are initialized
+        """Update the existing results with new results. Any columns in the
+        results group that are not already in the existing results are initialized
         with 0.0.
         """
         population = self._prepare_population(event)
@@ -192,12 +190,12 @@ class ResultsManager(Manager):
                     )
                 # Look for extra columns in the results_group and initialize with 0.
                 extra_cols = list(
-                    set(results_group.columns) - set(self._metrics[measure].columns)
+                    set(results_group.columns) - set(self._raw_results[measure].columns)
                 )
                 if extra_cols:
-                    self._metrics[measure][extra_cols] = 0.0
+                    self._raw_results[measure][extra_cols] = 0.0
                 for col in results_group.columns:
-                    self._metrics[measure][col] += results_group[col]
+                    self._raw_results[measure][col] += results_group[col]
 
     def set_default_stratifications(self, builder: Builder) -> None:
         default_stratifications = builder.configuration.stratification.default
@@ -317,7 +315,7 @@ class ResultsManager(Manager):
         additional_stratifications: List[str],
         excluded_stratifications: List[str],
         when: str,
-        report: Callable[[str, pd.DataFrame], None],
+        format_results: Callable[[str, pd.DataFrame], pd.DataFrame],
     ) -> None:
         self.logger.debug(f"Registering observation {name}")
         self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
@@ -329,7 +327,7 @@ class ResultsManager(Manager):
             additional_stratifications,
             excluded_stratifications,
             when,
-            report,
+            format_results,
         )
         self._add_resources(requires_columns, SourceType.COLUMN)
         self._add_resources(requires_values, SourceType.VALUE)

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -16,7 +16,7 @@ class Observation:
     - `aggregator_sources`: a list of the columns to observe
     - `aggregator`: a method that aggregates the `aggregator_sources`
     - `when`: the phase that the `Observation` is registered to
-    - `format_results`: the method that reports formats the `Observation` results
+    - `formatter`: the method that reports formats the `Observation` results
     """
 
     name: str
@@ -25,4 +25,4 @@ class Observation:
     aggregator_sources: Optional[List[str]]
     aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]]
     when: str
-    format_results: Callable[[str, pd.DataFrame], pd.DataFrame]
+    formatter: Callable[[str, pd.DataFrame], pd.DataFrame]

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -16,7 +16,7 @@ class Observation:
     - `aggregator_sources`: a list of the columns to observe
     - `aggregator`: a method that aggregates the `aggregator_sources`
     - `when`: the phase that the `Observation` is registered to
-    - `report`: the method that reports the `Observation`
+    - `format_results`: the method that reports formats the `Observation` results
     """
 
     name: str
@@ -25,4 +25,4 @@ class Observation:
     aggregator_sources: Optional[List[str]]
     aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]]
     when: str
-    report: Callable[[str, pd.DataFrame], None]
+    format_results: Callable[[str, pd.DataFrame], pd.DataFrame]

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -35,10 +35,8 @@ import os
 import pstats
 import shutil
 from pathlib import Path
-from time import time
 
 import click
-import pandas as pd
 from loguru import logger
 
 from vivarium.examples import disease_model
@@ -123,8 +121,6 @@ def run(
     verbosity = 1 + int(verbose) - int(quiet)
     configure_logging_to_terminal(verbosity=verbosity, long_format=False)
 
-    start = time()
-
     results_root = get_output_root(results_directory, model_specification, artifact_path)
     # Update permissions mask (assign to variable to avoid printing previous value)
     _ = os.umask(0o002)
@@ -143,12 +139,6 @@ def run(
 
     main = handle_exceptions(run_simulation, logger, with_debugger)
     finished_sim = main(model_specification, configuration=override_configuration)
-
-    # TODO [MIC-4982]: Save out required metrics for VCT to work
-    # metrics = pd.DataFrame(finished_sim.report(), index=[0])
-    # metrics["simulation_run_time"] = time() - start
-    # metrics["random_seed"] = finished_sim.configuration.randomness.random_seed
-    # metrics["input_draw"] = finished_sim.configuration.input_data.input_draw_number
 
 
 @simulate.command()

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -114,7 +114,7 @@ class HousePointsObserver(StratifiedObserver):
             requires_columns=[
                 "house_points",
             ],
-            format_results=partial(format_results, self.random_seed, self.input_draw),
+            formatter=partial(formatter, self.random_seed, self.input_draw),
         )
 
 
@@ -146,7 +146,7 @@ class QuidditchWinsObserver(StratifiedObserver):
             requires_columns=[
                 "quidditch_wins",
             ],
-            format_results=partial(format_results, self.random_seed, self.input_draw),
+            formatter=partial(formatter, self.random_seed, self.input_draw),
         )
 
 
@@ -162,7 +162,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
             requires_columns=[
                 "quidditch_wins",
             ],
-            format_results=partial(format_results, self.random_seed, self.input_draw),
+            formatter=partial(formatter, self.random_seed, self.input_draw),
         )
 
 
@@ -177,7 +177,7 @@ class MagicalAttributesObserver(StratifiedObserver):
             name="magical_attributes",
             aggregator=self._get_magical_attributes,
             excluded_stratifications=["student_house"],
-            format_results=lambda *_: None,
+            formatter=lambda *_: None,
         )
 
     def _get_magical_attributes(self, _: pd.DataFrame) -> pd.Series:
@@ -207,7 +207,7 @@ class HogwartsResultsStratifier(Component):
 ##################
 
 
-def format_results(
+def formatter(
     random_seed: str,
     input_draw: str,
     measure: str,

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -1,5 +1,5 @@
 import itertools
-from pathlib import Path
+from functools import partial
 from typing import List
 
 import numpy as np
@@ -8,7 +8,7 @@ import pandas as pd
 from vivarium.framework.components.manager import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
-from vivarium.framework.results import METRICS_COLUMN
+from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.observer import StratifiedObserver
 
 NAME = "hogwarts_house"
@@ -114,12 +114,7 @@ class HousePointsObserver(StratifiedObserver):
             requires_columns=[
                 "house_points",
             ],
-            report=self.write_results,
-        )
-
-    def write_results(self, measure: str, results: pd.DataFrame) -> None:
-        dataframe_to_csv(
-            measure, results, Path(self.results_dir), self.random_seed, self.input_draw
+            format_results=partial(format_results, self.random_seed, self.input_draw),
         )
 
 
@@ -151,12 +146,7 @@ class QuidditchWinsObserver(StratifiedObserver):
             requires_columns=[
                 "quidditch_wins",
             ],
-            report=self.write_results,
-        )
-
-    def write_results(self, measure: str, results: pd.DataFrame) -> None:
-        dataframe_to_csv(
-            measure, results, Path(self.results_dir), self.random_seed, self.input_draw
+            format_results=partial(format_results, self.random_seed, self.input_draw),
         )
 
 
@@ -172,18 +162,13 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
             requires_columns=[
                 "quidditch_wins",
             ],
-            report=self.write_results,
-        )
-
-    def write_results(self, measure: str, results: pd.DataFrame) -> None:
-        dataframe_to_csv(
-            measure, results, Path(self.results_dir), self.random_seed, self.input_draw
+            format_results=partial(format_results, self.random_seed, self.input_draw),
         )
 
 
 class MagicalAttributesObserver(StratifiedObserver):
     """Observer whose aggregator returns a pd.Series instead of a float (which in
-    turn results in metrics dataframe with multiple columns instead of just one
+    turn results in a dataframe with multiple columns instead of just one
     'value' column)
     """
 
@@ -192,7 +177,7 @@ class MagicalAttributesObserver(StratifiedObserver):
             name="magical_attributes",
             aggregator=self._get_magical_attributes,
             excluded_stratifications=["student_house"],
-            report=lambda *_: None,
+            format_results=lambda *_: None,
         )
 
     def _get_magical_attributes(self, _: pd.DataFrame) -> pd.Series:
@@ -222,23 +207,21 @@ class HogwartsResultsStratifier(Component):
 ##################
 
 
-def dataframe_to_csv(
-    measure: str,
-    results: pd.DataFrame,
-    results_dir: Path,
+def format_results(
     random_seed: str,
     input_draw: str,
-) -> None:
+    measure: str,
+    results: pd.DataFrame,
+) -> pd.DataFrame:
     """An test use case of an observer's report method that writes a DataFrame to a CSV file."""
     # Add extra cols
     results["measure"] = measure
     results["random_seed"] = random_seed
     results["input_draw"] = input_draw
     # Sort the columns such that the stratifications (index) are first
-    # and METRICS_COLUMN is last and sort the rows by the stratifications.
-    other_cols = [c for c in results.columns if c != METRICS_COLUMN]
-    results = results[other_cols + [METRICS_COLUMN]].sort_index().reset_index()
-    results.to_csv(results_dir / f"{measure}.csv", index=False)
+    # and VALUE_COLUMN is last and sort the rows by the stratifications.
+    other_cols = [c for c in results.columns if c != VALUE_COLUMN]
+    return results[other_cols + [VALUE_COLUMN]].sort_index().reset_index()
 
 
 def sorting_hat_vector(state_table: pd.DataFrame) -> pd.Series:

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -125,7 +125,7 @@ def test_add_observation(
         additional_stratifications=additional_stratifications,
         excluded_stratifications=excluded_stratifications,
         when=when,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
     assert len(ctx.observations) == 1
 
@@ -160,7 +160,7 @@ def test_double_add_observation(
         additional_stratifications=additional_stratifications,
         excluded_stratifications=excluded_stratifications,
         when=when,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
     ctx.add_observation(
         name=name,
@@ -170,7 +170,7 @@ def test_double_add_observation(
         additional_stratifications=additional_stratifications,
         excluded_stratifications=excluded_stratifications,
         when=when,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
     assert len(ctx.observations) == 1
 
@@ -267,7 +267,7 @@ def test_gather_results(pop_filter, aggregator_sources, aggregator, stratificati
         additional_stratifications=stratifications,
         excluded_stratifications=[],
         when=event_name,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
 
     filtered_pop = population.query(pop_filter)
@@ -359,7 +359,7 @@ def test_gather_results_partial_stratifications_in_results(
         additional_stratifications=stratifications,
         excluded_stratifications=[],
         when=event_name,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
 
     for results, _measure in ctx.gather_results(population, event_name):
@@ -386,7 +386,7 @@ def test_gather_results_with_empty_pop_filter():
         additional_stratifications=[],
         excluded_stratifications=[],
         when=event_name,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
 
     for result, _measure in ctx.gather_results(population, event_name):
@@ -409,7 +409,7 @@ def test_gather_results_with_no_stratifications():
         additional_stratifications=[],
         excluded_stratifications=[],
         when=event_name,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
 
     assert len(ctx.stratifications) == 0
@@ -439,7 +439,7 @@ def test_bad_aggregator_stratification():
         additional_stratifications=["house", "height"],  # `height` is not a stratification
         excluded_stratifications=[],
         when=event_name,
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
 
     with pytest.raises(KeyError, match="height"):

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -16,7 +16,7 @@ from tests.framework.results.helpers import (
     sorting_hat_vector,
     verify_stratification_added,
 )
-from vivarium.framework.results import METRICS_COLUMN
+from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.context import ResultsContext
 
 
@@ -125,7 +125,7 @@ def test_add_observation(
         additional_stratifications=additional_stratifications,
         excluded_stratifications=excluded_stratifications,
         when=when,
-        report=lambda: None,
+        format_results=lambda: None,
     )
     assert len(ctx.observations) == 1
 
@@ -160,7 +160,7 @@ def test_double_add_observation(
         additional_stratifications=additional_stratifications,
         excluded_stratifications=excluded_stratifications,
         when=when,
-        report=lambda: None,
+        format_results=lambda: None,
     )
     ctx.add_observation(
         name=name,
@@ -170,7 +170,7 @@ def test_double_add_observation(
         additional_stratifications=additional_stratifications,
         excluded_stratifications=excluded_stratifications,
         when=when,
-        report=lambda: None,
+        format_results=lambda: None,
     )
     assert len(ctx.observations) == 1
 
@@ -267,7 +267,7 @@ def test_gather_results(pop_filter, aggregator_sources, aggregator, stratificati
         additional_stratifications=stratifications,
         excluded_stratifications=[],
         when=event_name,
-        report=lambda: None,
+        format_results=lambda: None,
     )
 
     filtered_pop = population.query(pop_filter)
@@ -359,13 +359,13 @@ def test_gather_results_partial_stratifications_in_results(
         additional_stratifications=stratifications,
         excluded_stratifications=[],
         when=event_name,
-        report=lambda: None,
+        format_results=lambda: None,
     )
 
     for results, _measure in ctx.gather_results(population, event_name):
         unladen_results = results.loc["unladen_swallow"]
         assert len(unladen_results) > 0
-        assert (unladen_results[METRICS_COLUMN] == 0).all()
+        assert (unladen_results[VALUE_COLUMN] == 0).all()
 
 
 def test_gather_results_with_empty_pop_filter():
@@ -386,7 +386,7 @@ def test_gather_results_with_empty_pop_filter():
         additional_stratifications=[],
         excluded_stratifications=[],
         when=event_name,
-        report=lambda: None,
+        format_results=lambda: None,
     )
 
     for result, _measure in ctx.gather_results(population, event_name):
@@ -409,7 +409,7 @@ def test_gather_results_with_no_stratifications():
         additional_stratifications=[],
         excluded_stratifications=[],
         when=event_name,
-        report=lambda: None,
+        format_results=lambda: None,
     )
 
     assert len(ctx.stratifications) == 0
@@ -439,7 +439,7 @@ def test_bad_aggregator_stratification():
         additional_stratifications=["house", "height"],  # `height` is not a stratification
         excluded_stratifications=[],
         when=event_name,
-        report=lambda: None,
+        format_results=lambda: None,
     )
 
     with pytest.raises(KeyError, match="height"):
@@ -582,11 +582,11 @@ def test__format(aggregates):
     "aggregates",
     [
         pd.DataFrame(
-            {METRICS_COLUMN: [1.0, 2.0, 10.0, 20.0]},
+            {VALUE_COLUMN: [1.0, 2.0, 10.0, 20.0]},
             index=pd.Index(["ones"] * 2 + ["tens"] * 2),
         ),
         pd.DataFrame(
-            {METRICS_COLUMN: [1.0, 2.0, 10.0, 20.0, "bad", "bad"]},
+            {VALUE_COLUMN: [1.0, 2.0, 10.0, 20.0, "bad", "bad"]},
             index=pd.MultiIndex.from_arrays(
                 [
                     ["foo", "bar", "foo", "bar", "foo", "bar"],
@@ -607,10 +607,10 @@ def test__expand_index(aggregates):
         )
         # Check that existing values did not change
         assert (
-            full_idx_aggregates.loc[aggregates.index, METRICS_COLUMN]
-            == aggregates[METRICS_COLUMN]
+            full_idx_aggregates.loc[aggregates.index, VALUE_COLUMN]
+            == aggregates[VALUE_COLUMN]
         ).all()
         # Check that missingness was filled in with zeros
-        assert (full_idx_aggregates.query('type=="zeros"')[METRICS_COLUMN] == 0).all()
+        assert (full_idx_aggregates.query('type=="zeros"')[VALUE_COLUMN] == 0).all()
     else:
         assert aggregates.equals(full_idx_aggregates)

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -260,7 +260,7 @@ def test_register_observation_when_options(when, mocker):
 
     # Fake a timestep
     mock_event = mocker.Mock()
-    # Run on_post_setup to initialize the metrics attribute with 0s
+    # Run on_post_setup to initialize the raw_results attribute with 0s
     mgr.on_post_setup(mock_event)
     mgr.gather_results(when, mock_event)
 

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -266,7 +266,7 @@ def test_add_observation_nop_stratifications(
         additional_stratifications=additional,
         excluded_stratifications=excluded,
         when="collect_metrics",
-        format_results=lambda: None,
+        formatter=lambda: None,
     )
     for m in match:
         assert m in caplog.text

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -31,7 +31,7 @@ from tests.framework.results.helpers import (
     sorting_hat_vector,
     verify_stratification_added,
 )
-from vivarium.framework.results import METRICS_COLUMN
+from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.manager import ResultsManager
 from vivarium.interface.interactive import InteractiveContext
 
@@ -266,7 +266,7 @@ def test_add_observation_nop_stratifications(
         additional_stratifications=additional,
         excluded_stratifications=excluded,
         when="collect_metrics",
-        report=lambda: None,
+        format_results=lambda: None,
     )
     for m in match:
         assert m in caplog.text
@@ -291,16 +291,16 @@ def test_setting_default_stratifications_at_setup(mocker):
 ################################
 
 
-def test_metrics_initialized_as_empty_dict(mocker):
-    """Test that metrics are initialized as an empty dictionary"""
+def test__raw_results_initialized_as_empty_dict(mocker):
+    """Test that raw results are initialized as an empty dictionary"""
     mgr = ResultsManager()
     builder = mocker.Mock()
     mgr.setup(builder)
-    assert mgr.metrics == {}
+    assert mgr._raw_results == {}
 
 
-def test_stratified_metrics_initialization():
-    """Test that matrics are being initialized correctly. We expect a dictionary
+def test_stratified__raw_results_initialization():
+    """Test that raw results are being initialized correctly. We expect a dictionary
     of pd.DataFrames. Each key of the dictionary is an observed measure name and
     the corresponding value is a zeroed-out multiindex pd.DataFrame of that observer's
     stratifications.
@@ -313,13 +313,13 @@ def test_stratified_metrics_initialization():
     ]
 
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
-    metrics = sim._results.metrics
-    assert isinstance(metrics, dict)
-    assert set(metrics) == set(["house_points", "quidditch_wins"])
-    for metric in metrics:
-        result = metrics[metric]
+    raw_results = sim._results._raw_results
+    assert isinstance(raw_results, dict)
+    assert set(raw_results) == set(["house_points", "quidditch_wins"])
+    for measure in raw_results:
+        result = raw_results[measure]
         assert isinstance(result, pd.DataFrame)
-        assert (result[METRICS_COLUMN] == 0).all()
+        assert (result[VALUE_COLUMN] == 0).all()
     STUDENT_HOUSES_LIST = list(STUDENT_HOUSES)
 
     # Check that indexes are as expected
@@ -338,24 +338,24 @@ def test_stratified_metrics_initialization():
         .set_index(["student_house", "power_level"])
         .index
     )
-    assert metrics["house_points"].index.equals(expected_house_points_idx)
+    assert raw_results["house_points"].index.equals(expected_house_points_idx)
 
     # Single-stratification index is type CategoricalIndex
     expected_quidditch_idx = pd.CategoricalIndex(FAMILIARS, name="familiar")
-    assert metrics["quidditch_wins"].index.equals(expected_quidditch_idx)
+    assert raw_results["quidditch_wins"].index.equals(expected_quidditch_idx)
 
 
-def test_no_stratifications_metrics_initialization():
+def test_no_stratifications__raw_results_initialization():
     """Test that Observers requesting no stratifications result in a
     single-row DataFrame with 'value' of zero and index labeled 'all'
     """
     components = [Hogwarts(), NoStratificationsQuidditchWinsObserver()]
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
-    results = sim._results.metrics["no_stratifications_quidditch_wins"]
-    assert isinstance(results, pd.DataFrame)
-    assert results.shape == (1, 1)
-    assert results[METRICS_COLUMN].iat[0] == 0
-    assert results.index.equals(pd.Index(["all"]))
+    raw_results = sim._results._raw_results["no_stratifications_quidditch_wins"]
+    assert isinstance(raw_results, pd.DataFrame)
+    assert raw_results.shape == (1, 1)
+    assert raw_results[VALUE_COLUMN].iat[0] == 0
+    assert raw_results.index.equals(pd.Index(["all"]))
 
 
 def test_observers_with_missing_stratifications_fail():
@@ -397,8 +397,8 @@ def test_unused_stratifications_are_logged(caplog):
     assert "['familiar']" in log_split[1]
 
 
-def test_update_monotonically_increasing_metrics():
-    """Test that (monotonically increasing) metrics are being updated correctly."""
+def test_update_monotonically_increasing__raw_results():
+    """Test that (monotonically increasing) raw results are being updated correctly."""
 
     def _check_house_points(pop: pd.DataFrame, step_number: int) -> None:
         """We know that house points are stratified by 'student_house' and 'power_level_group'.
@@ -410,13 +410,13 @@ def test_update_monotonically_increasing_metrics():
         assert set(pop.loc[pop["house_points"] != 0, "power_level"]) == set([20, 80])
         group_sizes = pd.DataFrame(
             pop.groupby(["student_house", "power_level"]).size().astype("float"),
-            columns=[METRICS_COLUMN],
+            columns=[VALUE_COLUMN],
         )
-        metrics = sim._results.metrics["house_points"]
-        # We cannot use `equals` here because metrics has a MultiIndex where
+        raw_results = sim._results._raw_results["house_points"]
+        # We cannot use `equals` here because raw results have a MultiIndex where
         # each layer is a Category dtype but pop has object dtype for the relevant columns
         assert (
-            metrics.loc[("gryffindor", ["low", "very high"]), "value"].values
+            raw_results.loc[("gryffindor", ["low", "very high"]), "value"].values
             == (group_sizes.loc[("gryffindor", [20, 80]), "value"] * step_number).values
         ).all()
 
@@ -427,13 +427,13 @@ def test_update_monotonically_increasing_metrics():
         assert set(pop["quidditch_wins"]) == set([0, 1])
         assert (pop.loc[pop["quidditch_wins"] != 0, "familiar"] == "banana_slug").all()
         group_sizes = pd.DataFrame(
-            pop.groupby(["familiar"]).size().astype("float"), columns=[METRICS_COLUMN]
+            pop.groupby(["familiar"]).size().astype("float"), columns=[VALUE_COLUMN]
         )
-        metrics = sim._results.metrics["quidditch_wins"]
-        # We cannot use `equals` here because metrics has a MultiIndex where
+        raw_results = sim._results._raw_results["quidditch_wins"]
+        # We cannot use `equals` here because raw results have a MultiIndex where
         # each layer is a Category dtype but pop has object dtype for the relevant columns
         assert (
-            metrics[metrics[METRICS_COLUMN] != 0].values
+            raw_results[raw_results[VALUE_COLUMN] != 0].values
             == (group_sizes[group_sizes.index == "banana_slug"] * step_number).values
         ).all()
 
@@ -455,7 +455,7 @@ def test_update_monotonically_increasing_metrics():
     _check_quidditch_wins(pop, step_number=2)
 
 
-def test_update_metrics_fully_filtered_pop():
+def test_update__raw_results_fully_filtered_pop():
     components = [
         Hogwarts(),
         FullyFilteredHousePointsObserver(),
@@ -465,33 +465,33 @@ def test_update_metrics_fully_filtered_pop():
     sim.step()
     # The FullyFilteredHousePointsObserver filters the population to a bogus
     # power level and so we should not be observing anything
-    assert (sim._results.metrics["house_points"][METRICS_COLUMN] == 0).all()
+    assert (sim._results._raw_results["house_points"][VALUE_COLUMN] == 0).all()
     sim.step()
-    assert (sim._results.metrics["house_points"][METRICS_COLUMN] == 0).all()
+    assert (sim._results._raw_results["house_points"][VALUE_COLUMN] == 0).all()
 
 
-def test_update_metrics_no_stratifications():
+def test_update__raw_results_no_stratifications():
     components = [Hogwarts(), NoStratificationsQuidditchWinsObserver()]
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
     sim.step()
     pop = sim.get_population()
-    results = sim._results.metrics["no_stratifications_quidditch_wins"]
-    assert results.loc["all"][METRICS_COLUMN] == pop["quidditch_wins"].sum()
+    raw_results = sim._results._raw_results["no_stratifications_quidditch_wins"]
+    assert raw_results.loc["all"][VALUE_COLUMN] == pop["quidditch_wins"].sum()
     sim.step()
     pop = sim.get_population()
-    results = sim._results.metrics["no_stratifications_quidditch_wins"]
-    assert results.loc["all"][METRICS_COLUMN] == pop["quidditch_wins"].sum() * 2
+    raw_results = sim._results._raw_results["no_stratifications_quidditch_wins"]
+    assert raw_results.loc["all"][VALUE_COLUMN] == pop["quidditch_wins"].sum() * 2
 
 
-def test_update_metrics_extra_columns():
-    """Test that metrics are updated correctly when the aggregator return
+def test_update__raw_results_extra_columns():
+    """Test that raw results are updated correctly when the aggregator return
     contains multiple columns (i.e. not just a single 'value' column)
     """
     components = [Hogwarts(), HogwartsResultsStratifier(), MagicalAttributesObserver()]
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
     sim.step()
-    results = sim._results.metrics["magical_attributes"]
-    assert (results[["spell_power", "potion_power"]].values == [1, 1]).all()
+    raw_results = sim._results._raw_results["magical_attributes"]
+    assert (raw_results[["spell_power", "potion_power"]].values == [1, 1]).all()
     sim.step()
-    results = sim._results.metrics["magical_attributes"]
-    assert (results[["spell_power", "potion_power"]].values == [2, 2]).all()
+    raw_results = sim._results._raw_results["magical_attributes"]
+    assert (raw_results[["spell_power", "potion_power"]].values == [2, 2]).all()

--- a/tests/framework/results/test_observer.py
+++ b/tests/framework/results/test_observer.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from layered_config_tree import LayeredConfigTree
 
-from vivarium.framework.results import METRICS_COLUMN
+from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.observer import Observer, StratifiedObserver
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ from vivarium import Component, Observer, StratifiedObserver
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
-from vivarium.framework.results import METRICS_COLUMN
+from vivarium.framework.results import VALUE_COLUMN
 
 
 class MockComponentA(Observer):


### PR DESCRIPTION
## Updates for psimulate

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4982

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This is a bit of a grab bag PR that paves the way for better handling
of psimulate. Notable changes:

- Removed the 'on_report' listener and instead directly call the results formatted
from a ResultsManager method as required
- Moved the writing of results to disk out of being an Observation duty
and into the engine.
- Renamed many variables away from "metrics" and towards "results"

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tests pass
