### PR TITLE
remove -l option; save out finalized model spec

### DIFF
--- a/docs/source/concepts/entry_points.rst
+++ b/docs/source/concepts/entry_points.rst
@@ -88,10 +88,10 @@ modification of a simulation defined in a model specification file.
    intended use case, so tread cautiously.
 
 By intention, the context exposes a very simple interface for managing the
-:ref:`simulation lifecycle <lifecycle_concept>`.  The combination of
-initializing and running the simulation is encapsulated in the
-:func:`run_simulation <vivarium.framework.engine.run_simulation>` command
-also available in the :mod:`engine <vivarium.framework.engine>`.
+:ref:`simulation lifecycle <lifecycle_concept>`.  Once a context is instantiated,
+all steps of running a simulation are encapsulated in the
+:func:`run_simulation <vivarium.framework.engine.SimulationContext.run_simulation>`
+method.
 
 The simulation :class:`Builder <vivarium.framework.engine.Builder>` is also
 part of the engine. It is the main interface that components use to interact

--- a/src/vivarium/examples/disease_model/disease_model.yaml
+++ b/src/vivarium/examples/disease_model/disease_model.yaml
@@ -23,9 +23,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2026
-            month: 12
-            day: 31
+            year: 2022
+            month: 1
+            day: 7
         step_size: 0.5  # Days
     population:
         population_size: 100_000

--- a/src/vivarium/examples/disease_model/disease_model.yaml
+++ b/src/vivarium/examples/disease_model/disease_model.yaml
@@ -23,9 +23,9 @@ configuration:
             month: 1
             day: 1
         end:
-            year: 2022
-            month: 1
-            day: 7
+            year: 2026
+            month: 12
+            day: 31
         step_size: 0.5  # Days
     population:
         population_size: 100_000

--- a/src/vivarium/framework/configuration.py
+++ b/src/vivarium/framework/configuration.py
@@ -10,7 +10,7 @@ representations of :term:`model specifications <Model Specification>` and
 """
 
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 import yaml
 from layered_config_tree import ConfigurationError, LayeredConfigTree
@@ -19,10 +19,10 @@ from vivarium.framework.plugins import DEFAULT_PLUGINS
 
 
 def build_model_specification(
-    model_specification: Union[str, Path, LayeredConfigTree] = None,
-    component_configuration: Union[Dict, LayeredConfigTree] = None,
-    configuration: Union[Dict, LayeredConfigTree] = None,
-    plugin_configuration: Union[Dict, LayeredConfigTree] = None,
+    model_specification: Optional[Union[str, Path, LayeredConfigTree]] = None,
+    component_configuration: Optional[Union[Dict, LayeredConfigTree]] = None,
+    configuration: Optional[Union[Dict, LayeredConfigTree]] = None,
+    plugin_configuration: Optional[Union[Dict, LayeredConfigTree]] = None,
 ) -> LayeredConfigTree:
     if isinstance(model_specification, (str, Path)):
         validate_model_specification_file(model_specification)

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Set, Union
 
 import numpy as np
 import pandas as pd
+import yaml
 from layered_config_tree import ConfigurationKeyError, LayeredConfigTree
 
 from vivarium import Component
@@ -112,6 +113,15 @@ class SimulationContext:
         model_specification = build_model_specification(
             model_specification, component_configuration, configuration, plugin_configuration
         )
+        results_dir = (
+            model_specification.to_dict()
+            .get("configuration", {})
+            .get("output_data", {})
+            .get("results_directory")
+        )
+        if results_dir:
+            with open(f"{results_dir}/complete_model_specification.yaml", "w") as f:
+                yaml.dump(model_specification.to_dict(), f)
 
         self._plugin_configuration = model_specification.plugins
         self._component_configuration = model_specification.components

--- a/src/vivarium/framework/randomness/index_map.py
+++ b/src/vivarium/framework/randomness/index_map.py
@@ -215,7 +215,7 @@ class IndexMap:
 
         """
         if isinstance(column.iloc[0], datetime.datetime):
