### PR TITLE
stop writing seed/draw to simulation results

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
 
     install_requirements = [
         "layered_config_tree>=1.0.2",
-        "numpy",
+        "numpy<2.0.0",
         "pandas",
         "pyyaml>=5.1",
         "scipy",

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -16,8 +16,6 @@ class Observer(Component, ABC):
     def __init__(self) -> None:
         super().__init__()
         self.results_dir = None
-        self.input_draw = None
-        self.random_seed = None
 
     @abstractmethod
     def register_observations(self, builder: Builder) -> None:
@@ -35,14 +33,6 @@ class Observer(Component, ABC):
             builder.configuration.to_dict()
             .get("output_data", {})
             .get("results_directory", None)
-        )
-        self.input_draw = (
-            builder.configuration.to_dict()
-            .get("input_data", {})
-            .get("input_draw_number", None)
-        )
-        self.random_seed = (
-            builder.configuration.to_dict().get("randomness", {}).get("random_seed", None)
         )
 
 

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -1,5 +1,4 @@
 import itertools
-from functools import partial
 from typing import List
 
 import numpy as np
@@ -114,7 +113,7 @@ class HousePointsObserver(StratifiedObserver):
             requires_columns=[
                 "house_points",
             ],
-            formatter=partial(formatter, self.random_seed, self.input_draw),
+            formatter=formatter,
         )
 
 
@@ -146,7 +145,7 @@ class QuidditchWinsObserver(StratifiedObserver):
             requires_columns=[
                 "quidditch_wins",
             ],
-            formatter=partial(formatter, self.random_seed, self.input_draw),
+            formatter=formatter,
         )
 
 
@@ -162,7 +161,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
             requires_columns=[
                 "quidditch_wins",
             ],
-            formatter=partial(formatter, self.random_seed, self.input_draw),
+            formatter=formatter,
         )
 
 
@@ -208,16 +207,12 @@ class HogwartsResultsStratifier(Component):
 
 
 def formatter(
-    random_seed: str,
-    input_draw: str,
     measure: str,
     results: pd.DataFrame,
 ) -> pd.DataFrame:
     """An test use case of an observer's report method that writes a DataFrame to a CSV file."""
     # Add extra cols
     results["measure"] = measure
-    results["random_seed"] = random_seed
-    results["input_draw"] = input_draw
     # Sort the columns such that the stratifications (index) are first
     # and VALUE_COLUMN is last and sort the rows by the stratifications.
     other_cols = [c for c in results.columns if c != VALUE_COLUMN]

--- a/tests/framework/results/test_observer.py
+++ b/tests/framework/results/test_observer.py
@@ -33,13 +33,13 @@ def test_observer_instantiation():
 
 
 @pytest.mark.parametrize(
-    "is_interactive, results_dir, draw, seed",
+    "is_interactive, results_dir",
     [
-        (False, "/some/results/dir", 111, 222),
-        (True, None, None, None),
+        (False, "/some/results/dir"),
+        (True, None),
     ],
 )
-def test_get_formatter_attributes(is_interactive, results_dir, draw, seed, mocker):
+def test_get_formatter_attributes(is_interactive, results_dir, mocker):
     builder = mocker.Mock()
     if is_interactive:
         builder.configuration = LayeredConfigTree()
@@ -47,8 +47,6 @@ def test_get_formatter_attributes(is_interactive, results_dir, draw, seed, mocke
         builder.configuration = LayeredConfigTree(
             {
                 "output_data": {"results_directory": results_dir},
-                "input_data": {"input_draw_number": draw},
-                "randomness": {"random_seed": seed},
             }
         )
 
@@ -56,8 +54,6 @@ def test_get_formatter_attributes(is_interactive, results_dir, draw, seed, mocke
     observer.get_formatter_attributes(builder)
 
     assert observer.results_dir == results_dir
-    assert observer.input_draw == draw
-    assert observer.random_seed == seed
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -393,9 +393,6 @@ def test_get_results_formatting(SimulationContext, base_config):
         df = eval(measure)
         # Check that metrics col matches name of dataset
         assert (df["measure"] == measure).all()
-        # Check for other cols
-        assert "random_seed" in df.columns
-        assert "input_draw" in df.columns
         # We do enforce a col order, but most importantly ensure VALUE_COLUMN is at the end
         assert df.columns[-1] == VALUE_COLUMN
         # Check values


### PR DESCRIPTION
## Do not include seed/draw in results

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5116

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This just removes including seed and draw columns for single-simulation
results. They are unnecessary since we already write out the finalized
simulation configuration and they result in duplicate columns in parallel
simulation results

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests updated and pass
