### PR TITLE
Mic-5121/Hotfix/pin numpy below 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.3.8 - 06/17/24**
+
+ - Hotfix pin numpy below 2.0
+
 **2.3.7 - 03/21/24**
   
   - Add deprecation warning to import ConfigTree from the config_tree package

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         long_description = f.read()
 
     install_requirements = [
-        "numpy",
+        "numpy<2.0.0",
         "pandas",
         "pyyaml>=5.1",
         "scipy",


### PR DESCRIPTION
## Mic-5121/Hotfix/pin numpy below 2.0

### Pin numpy below 2.0 until we can update to major version at a later data.
- *Category*: Build
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5121

### Changes and notes
-Pin numpy below 2.0

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