-            column = self._clip_to_seconds(column.view(np.int64))
+            column = self._clip_to_seconds(column.astype(np.int64))
         elif np.issubdtype(column.iloc[0], np.integer):
             if not len(column >= 0) == len(column):
                 raise RandomnessError(

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -141,7 +141,8 @@ def run(
     with open(f"{results_directory}/model_specification.yaml", "w") as f:
         yaml.dump(sim.model_specification.to_dict(), f)
 
-    handle_exceptions(sim.run_simulation, logger, with_debugger)()
+    main = handle_exceptions(sim.run_simulation, logger, with_debugger)
+    sim = main()
 
     # Save out simulation metadata
     metadata = {}

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -165,7 +165,7 @@ def test():
     sim = SimulationContext(model_specification)
 
     main = handle_exceptions(sim.run_simulation, logger, with_debugger=False)
-    sim = main()
+    main()
 
     click.echo()
     click.secho("Installation test successful!", fg="green")

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -142,7 +142,7 @@ def run(
         yaml.dump(sim.model_specification.to_dict(), f)
 
     main = handle_exceptions(sim.run_simulation, logger, with_debugger)
-    sim = main()
+    main()
 
     # Save out simulation metadata
     metadata = {}

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -66,7 +66,6 @@ def simulate():
 @click.argument(
     "model_specification", type=click.Path(exists=True, dir_okay=False, resolve_path=True)
 )
-@click.option("--location", "-l", help="Location to run the simulation in.")
 @click.option(
     "--artifact_path",
     "-i",
@@ -101,7 +100,6 @@ def simulate():
 )
 def run(
     model_specification: Path,
-    location: str,
     artifact_path: Path,
     results_directory: Path,
     verbose: bool,
@@ -135,8 +133,6 @@ def run(
 
     output_data = {"results_directory": str(results_root)}
     input_data = {}
-    if location:
-        input_data["location"] = location
     if artifact_path:
         input_data["artifact_path"] = artifact_path
     override_configuration = {"output_data": output_data, "input_data": input_data}
@@ -150,7 +146,6 @@ def run(
     metadata["input_draw"] = finished_sim.configuration.input_data.input_draw_number
     metadata["simulation_run_time"] = time() - start
     metadata["artifact_path"] = artifact_path
-    metadata["location"] = location
     with open(results_root / "metadata.yaml", "w") as f:
         yaml.dump(metadata, f, default_flow_style=False)
 

--- a/src/vivarium/interface/cli.py
+++ b/src/vivarium/interface/cli.py
@@ -162,9 +162,11 @@ def test():
     configure_logging_to_terminal(verbosity=2, long_format=False)
     model_specification = disease_model.get_model_specification_path()
 
-    main = handle_exceptions(run_simulation, logger, with_debugger=False)
+    sim = SimulationContext(model_specification)
 
-    main(model_specification)
+    main = handle_exceptions(sim.run_simulation, logger, with_debugger=False)
+    sim = main()
+
     click.echo()
     click.secho("Installation test successful!", fg="green")
 
@@ -200,7 +202,8 @@ def profile(model_specification, results_directory, process):
     out_stats_file = results_directory / f"{model_specification.name}".replace(
         "yaml", "stats"
     )
-    command = f'run_simulation("{model_specification}")'
+    sim = SimulationContext(model_specification)
+    command = f"sim.run_simulation()"
     cProfile.runctx(command, globals=globals(), locals=locals(), filename=str(out_stats_file))
 
     if process:

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -331,7 +331,7 @@ def test_SimulationContext_report_write(base_config, components, tmpdir):
     ]
     finished_sim = run_simulation(base_config, components, configuration)
     # Check for expected results written
-    results_list = [file for file in results_root.rglob("*")]
+    results_list = [file for file in results_root.rglob("*.parquet")]
     assert set([file.name for file in results_list]) == set(
         [
             "house_points.parquet",
@@ -405,6 +405,13 @@ def test_get_results_formatting(base_config):
         assert (df.loc[~filter, VALUE_COLUMN] == 0).all()
         # Check that expected groups' values are a multiple of the number of steps
         assert (df.loc[filter, VALUE_COLUMN] % num_steps == 0).all()
+
+
+def test_save_out_complete_model_spec(SimulationContext, base_config, components, tmpdir):
+    results_root = Path(tmpdir)
+    configuration = {"output_data": {"results_directory": str(results_root)}}
+    _ = SimulationContext(base_config, components, configuration)
+    assert results_root / "complete_model_specification.yaml" in results_root.iterdir()
 
 
 ####################

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -28,7 +28,6 @@ from vivarium.framework.components import (
 )
 from vivarium.framework.engine import Builder
 from vivarium.framework.engine import SimulationContext as SimulationContext_
-from vivarium.framework.engine import run_simulation
 from vivarium.framework.event import EventInterface, EventManager
 from vivarium.framework.lifecycle import LifeCycleInterface, LifeCycleManager
 from vivarium.framework.logging import LoggingInterface, LoggingManager
@@ -281,11 +280,10 @@ def test_SimulationContext_finalize(SimulationContext, base_config, components):
     assert listener.simulation_end_called
 
 
-def test_get_results(base_config):
+def test_get_results(SimulationContext, base_config):
     """Test that get_results returns expected values. This does NOT test for
     correct formatting.
     """
-    base_config.update(HARRY_POTTER_CONFIG)
     components = [
         Hogwarts(),
         HousePointsObserver(),
@@ -293,14 +291,14 @@ def test_get_results(base_config):
         QuidditchWinsObserver(),
         HogwartsResultsStratifier(),
     ]
-    finished_sim = run_simulation(base_config, components)
-    for measure, results in finished_sim.get_results().items():
-        raw_results = finished_sim._results._raw_results[measure].sort_index()
+    sim = SimulationContext(base_config, components, configuration=HARRY_POTTER_CONFIG)
+    sim.run_simulation()
+    for measure, results in sim.get_results().items():
+        raw_results = sim._results._raw_results[measure].sort_index()
         assert results.set_index(raw_results.index.names)[[VALUE_COLUMN]].equals(raw_results)
 
 
-def test_SimulationContext_report_no_write_warning(base_config, caplog):
-    base_config.update(HARRY_POTTER_CONFIG)
+def test_SimulationContext_report_no_write_warning(SimulationContext, base_config, caplog):
     components = [
         Hogwarts(),
         HousePointsObserver(),
@@ -308,16 +306,17 @@ def test_SimulationContext_report_no_write_warning(base_config, caplog):
         QuidditchWinsObserver(),
         HogwartsResultsStratifier(),
     ]
-    finished_sim = run_simulation(base_config, components)
+    sim = SimulationContext(base_config, components, configuration=HARRY_POTTER_CONFIG)
+    sim.run_simulation()
     assert "No results directory set; results are not written to disk." in caplog.text
-    results = finished_sim.get_results()
+    results = sim.get_results()
     assert set(results) == set(
         ["house_points", "quidditch_wins", "no_stratifications_quidditch_wins"]
     )
     assert all([isinstance(df, pd.DataFrame) for df in results.values()])
 
 
-def test_SimulationContext_report_write(base_config, components, tmpdir):
+def test_SimulationContext_report_write(SimulationContext, base_config, components, tmpdir):
     """Test that the written results match get_results"""
     results_root = Path(tmpdir)
     configuration = {"output_data": {"results_directory": str(results_root)}}
@@ -329,7 +328,8 @@ def test_SimulationContext_report_write(base_config, components, tmpdir):
         QuidditchWinsObserver(),
         HogwartsResultsStratifier(),
     ]
-    finished_sim = run_simulation(base_config, components, configuration)
+    sim = SimulationContext(base_config, components, configuration)
+    sim.run_simulation()
     # Check for expected results written
     results_list = [file for file in results_root.rglob("*.parquet")]
     assert set([file.name for file in results_list]) == set(
@@ -342,12 +342,12 @@ def test_SimulationContext_report_write(base_config, components, tmpdir):
 
     # Check that written results match get_results method
     for measure in ["house_points", "quidditch_wins", "no_stratifications_quidditch_wins"]:
-        results = finished_sim.get_results()[measure]
+        results = sim.get_results()[measure]
         written_results = pd.read_parquet(results_root / f"{measure}.parquet")
         assert results.equals(written_results)
 
 
-def test_get_results_formatting(base_config):
+def test_get_results_formatting(SimulationContext, base_config):
     """Test formatted results are as expected"""
     components = [
         Hogwarts(),
@@ -356,14 +356,13 @@ def test_get_results_formatting(base_config):
         QuidditchWinsObserver(),
         HogwartsResultsStratifier(),
     ]
-    finished_sim = run_simulation(base_config, components, configuration=HARRY_POTTER_CONFIG)
-    num_steps = _get_num_steps(finished_sim)
+    sim = SimulationContext(base_config, components, configuration=HARRY_POTTER_CONFIG)
+    sim.run_simulation()
+    num_steps = _get_num_steps(sim)
 
-    house_points = finished_sim.get_results()["house_points"]
-    quidditch_wins = finished_sim.get_results()["quidditch_wins"]
-    no_stratifications_quidditch_wins = finished_sim.get_results()[
-        "no_stratifications_quidditch_wins"
-    ]
+    house_points = sim.get_results()["house_points"]
+    quidditch_wins = sim.get_results()["quidditch_wins"]
+    no_stratifications_quidditch_wins = sim.get_results()["no_stratifications_quidditch_wins"]
 
     # Check that each dataset includes the entire cartesian product of stratifications
     # (or, when no stratifications, just a single "all" row)
@@ -405,13 +404,6 @@ def test_get_results_formatting(base_config):
         assert (df.loc[~filter, VALUE_COLUMN] == 0).all()
         # Check that expected groups' values are a multiple of the number of steps
         assert (df.loc[filter, VALUE_COLUMN] % num_steps == 0).all()
-
-
-def test_save_out_complete_model_spec(SimulationContext, base_config, components, tmpdir):
-    results_root = Path(tmpdir)
-    configuration = {"output_data": {"results_directory": str(results_root)}}
-    _ = SimulationContext(base_config, components, configuration)
-    assert results_root / "complete_model_specification.yaml" in results_root.iterdir()
 
 
 ####################

--- a/tests/interface/test_cli.py
+++ b/tests/interface/test_cli.py
@@ -33,15 +33,24 @@ def model_spec(base_config, tmp_path) -> str:
     return filepath
 
 
-@pytest.mark.parametrize("cli_args", [(), ("-i",), ("-l",), ("-i", "-l")])
-def test_simulate_run(runner, model_spec, hdf_file_path, cli_args):
+def test_simulate_run(runner, model_spec, hdf_file_path):
+
+    run_parameters = {param.name for param in simulate.commands["run"].params}
+    expected_parameters = {
+        "model_specification",
+        "artifact_path",
+        "results_directory",
+        "verbose",
+        "quiet",
+        "with_debugger",
+    }
+    different_params = run_parameters.symmetric_difference(expected_parameters)
+    if run_parameters.symmetric_difference(expected_parameters):
+        raise ValueError(
+            f"Missing or unexpected parameters in simulate run: {different_params}"
+        )
     output_dir = "/".join(model_spec.split("/")[:-1])
-    extra_args = []
-    if "-i" in cli_args:
-        extra_args.extend(["-i", hdf_file_path])
-    if "-l" in cli_args:
-        extra_args.extend(["-l", "Hogwarts"])
-    args = ["run", model_spec, "-o", output_dir] + extra_args
+    args = ["run", model_spec, "-o", output_dir, "-i", hdf_file_path]
     sim = runner.invoke(simulate, args)
     assert sim.exit_code == 0
     results_dir = list(Path(output_dir).rglob("*/simulation.log"))[0].parent
@@ -54,14 +63,10 @@ def test_simulate_run(runner, model_spec, hdf_file_path, cli_args):
         metadata = yaml.safe_load(f)
 
     assert set(metadata) == set(
-        ["input_draw", "random_seed", "simulation_run_time", "artifact_path", "location"]
+        ["input_draw", "random_seed", "simulation_run_time", "artifact_path"]
     )
     assert metadata["simulation_run_time"] > 0.0
-    if "-i" in cli_args:
-        assert metadata["artifact_path"] == hdf_file_path
-    else:
-        assert metadata["artifact_path"] is None
-    if "-l" in cli_args:
-        assert metadata["location"] == "Hogwarts"
-    else:
-        assert metadata["location"] is None
+    # Ensure '-i' worked
+    with open(results_dir / "complete_model_specification.yaml") as f:
+        ms = yaml.safe_load(f)
+    assert ms["configuration"]["input_data"]["artifact_path"] == str(hdf_file_path)

--- a/tests/interface/test_cli.py
+++ b/tests/interface/test_cli.py
@@ -27,10 +27,11 @@ def model_spec(base_config, tmp_path) -> str:
             "HogwartsResultsStratifier()",
         ],
     }
-    filepath = f"{tmp_path}/model_spec.yaml"
+    (tmp_path / "model_spec").mkdir()
+    filepath = tmp_path / "model_spec" / "model_spec.yaml"
     with open(filepath, "w") as f:
         yaml.dump(model_spec, f)
-    return filepath
+    return str(filepath)
 
 
 def test_simulate_run(runner, model_spec, hdf_file_path):
@@ -49,7 +50,7 @@ def test_simulate_run(runner, model_spec, hdf_file_path):
         raise ValueError(
             f"Missing or unexpected parameters in simulate run: {different_params}"
         )
-    output_dir = "/".join(model_spec.split("/")[:-1])
+    output_dir = "/".join(model_spec.split("/")[:-2])
     args = ["run", model_spec, "-o", output_dir, "-i", hdf_file_path]
     sim = runner.invoke(simulate, args)
     assert sim.exit_code == 0
@@ -67,6 +68,6 @@ def test_simulate_run(runner, model_spec, hdf_file_path):
     )
     assert metadata["simulation_run_time"] > 0.0
     # Ensure '-i' worked
-    with open(results_dir / "complete_model_specification.yaml") as f:
+    with open(f"{output_dir}/model_specification.yaml") as f:
         ms = yaml.safe_load(f)
     assert ms["configuration"]["input_data"]["artifact_path"] == str(hdf_file_path)


### PR DESCRIPTION
## Remove --location option and save out finalized model spec

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: 
    - https://jira.ihme.washington.edu/browse/MIC-5101
    - https://jira.ihme.washington.edu/browse/MIC-5103

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This feeds two birds with one scone by removing the unused
`simulate run --location` option as well as saving out the finalized
model specification. I'm open to suggestions on a better name than
"complete_model_specification".

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass

