### PR TITLE
Feature/sbachmei/mic 5117 refactor observation to different types

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -206,7 +206,7 @@ class SimulationContext:
     def name(self) -> str:
         return self._name
 
-    def get_results(self) -> Dict[str, Any]:
+    def get_results(self) -> Dict[str, pd.DataFrame]:
         """Return the formatted results."""
         return self._results.get_results()
 

--- a/src/vivarium/framework/randomness/index_map.py
+++ b/src/vivarium/framework/randomness/index_map.py
@@ -215,7 +215,7 @@ class IndexMap:
 
         """
         if isinstance(column.iloc[0], datetime.datetime):
-            column = self._clip_to_seconds(column.view(np.int64))
+            column = self._clip_to_seconds(column.astype(np.int64))
         elif np.issubdtype(column.iloc[0], np.integer):
             if not len(column >= 0) == len(column):
                 raise RandomnessError(

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -8,7 +8,7 @@ from pandas.core.groupby import DataFrameGroupBy
 
 from vivarium.framework.engine import Builder
 from vivarium.framework.results.exceptions import ResultsConfigurationError
-from vivarium.framework.results.observation import SummingObservation
+from vivarium.framework.results.observation import AddingObservation
 from vivarium.framework.results.stratification import Stratification
 
 
@@ -95,7 +95,7 @@ class ResultsContext:
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
         self.stratifications.append(stratification)
 
-    def add_summing_observation(
+    def register_adding_observation(
         self,
         name: str,
         pop_filter: str,
@@ -109,7 +109,7 @@ class ResultsContext:
         stratifications = self._get_stratifications(
             additional_stratifications, excluded_stratifications
         )
-        observation = SummingObservation(
+        observation = AddingObservation(
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -120,9 +120,7 @@ class ResultsContext:
         )
         self.observations[when][(pop_filter, stratifications)].append(observation)
 
-    def gather_results(
-        self, population: pd.DataFrame, event_name: str
-    ) -> Generator[
+    def gather_results(self, population: pd.DataFrame, event_name: str) -> Generator[
         Tuple[
             Optional[pd.DataFrame],
             Optional[str],

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -120,7 +120,9 @@ class ResultsContext:
         )
         self.observations[when][(pop_filter, stratifications)].append(observation)
 
-    def gather_results(self, population: pd.DataFrame, event_name: str) -> Generator[
+    def gather_results(
+        self, population: pd.DataFrame, event_name: str
+    ) -> Generator[
         Tuple[
             Optional[pd.DataFrame],
             Optional[str],

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -144,7 +144,7 @@ class ResultsInterface:
     # def register_observation(self, ...):
     #     pass
 
-    def register_summing_observation(
+    def register_adding_observation(
         self,
         name: str,
         pop_filter: str = "tracked==True",
@@ -192,7 +192,7 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_summing_observation(
+        self._manager.register_adding_observation(
             name,
             pop_filter,
             when,

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -50,6 +50,10 @@ class ResultsInterface:
         """The name of this ResultsInterface."""
         return self._name
 
+    ##################################
+    # Stratification-related methods #
+    ##################################
+
     # TODO: It is not reflected in the sample code here, but the “when” parameter should be added
     #  to the stratification registration calls, probably as a List. Consider this after observer implementation
     def register_stratification(
@@ -132,20 +136,28 @@ class ResultsInterface:
             target, target_type, binned_column, bin_edges, labels, **cut_kwargs
         )
 
-    def register_observation(
+    ###############################
+    # Observation-related methods #
+    ###############################
+
+    # TODO: This should implement the most basic Observation registration
+    # def register_observation(self, ...):
+    #     pass
+
+    def register_summing_observation(
         self,
         name: str,
         pop_filter: str = "tracked==True",
-        aggregator_sources: Optional[List[str]] = None,
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]] = len,
-        requires_columns: List[str] = [],
-        requires_values: List[str] = [],
-        additional_stratifications: List[str] = [],
-        excluded_stratifications: List[str] = [],
         when: str = "collect_metrics",
         formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,
+        additional_stratifications: List[str] = [],
+        excluded_stratifications: List[str] = [],
+        aggregator_sources: Optional[List[str]] = None,
+        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]] = len,
+        requires_columns: List[str] = [],
+        requires_values: List[str] = [],
     ) -> None:
         """Provide the results system all the information it needs to perform the observation.
 
@@ -156,6 +168,17 @@ class ResultsInterface:
         pop_filter
             A Pandas query filter string to filter the population down to the simulants who should
             be considered for the observation.
+        when
+            String name of the phase of a time-step the observation should happen. Valid values are:
+            `"time_step__prepare"`, `"time_step"`, `"time_step__cleanup"`, `"collect_metrics"`.
+        formatter
+            A function that handles formatting of the raw observations.
+        additional_stratifications
+            A list of additional :class:`stratification <vivarium.framework.results.stratification.Stratification>`
+            names by which to stratify.
+        excluded_stratifications
+            A list of default :class:`stratification <vivarium.framework.results.stratification.Stratification>`
+            names to remove from the observation.
         aggregator_sources
             A list of population view columns to be used in the aggregator.
         aggregator
@@ -164,31 +187,27 @@ class ResultsInterface:
             A list of the state table columns that are required by either the pop_filter or the aggregator.
         requires_values
             A list of the value pipelines that are required by either the pop_filter or the aggregator.
-        additional_stratifications
-            A list of additional :class:`stratification <vivarium.framework.results.stratification.Stratification>`
-            names by which to stratify.
-        excluded_stratifications
-            A list of default :class:`stratification <vivarium.framework.results.stratification.Stratification>`
-            names to remove from the observation.
-        when
-            String name of the phase of a time-step the observation should happen. Valid values are:
-            `"time_step__prepare"`, `"time_step"`, `"time_step__cleanup"`, `"collect_metrics"`.
-        formatter
-            A function that handles formatting of the final observations at the end of the simulation.
 
         Returns
         ------
         None
         """
-        self._manager.register_observation(
+        self._manager.register_summing_observation(
             name,
             pop_filter,
+            when,
+            formatter,
+            additional_stratifications,
+            excluded_stratifications,
             aggregator_sources,
             aggregator,
             requires_columns,
             requires_values,
-            additional_stratifications,
-            excluded_stratifications,
-            when,
-            formatter,
         )
+
+    # TODO
+    # def register_addition_observation(...):
+    #     pass
+
+    # def register_concatenation_observation(...):
+    #     pass

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -303,7 +303,7 @@ class ResultsManager(Manager):
             **target_kwargs,
         )
 
-    def register_summing_observation(
+    def register_adding_observation(
         self,
         name: str,
         pop_filter: str,
@@ -318,7 +318,7 @@ class ResultsManager(Manager):
     ) -> None:
         self.logger.debug(f"Registering observation {name}")
         self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
-        self._results_context.add_summing_observation(
+        self._results_context.register_adding_observation(
             name,
             pop_filter,
             when,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -180,7 +180,7 @@ class ResultsManager(Manager):
         with 0.0.
         """
         population = self._prepare_population(event)
-        for results_group, measure in self._results_context.gather_results(
+        for results_group, measure, updater in self._results_context.gather_results(
             population, event_name
         ):
             if results_group is not None:
@@ -188,14 +188,13 @@ class ResultsManager(Manager):
                     raise ValueError(
                         f"There is a results group {results_group} but no corresponding measure"
                     )
-                # Look for extra columns in the results_group and initialize with 0.
-                extra_cols = list(
-                    set(results_group.columns) - set(self._raw_results[measure].columns)
+                if updater is None:
+                    raise ValueError(
+                        f"There is a results group {results_group} but no corresponding updater"
+                    )
+                self._raw_results[measure] = updater(
+                    self._raw_results[measure], results_group
                 )
-                if extra_cols:
-                    self._raw_results[measure][extra_cols] = 0.0
-                for col in results_group.columns:
-                    self._raw_results[measure][col] += results_group[col]
 
     def set_default_stratifications(self, builder: Builder) -> None:
         default_stratifications = builder.configuration.stratification.default
@@ -304,30 +303,30 @@ class ResultsManager(Manager):
             **target_kwargs,
         )
 
-    def register_observation(
+    def register_summing_observation(
         self,
         name: str,
         pop_filter: str,
+        when: str,
+        formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
+        additional_stratifications: List[str],
+        excluded_stratifications: List[str],
         aggregator_sources: Optional[List[str]],
         aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
         requires_columns: List[str],
         requires_values: List[str],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        when: str,
-        formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
     ) -> None:
         self.logger.debug(f"Registering observation {name}")
         self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
-        self._results_context.add_observation(
+        self._results_context.add_summing_observation(
             name,
             pop_filter,
-            aggregator_sources,
-            aggregator,
-            additional_stratifications,
-            excluded_stratifications,
             when,
             formatter,
+            additional_stratifications,
+            excluded_stratifications,
+            aggregator_sources,
+            aggregator,
         )
         self._add_resources(requires_columns, SourceType.COLUMN)
         self._add_resources(requires_values, SourceType.VALUE)

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -4,25 +4,178 @@ from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple, Union
 
 import pandas as pd
+from pandas.core.groupby import DataFrameGroupBy
 
 
 @dataclass
 class Observation:
-    """Simple container class for managing observations.
-    An `Observation` class has the following attributes:
+    """The most basic container class for managing observations with the following attributes:
     - `name`: name of the `Observation` and is the measure it is observing
     - `pop_filter`: a filter that is applied to the population before the observation is made
-    - `stratifications`: a tuple of columns for the `Observation` to stratify by
-    - `aggregator_sources`: a list of the columns to observe
-    - `aggregator`: a method that aggregates the `aggregator_sources`
     - `when`: the phase that the `Observation` is registered to
-    - `formatter`: the method that reports formats the `Observation` results
+    - `creator`: method that creates the results
+    - `updater`: method that updates the results with new observations
+    - `formatter`: method that formats the results
     """
 
     name: str
     pop_filter: str
-    stratifications: Tuple[str, ...]
-    aggregator_sources: Optional[List[str]]
-    aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]]
     when: str
+    creator: Callable
+    updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
     formatter: Callable[[str, pd.DataFrame], pd.DataFrame]
+
+
+class StratifiedObservation(Observation):
+    """Container class for managing stratified observations. Includes the following attributes:
+    - `name`: name of the `StratifiedObservation` and is the measure it is observing
+    - `pop_filter`: a filter that is applied to the population before the observation is made
+    - `when`: the phase that the `StratifiedObservation` is registered to
+    - `creator`: method that creates the results
+    - `updater`: method that updates the results with new observations
+    - `formatter`: method that formats the results
+    - `stratifications`: a tuple of columns for the `StratifiedObservation` to stratify by
+    - `aggregator_sources`: a list of the columns to observe
+    - `aggregator`: a method that aggregates the `aggregator_sources`
+    """
+
+    def __init__(
+        self,
+        name: str,
+        pop_filter: str,
+        when: str,
+        creator: Callable,
+        updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
+        formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
+        stratifications: Tuple[str, ...],
+        aggregator_sources: Optional[List[str]],
+        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
+    ):
+        super().__init__(
+            name,
+            pop_filter,
+            when,
+            creator,
+            updater,
+            formatter,
+        )
+        self.stratifications = stratifications
+        self.aggregator_sources = aggregator_sources
+        self.aggregator = aggregator
+
+
+class SummingObservation(StratifiedObservation):
+    """Specific container class for managing stratified observations and adds
+    new ones at each phase the class is registered to. Includes the following attributes:
+    - `name`: name of the `AddingObservation` and is the measure it is observing
+    - `pop_filter`: a filter that is applied to the population before the observation is made
+    - `when`: the phase that the `AddingObservation` is registered to
+    - `formatter`: method that formats the results
+    - `stratifications`: a tuple of columns for the `AddingObservation` to stratify by
+    - `aggregator_sources`: a list of the columns to observe
+    - `aggregator`: a method that aggregates the `aggregator_sources`
+    """
+
+    def __init__(
+        self,
+        name: str,
+        pop_filter: str,
+        when: str,
+        formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
+        stratifications: Tuple[str, ...],
+        aggregator_sources: Optional[List[str]],
+        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
+    ):
+        super().__init__(
+            name,
+            pop_filter,
+            when,
+            self.create_results,
+            self.add_results,
+            formatter,
+            stratifications,
+            aggregator_sources,
+            aggregator,
+        )
+
+    def create_results(
+        self,
+        pop_groups: Union[DataFrameGroupBy, pd.DataFrame],
+        stratifications: Tuple[str, ...],
+    ) -> pd.DataFrame:
+        df = self._aggregate(pop_groups, self.aggregator_sources, self.aggregator)
+        df = self._format(df)
+        df = self._expand_index(df)
+        if not list(stratifications):
+            df.index.name = "stratification"
+        return df
+
+    @staticmethod
+    def _aggregate(
+        pop_groups: Union[DataFrameGroupBy, pd.DataFrame],
+        aggregator_sources: Optional[List[str]],
+        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
+    ) -> Union[pd.Series[float], pd.DataFrame]:
+        aggregates = (
+            pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)
+            if aggregator_sources
+            else pop_groups.apply(aggregator)
+        )
+        return aggregates
+
+    @staticmethod
+    def _format(aggregates: Union[pd.Series[float], pd.DataFrame]) -> pd.DataFrame:
+        df = pd.DataFrame(aggregates) if isinstance(aggregates, pd.Series) else aggregates
+        if df.shape[1] == 1:
+            df.rename(columns={df.columns[0]: "value"}, inplace=True)
+        return df
+
+    @staticmethod
+    def _expand_index(aggregates: pd.DataFrame) -> pd.DataFrame:
+        if isinstance(aggregates.index, pd.MultiIndex):
+            full_idx = pd.MultiIndex.from_product(aggregates.index.levels)
+        else:
+            full_idx = aggregates.index
+        aggregates = aggregates.reindex(full_idx).fillna(0.0)
+        return aggregates
+
+    @staticmethod
+    def add_results(
+        existing_results: pd.DataFrame, new_observations: pd.DataFrame
+    ) -> pd.DataFrame:
+        updated_results = existing_results
+        # Look for extra columns in the new_observations and initialize with 0.
+        extra_cols = list(set(new_observations.columns) - set(existing_results.columns))
+        if extra_cols:
+            updated_results[extra_cols] = 0.0
+        for col in new_observations.columns:
+            updated_results[col] += new_observations[col]
+        return updated_results
+
+
+# TODO [MIC-4985]
+# class ConcatenatorObservation(Observation):
+#     def __init__(
+#         self,
+#         name: str,
+#         pop_filter: str,
+#         when: str,
+#         formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
+#         creator: Callable,
+#     ):
+#         super().__init__(
+#             name,
+#             pop_filter,
+#             when,
+#             formatter,
+#             self.concatenate_results,
+#             creator,
+#         )
+
+#     @staticmethod
+#     def concatenate_results(
+#         existing_results: pd.DataFrame, new_observations: pd.DataFrame
+#     ) -> pd.DataFrame:
+#         if existing_results.empty:
+#             return new_observations
+#         return pd.concat([existing_results, new_observations], axis=1)

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -103,7 +103,7 @@ class StratifiedObservation(Observation):
         return aggregates
 
 
-class SummingObservation(StratifiedObservation):
+class AddingObservation(StratifiedObservation):
     """Specific container class for managing stratified observations and adds
     new ones at each phase the class is registered to. Includes the following attributes:
     - `name`: name of the `AddingObservation` and is the measure it is observing

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -143,9 +143,11 @@ class SummingObservation(StratifiedObservation):
     def add_results(
         existing_results: pd.DataFrame, new_observations: pd.DataFrame
     ) -> pd.DataFrame:
-        updated_results = existing_results
+        updated_results = existing_results.copy()
         # Look for extra columns in the new_observations and initialize with 0.
-        extra_cols = list(set(new_observations.columns) - set(existing_results.columns))
+        extra_cols = [
+            c for c in new_observations.columns if c not in existing_results.columns
+        ]
         if extra_cols:
             updated_results[extra_cols] = 0.0
         for col in new_observations.columns:

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -27,9 +27,9 @@ class Observer(Component, ABC):
     def setup_component(self, builder: Builder) -> None:
         super().setup_component(builder)
         self.register_observations(builder)
-        self.get_report_attributes(builder)
+        self.get_formatter_attributes(builder)
 
-    def get_report_attributes(self, builder: Builder) -> None:
+    def get_formatter_attributes(self, builder: Builder) -> None:
         """Define commonly-used attributes for reporting."""
         self.results_dir = (
             builder.configuration.to_dict()

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -174,7 +174,7 @@ def test_flatten_with_nested_sub_components():
 def test_setup_components(mocker):
     builder = mocker.Mock()
     builder.configuration = {}
-    mocker.patch("vivarium.framework.results.observer.Observer.get_report_attributes")
+    mocker.patch("vivarium.framework.results.observer.Observer.get_formatter_attributes")
     mock_a = MockComponentA("test_a")
     mock_b = MockComponentB("test_b")
     components = OrderedComponentSet(mock_a, mock_b)

--- a/tests/framework/randomness/test_index_map.py
+++ b/tests/framework/randomness/test_index_map.py
@@ -88,7 +88,7 @@ def test_clip_to_seconds_series():
     k = (
         pd.date_range(pd.to_datetime(stamp, unit="s"), periods=10000, freq="ns")
         .to_series()
-        .view(np.int64)
+        .astype(np.int64)
     )
     assert len(m._clip_to_seconds(k).unique()) == 1
     assert m._clip_to_seconds(k).unique()[0] == stamp

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -107,7 +107,7 @@ class HousePointsObserver(StratifiedObserver):
     """
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_observation(
+        builder.results.register_summing_observation(
             name="house_points",
             aggregator_sources=["house_points"],
             aggregator=sum,
@@ -122,7 +122,7 @@ class FullyFilteredHousePointsObserver(Component):
     """Same as `HousePointsObserver but with a filter that leaves no simulants"""
 
     def setup(self, builder: Builder) -> None:
-        builder.results.register_observation(
+        builder.results.register_summing_observation(
             name="house_points",
             pop_filter="tracked==True & power_level=='one billion'",
             aggregator_sources=["house_points"],
@@ -137,7 +137,7 @@ class QuidditchWinsObserver(StratifiedObserver):
     """Observer that is stratified by a single column ('familiar')"""
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_observation(
+        builder.results.register_summing_observation(
             name="quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
@@ -154,7 +154,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
     """Same as above but no stratifications at all"""
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_observation(
+        builder.results.register_summing_observation(
             name="no_stratifications_quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
@@ -173,7 +173,7 @@ class MagicalAttributesObserver(StratifiedObserver):
     """
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_observation(
+        builder.results.register_summing_observation(
             name="magical_attributes",
             aggregator=self._get_magical_attributes,
             excluded_stratifications=["student_house"],

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -107,7 +107,7 @@ class HousePointsObserver(StratifiedObserver):
     """
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_summing_observation(
+        builder.results.register_adding_observation(
             name="house_points",
             aggregator_sources=["house_points"],
             aggregator=sum,
@@ -122,7 +122,7 @@ class FullyFilteredHousePointsObserver(Component):
     """Same as `HousePointsObserver but with a filter that leaves no simulants"""
 
     def setup(self, builder: Builder) -> None:
-        builder.results.register_summing_observation(
+        builder.results.register_adding_observation(
             name="house_points",
             pop_filter="tracked==True & power_level=='one billion'",
             aggregator_sources=["house_points"],
@@ -137,7 +137,7 @@ class QuidditchWinsObserver(StratifiedObserver):
     """Observer that is stratified by a single column ('familiar')"""
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_summing_observation(
+        builder.results.register_adding_observation(
             name="quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
@@ -154,7 +154,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
     """Same as above but no stratifications at all"""
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_summing_observation(
+        builder.results.register_adding_observation(
             name="no_stratifications_quidditch_wins",
             aggregator_sources=["quidditch_wins"],
             aggregator=sum,
@@ -173,7 +173,7 @@ class MagicalAttributesObserver(StratifiedObserver):
     """
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_summing_observation(
+        builder.results.register_adding_observation(
             name="magical_attributes",
             aggregator=self._get_magical_attributes,
             excluded_stratifications=["student_house"],

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -117,7 +117,7 @@ def test_add_observation(
     ctx = ResultsContext()
     ctx._default_stratifications = ["age", "sex"]
     assert len(ctx.observations) == 0
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name=name,
         pop_filter=pop_filter,
         aggregator_sources=[],
@@ -152,7 +152,7 @@ def test_double_add_observation(
     ctx = ResultsContext()
     ctx._default_stratifications = ["age", "sex"]
     assert len(ctx.observations) == 0
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name=name,
         pop_filter=pop_filter,
         aggregator_sources=[],
@@ -162,7 +162,7 @@ def test_double_add_observation(
         when=when,
         formatter=lambda: None,
     )
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name=name,
         pop_filter=pop_filter,
         aggregator_sources=[],
@@ -259,7 +259,7 @@ def test_gather_results(pop_filter, aggregator_sources, aggregator, stratificati
         ctx.add_stratification("house", ["house"], CATEGORIES, None, True)
     if "familiar" in stratifications:
         ctx.add_stratification("familiar", ["familiar"], FAMILIARS, None, True)
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name="foo",
         pop_filter=pop_filter,
         aggregator_sources=aggregator_sources,
@@ -351,7 +351,7 @@ def test_gather_results_partial_stratifications_in_results(
         ctx.add_stratification("house", ["house"], CATEGORIES, None, True)
     if "familiar" in stratifications:
         ctx.add_stratification("familiar", ["familiar"], FAMILIARS, None, True)
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name=name,
         pop_filter=pop_filter,
         aggregator_sources=aggregator_sources,
@@ -378,7 +378,7 @@ def test_gather_results_with_empty_pop_filter():
     population = BASE_POPULATION.copy()
 
     event_name = "collect_metrics"
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name="wizard_count",
         pop_filter="house == 'durmstrang'",
         aggregator_sources=[],
@@ -401,7 +401,7 @@ def test_gather_results_with_no_stratifications():
     population = BASE_POPULATION.copy()
 
     event_name = "collect_metrics"
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name="wizard_count",
         pop_filter="",
         aggregator_sources=None,
@@ -436,7 +436,7 @@ def test_bad_aggregator_stratification():
     # Set up stratifications
     ctx.add_stratification("house", ["house"], CATEGORIES, None, True)
     ctx.add_stratification("familiar", ["familiar"], FAMILIARS, None, True)
-    ctx.add_summing_observation(
+    ctx.register_adding_observation(
         name="this_shouldnt_work",
         pop_filter="",
         aggregator_sources=[],

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -56,7 +56,7 @@ def _silly_aggregator(_: pd.DataFrame) -> float:
     ],
     ids=["valid_on_collect_metrics", "valid_on_time_step__prepare", "valid_pipelines"],
 )
-def test_register_observation(
+def test_register_summing_observation(
     mocker,
     name,
     pop_filter,
@@ -77,20 +77,21 @@ def test_register_observation(
     builder.value.get_value = MethodType(mock_get_value, builder)
     mgr.setup(builder)
     assert len(interface._manager._results_context.observations) == 0
-    interface.register_observation(
-        name,
-        pop_filter,
-        aggregator_columns,
-        aggregator,
-        requires_columns,
-        requires_values,
-        additional_stratifications,
-        excluded_stratifications,
+    interface.register_summing_observation(
+        name=name,
+        pop_filter=pop_filter,
+        when=when,
+        additional_stratifications=additional_stratifications,
+        excluded_stratifications=excluded_stratifications,
+        aggregator_sources=aggregator_columns,
+        aggregator=aggregator,
+        requires_columns=requires_columns,
+        requires_values=requires_values,
     )
     assert len(interface._manager._results_context.observations) == 1
 
 
-def test_register_observations(mocker):
+def test_register_multiple_summing_observations(mocker):
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
     builder = mocker.Mock()
@@ -98,15 +99,10 @@ def test_register_observations(mocker):
     mgr.setup(builder)
 
     assert len(interface._manager._results_context.observations) == 0
-    interface.register_observation(
-        "living_person_time",
-        aggregator_sources=[],
-        aggregator=_silly_aggregator,
-        requires_columns=[],
-        requires_values=[],
-        additional_stratifications=[],
-        excluded_stratifications=[],
+    interface.register_summing_observation(
+        name="living_person_time",
         when="collect_metrics",
+        aggregator=_silly_aggregator,
     )
     # Test observation gets added
     assert len(interface._manager._results_context.observations) == 1
@@ -114,16 +110,11 @@ def test_register_observations(mocker):
     assert ("tracked==True", ()) in interface._manager._results_context.observations[
         "collect_metrics"
     ]
-    interface.register_observation(
-        "undead_person_time",
-        "undead == True",
-        [],
-        _silly_aggregator,
-        [],
-        [],
-        [],
-        [],
-        "time_step__prepare",
+    interface.register_summing_observation(
+        name="undead_person_time",
+        pop_filter="undead == True",
+        when="time_step__prepare",
+        aggregator=_silly_aggregator,
     )
     # Test new observation gets added
     assert len(interface._manager._results_context.observations) == 2
@@ -146,7 +137,7 @@ def test_unhashable_pipeline(mocker):
 
     assert len(interface._manager._results_context.observations) == 0
     with pytest.raises(TypeError, match="unhashable"):
-        interface.register_observation(
+        interface.register_summing_observation(
             "living_person_time",
             'alive == "alive" and undead == False',
             [],
@@ -177,7 +168,7 @@ def mock__prepare_population(self, event):
     "when",
     ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"],
 )
-def test_register_observation_when_options(when, mocker):
+def test_register_summing_observation_when_options(when, mocker):
     """Test the full interface lifecycle of adding an observation and simulation event."""
     # Create interface
     mgr = ResultsManager()
@@ -204,50 +195,14 @@ def test_register_observation_when_options(when, mocker):
     }
 
     # Register observations to all four phases
-    results_interface.register_observation(
-        "time_step__prepare_measure",
-        "tracked==True",
-        None,
-        time_step__prepare_mock_aggregator,
-        ["house", "familiar"],
-        [],
-        ["house", "familiar"],
-        [],
-        "time_step__prepare",
-    )
-    results_interface.register_observation(
-        "time_step_measure",
-        "tracked==True",
-        None,
-        time_step_mock_aggregator,
-        ["house", "familiar"],
-        [],
-        ["house", "familiar"],
-        [],
-        "time_step",
-    )
-    results_interface.register_observation(
-        "time_step__cleanup_measure",
-        "tracked==True",
-        None,
-        time_step__cleanup_mock_aggregator,
-        ["house", "familiar"],
-        [],
-        ["house", "familiar"],
-        [],
-        "time_step__cleanup",
-    )
-    results_interface.register_observation(
-        "collect_metrics_measure",
-        "tracked==True",
-        None,
-        collect_metrics_mock_aggregator,
-        ["house", "familiar"],
-        [],
-        ["house", "familiar"],
-        [],
-        "collect_metrics",
-    )
+    for phase, aggregator in aggregator_map.items():
+        results_interface.register_summing_observation(
+            name=f"{phase}_measure",
+            when=phase,
+            additional_stratifications=["house", "familiar"],
+            aggregator=aggregator,
+            requires_columns=["house", "familiar"],
+        )
 
     # Mock in mgr._prepare_population to return population table, event
     mocker.patch.object(mgr, "_prepare_population")

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -56,7 +56,7 @@ def _silly_aggregator(_: pd.DataFrame) -> float:
     ],
     ids=["valid_on_collect_metrics", "valid_on_time_step__prepare", "valid_pipelines"],
 )
-def test_register_summing_observation(
+def test_register_adding_observation(
     mocker,
     name,
     pop_filter,
@@ -77,7 +77,7 @@ def test_register_summing_observation(
     builder.value.get_value = MethodType(mock_get_value, builder)
     mgr.setup(builder)
     assert len(interface._manager._results_context.observations) == 0
-    interface.register_summing_observation(
+    interface.register_adding_observation(
         name=name,
         pop_filter=pop_filter,
         when=when,
@@ -91,7 +91,7 @@ def test_register_summing_observation(
     assert len(interface._manager._results_context.observations) == 1
 
 
-def test_register_multiple_summing_observations(mocker):
+def test_register_multiple_adding_observations(mocker):
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
     builder = mocker.Mock()
@@ -99,7 +99,7 @@ def test_register_multiple_summing_observations(mocker):
     mgr.setup(builder)
 
     assert len(interface._manager._results_context.observations) == 0
-    interface.register_summing_observation(
+    interface.register_adding_observation(
         name="living_person_time",
         when="collect_metrics",
         aggregator=_silly_aggregator,
@@ -110,7 +110,7 @@ def test_register_multiple_summing_observations(mocker):
     assert ("tracked==True", ()) in interface._manager._results_context.observations[
         "collect_metrics"
     ]
-    interface.register_summing_observation(
+    interface.register_adding_observation(
         name="undead_person_time",
         pop_filter="undead == True",
         when="time_step__prepare",
@@ -137,7 +137,7 @@ def test_unhashable_pipeline(mocker):
 
     assert len(interface._manager._results_context.observations) == 0
     with pytest.raises(TypeError, match="unhashable"):
-        interface.register_summing_observation(
+        interface.register_adding_observation(
             "living_person_time",
             'alive == "alive" and undead == False',
             [],
@@ -168,7 +168,7 @@ def mock__prepare_population(self, event):
     "when",
     ["time_step__prepare", "time_step", "time_step__cleanup", "collect_metrics"],
 )
-def test_register_summing_observation_when_options(when, mocker):
+def test_register_adding_observation_when_options(when, mocker):
     """Test the full interface lifecycle of adding an observation and simulation event."""
     # Create interface
     mgr = ResultsManager()
@@ -196,7 +196,7 @@ def test_register_summing_observation_when_options(when, mocker):
 
     # Register observations to all four phases
     for phase, aggregator in aggregator_map.items():
-        results_interface.register_summing_observation(
+        results_interface.register_adding_observation(
             name=f"{phase}_measure",
             when=phase,
             additional_stratifications=["house", "familiar"],

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -256,7 +256,7 @@ def test_add_observation_nop_stratifications(
     mgr.logger = logger
 
     mgr._results_context.default_stratifications = default
-    mgr.register_summing_observation(
+    mgr.register_adding_observation(
         name="name",
         pop_filter='alive == "alive"',
         aggregator_sources=[],

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -256,7 +256,7 @@ def test_add_observation_nop_stratifications(
     mgr.logger = logger
 
     mgr._results_context.default_stratifications = default
-    mgr.register_observation(
+    mgr.register_summing_observation(
         name="name",
         pop_filter='alive == "alive"',
         aggregator_sources=[],

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -7,8 +7,8 @@ from tests.framework.results.helpers import BASE_POPULATION, CATEGORIES, FAMILIA
 from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.context import ResultsContext
 from vivarium.framework.results.observation import (
-    StratifiedObservation,
     AddingObservation,
+    StratifiedObservation,
 )
 
 

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -8,7 +8,7 @@ from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.context import ResultsContext
 from vivarium.framework.results.observation import (
     StratifiedObservation,
-    SummingObservation,
+    AddingObservation,
 )
 
 
@@ -27,9 +27,9 @@ def stratified_observation():
 
 
 @pytest.fixture
-def summing_observation():
-    return SummingObservation(
-        name="summing_observation_name",
+def adding_observation():
+    return AddingObservation(
+        name="adding_observation_name",
         pop_filter="",
         when="whenevs",
         formatter=lambda _, __: pd.DataFrame(),
@@ -191,9 +191,9 @@ def test_stratified_observation_creator(stratifications, stratified_observation)
         pd.DataFrame({"another_value": [3.0, 4.0], "yet_another_value": [5.0, 6.0]}),
     ],
 )
-def test_summing_observation_updater(new_observations, summing_observation):
+def test_adding_observation_updater(new_observations, adding_observation):
     existing_results = pd.DataFrame({"value": [0.0, 0.0]})
-    updated_results = summing_observation.updater(existing_results, new_observations)
+    updated_results = adding_observation.updater(existing_results, new_observations)
     if "value" in new_observations.columns:
         assert updated_results.equals(new_observations)
     else:

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -1,0 +1,159 @@
+import itertools
+
+import pandas as pd
+import pytest
+
+from tests.framework.results.helpers import (
+    BASE_POPULATION,
+    CATEGORIES,
+    FAMILIARS,
+    NAME,
+    SOURCES,
+    sorting_hat_serial,
+    sorting_hat_vector,
+    verify_stratification_added,
+)
+from vivarium.framework.results import VALUE_COLUMN
+from vivarium.framework.results.context import ResultsContext, SummingObservation
+
+
+@pytest.mark.parametrize(
+    "stratifications, aggregator_sources, aggregator",
+    [
+        # Series or single-column dataframe return
+        (("familiar",), ["power_level"], len),
+        (("familiar",), [], len),
+        (("familiar", "house"), ["power_level"], len),
+        (("familiar", "house"), [], len),
+        ((), ["power_level"], len),
+        ((), [], len),
+        # Multiple-column dataframe return
+        (("familiar",), ["power_level", "tracked"], sum),
+        (("familiar", "house"), ["power_level", "tracked"], sum),
+        ((), ["power_level", "tracked"], sum),
+    ],
+)
+def test_summing_observation__aggregate(stratifications, aggregator_sources, aggregator):
+    """Test that we are aggregating correctly. There are some nuances here:
+    - If aggregator_resources is provided, then simply .apply it to the groups passed in.
+    - If no aggregator_resources are provided, then we want a full aggregation of the groups.
+    - _aggregate can return either a pd.Series or a pd.DataFrame of any number of columns
+    """
+    groups = ResultsContext()._get_groups(
+        stratifications=stratifications, filtered_pop=BASE_POPULATION
+    )
+    obs = SummingObservation(
+        name="foo",
+        pop_filter="",
+        when="whenevs",
+        formatter=lambda _, __: pd.DataFrame(),
+        stratifications=stratifications,
+        aggregator_sources=aggregator_sources,
+        aggregator=aggregator,
+    )
+    aggregates = obs._aggregate(
+        pop_groups=groups,
+        aggregator_sources=aggregator_sources,
+        aggregator=aggregator,
+    )
+    if aggregator == len:
+        if stratifications:
+            stratification_idx = (
+                set(itertools.product(*(FAMILIARS, CATEGORIES)))
+                if "house" in stratifications
+                else set(FAMILIARS)
+            )
+            assert set(aggregates.index) == stratification_idx
+            assert (aggregates.values == len(BASE_POPULATION) / groups.ngroups).all()
+        else:
+            assert len(aggregates.values) == 1
+            assert aggregates.values[0] == len(BASE_POPULATION)
+    else:  # sum aggregator
+        assert aggregates.shape[1] == 2
+        expected = BASE_POPULATION[["power_level", "tracked"]].sum() / groups.ngroups
+        if stratifications:
+            stratification_idx = (
+                set(itertools.product(*(FAMILIARS, CATEGORIES)))
+                if "house" in stratifications
+                else set(FAMILIARS)
+            )
+            assert set(aggregates.index) == stratification_idx
+            assert (aggregates.sum() / groups.ngroups).equals(expected)
+        else:
+            assert len(aggregates.values) == 1
+            for col in ["power_level", "tracked"]:
+                assert aggregates.loc["all", col] == expected[col]
+
+
+@pytest.mark.parametrize(
+    "aggregates",
+    [
+        pd.Series(data=[1, 2, 3], index=pd.Index(["a", "b", "c"], name="index")),
+        pd.DataFrame({"col1": [1, 2], "strat1": [1, 1], "strat2": ["cat", "dog"]}).set_index(
+            ["strat1", "strat2"]
+        ),
+    ],
+)
+def test_summing_observation__format(aggregates):
+    obs = SummingObservation(
+        name="foo",
+        pop_filter="",
+        when="whenevs",
+        formatter=lambda _, __: pd.DataFrame(),
+        stratifications=(),
+        aggregator_sources=None,
+        aggregator=lambda _: 0.0,
+    )
+    new_aggregates = obs._format(aggregates=aggregates)
+    assert isinstance(new_aggregates, pd.DataFrame)
+    if isinstance(aggregates, pd.Series):
+        assert new_aggregates.equals(aggregates.to_frame("value"))
+    else:
+        assert new_aggregates.equals(aggregates)
+
+
+@pytest.mark.parametrize(
+    "aggregates",
+    [
+        pd.DataFrame(
+            {VALUE_COLUMN: [1.0, 2.0, 10.0, 20.0]},
+            index=pd.Index(["ones"] * 2 + ["tens"] * 2),
+        ),
+        pd.DataFrame(
+            {VALUE_COLUMN: [1.0, 2.0, 10.0, 20.0, "bad", "bad"]},
+            index=pd.MultiIndex.from_arrays(
+                [
+                    ["foo", "bar", "foo", "bar", "foo", "bar"],
+                    ["ones", "ones", "tens", "tens", "zeros", "zeros"],
+                ],
+                names=["nonsense", "type"],
+            ),
+        ).query('type!="zeros"'),
+    ],
+)
+def test_summing_observation__expand_index(aggregates):
+    obs = SummingObservation(
+        name="foo",
+        pop_filter="",
+        when="whenevs",
+        formatter=lambda _, __: pd.DataFrame(),
+        stratifications=(),
+        aggregator_sources=None,
+        aggregator=lambda _: 0.0,
+    )
+    full_idx_aggregates = obs._expand_index(aggregates=aggregates)
+    # NOTE: pd.MultiIndex is a subclass of pd.Index, i.e. check for this first!
+    if isinstance(aggregates.index, pd.MultiIndex):
+        # Check that index is cartesian product of the original index levels
+        assert full_idx_aggregates.index.equals(
+            pd.MultiIndex.from_product(aggregates.index.levels)
+        )
+        # Check that existing values did not change
+        assert (
+            full_idx_aggregates.loc[aggregates.index, VALUE_COLUMN]
+            == aggregates[VALUE_COLUMN]
+        ).all()
+        # Check that missingness was filled in with zeros
+        assert (full_idx_aggregates.query('type=="zeros"')[VALUE_COLUMN] == 0).all()
+    else:
+        assert aggregates.equals(full_idx_aggregates)

--- a/tests/framework/results/test_observer.py
+++ b/tests/framework/results/test_observer.py
@@ -39,7 +39,7 @@ def test_observer_instantiation():
         (True, None, None, None),
     ],
 )
-def test_get_report_attributes(is_interactive, results_dir, draw, seed, mocker):
+def test_get_formatter_attributes(is_interactive, results_dir, draw, seed, mocker):
     builder = mocker.Mock()
     if is_interactive:
         builder.configuration = LayeredConfigTree()
@@ -53,7 +53,7 @@ def test_get_report_attributes(is_interactive, results_dir, draw, seed, mocker):
         )
 
     observer = TestObserver()
-    observer.get_report_attributes(builder)
+    observer.get_formatter_attributes(builder)
 
     assert observer.results_dir == results_dir
     assert observer.input_draw == draw

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -48,7 +48,7 @@ class MockComponentB(StratifiedObserver):
         self.builder_used_for_setup = builder
 
     def register_observations(self, builder):
-        builder.results.register_summing_observation("test", aggregator=self.counter)
+        builder.results.register_adding_observation("test", aggregator=self.counter)
 
     def create_lookup_tables(self, builder):
         return {}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -48,7 +48,7 @@ class MockComponentB(StratifiedObserver):
         self.builder_used_for_setup = builder
 
     def register_observations(self, builder):
-        builder.results.register_observation("test", aggregator=self.counter)
+        builder.results.register_summing_observation("test", aggregator=self.counter)
 
     def create_lookup_tables(self, builder):
         return {}


### PR DESCRIPTION
## Refactor Observation into specify types
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5117

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This is not a feature change, just a refactor. To pave the way for different
types of observations (different than just a summation type), this
changes the registration entry point to be more specific for our most-used
type, i.e. `register_summing_observation`.

Changes include:

- Adding newly-named entry points
- Changed `Observation` to be a more generic class by removing the
  stratification-specific attributes.
- Creating a new `StratifiedObservation` class which inherits from
  `Observation` and adds the stratification-specific attributes. It does
  not define a creator attribute or the new updater or formatter attributes.
- Creating a new `SummingObservation` which inherits from`StratifiedObservation`
  and specifically defines the creator and updater attributes.
    - The relevent code for these two new attributes are moved from `ResultsContext`
       and into the `SummingObservation` as methods.
- Reordering the args for observation instantiation (annoying, sorry)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Updated tests and they pass.

