### PR TITLE
Feature/sbachmei/refactor observation registrations and other minor updates

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Callable, Generator, List, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from pandas.core.groupby import DataFrameGroupBy
 
 from vivarium.framework.engine import Builder
 from vivarium.framework.results.exceptions import ResultsConfigurationError
-from vivarium.framework.results.observation import (
-    AddingObservation,
-    ConcatenatingObservation,
-    StratifiedObservation,
-    UnstratifiedObservation,
-)
+from vivarium.framework.results.observation import BaseObservation
 from vivarium.framework.results.stratification import Stratification
 
 
@@ -100,93 +95,15 @@ class ResultsContext:
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
         self.stratifications.append(stratification)
 
-    def register_stratified_observation(
+    def register_observation(
         self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
+        observation_type: Type[BaseObservation],
+        **kwargs,
     ) -> None:
-        stratifications = self._get_stratifications(
-            additional_stratifications, excluded_stratifications
-        )
-        observation = StratifiedObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-            stratifications=stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
-        )
-        self.observations[when][(pop_filter, stratifications)].append(observation)
-
-    def register_unstratified_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        results_gatherer: Callable[[pd.DataFrame], pd.DataFrame],
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        observation = UnstratifiedObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_gatherer=results_gatherer,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-        )
-        self.observations[when][(pop_filter, None)].append(observation)
-
-    def register_adding_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
-    ) -> None:
-        stratifications = self._get_stratifications(
-            additional_stratifications, excluded_stratifications
-        )
-        observation = AddingObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_formatter=results_formatter,
-            stratifications=stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
-        )
-        self.observations[when][(pop_filter, stratifications)].append(observation)
-
-    def register_concatenating_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        included_columns: List[str],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        observation = ConcatenatingObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            included_columns=included_columns,
-            results_formatter=results_formatter,
-        )
-        self.observations[when][(pop_filter, None)].append(observation)
+        observation = observation_type(**kwargs)
+        self.observations[observation.when][
+            (observation.pop_filter, observation.stratifications)
+        ].append(observation)
 
     def gather_results(
         self, population: pd.DataFrame, event_name: str
@@ -222,18 +139,6 @@ class ResultsContext:
                     for observation in observations:
                         aggregates = observation.results_gatherer(pop_groups, stratifications)
                         yield aggregates, observation.name, observation.results_updater
-
-    def _get_stratifications(
-        self,
-        additional_stratifications: List[str] = [],
-        excluded_stratifications: List[str] = [],
-    ) -> Tuple[str, ...]:
-        stratifications = list(
-            set(self.default_stratifications) - set(excluded_stratifications)
-            | set(additional_stratifications)
-        )
-        # Makes sure measure identifiers have fields in the same relative order.
-        return tuple(sorted(stratifications))
 
     @staticmethod
     def _filter_population(population: pd.DataFrame, pop_filter: str) -> pd.DataFrame:

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -108,7 +108,9 @@ class ResultsContext:
             (observation.pop_filter, observation.stratifications)
         ].append(observation)
 
-    def gather_results(self, population: pd.DataFrame, event_name: str) -> Generator[
+    def gather_results(
+        self, population: pd.DataFrame, event_name: str
+    ) -> Generator[
         Tuple[
             Optional[pd.DataFrame],
             Optional[str],

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -98,16 +98,17 @@ class ResultsContext:
     def register_observation(
         self,
         observation_type: Type[BaseObservation],
+        name: str,
+        pop_filter: str,
+        when: str,
         **kwargs,
     ) -> None:
-        observation = observation_type(**kwargs)
+        observation = observation_type(name=name, pop_filter=pop_filter, when=when, **kwargs)
         self.observations[observation.when][
             (observation.pop_filter, observation.stratifications)
         ].append(observation)
 
-    def gather_results(
-        self, population: pd.DataFrame, event_name: str
-    ) -> Generator[
+    def gather_results(self, population: pd.DataFrame, event_name: str) -> Generator[
         Tuple[
             Optional[pd.DataFrame],
             Optional[str],

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import pandas as pd
@@ -16,6 +15,11 @@ from vivarium.framework.results.observation import (
 if TYPE_CHECKING:
     # cyclic import
     from vivarium.framework.results.manager import ResultsManager
+
+
+def _required_function_placeholder(*args, **kwargs) -> pd.DataFrame:
+    """Placeholder function to indicate that a required function is missing."""
+    return pd.DataFrame()
 
 
 class ResultsInterface:
@@ -158,7 +162,7 @@ class ResultsInterface:
         requires_values: List[str] = [],
         results_updater: Callable[
             [pd.DataFrame, pd.DataFrame], pd.DataFrame
-        ] = StratifiedObservation._raise_missing,
+        ] = _required_function_placeholder,
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,
@@ -224,10 +228,9 @@ class ResultsInterface:
     def _check_for_required_callables(
         observation_name: str, required_callables: Dict[str, Callable]
     ) -> None:
-        breakpoint()
         missing = []
         for arg_name, callable in required_callables.items():
-            if callable.__func__ == BaseObservation._raise_missing.__func__:
+            if callable == _required_function_placeholder:
                 missing.append(arg_name)
         if len(missing) > 0:
             raise ValueError(
@@ -243,10 +246,10 @@ class ResultsInterface:
         requires_values: List[str] = [],
         results_gatherer: Callable[
             [pd.DataFrame], pd.DataFrame
-        ] = UnstratifiedObservation._raise_missing,
+        ] = _required_function_placeholder,
         results_updater: Callable[
             [pd.DataFrame, pd.DataFrame], pd.DataFrame
-        ] = UnstratifiedObservation._raise_missing,
+        ] = _required_function_placeholder,
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,
@@ -405,6 +408,7 @@ class ResultsInterface:
         ------
         None
         """
+        included_columns = ["event_time"] + requires_columns + requires_values
         self._manager.register_observation(
             observation_type=ConcatenatingObservation,
             is_stratified=False,
@@ -414,4 +418,5 @@ class ResultsInterface:
             requires_columns=requires_columns,
             requires_values=requires_values,
             results_formatter=results_formatter,
+            included_columns=included_columns,
         )

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -1,26 +1,18 @@
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import pandas as pd
 
+from vivarium.framework.results.observation import (
+    StratifiedObservation,
+    UnstratifiedObservation,
+)
+
 if TYPE_CHECKING:
     # cyclic import
     from vivarium.framework.results.manager import ResultsManager
-
-
-def _raise_missing_unstratified_observation_results_gatherer(*args, **kwargs) -> pd.DataFrame:
-    raise RuntimeError(
-        "An UnstratifiedObservation has been registered without a `results_gatherer` "
-        "Callable which is required."
-    )
-
-
-def _raise_missing_unstratified_observation_results_updater(*args, **kwargs) -> pd.DataFrame:
-    raise RuntimeError(
-        "An UnstratifiedObservation has been registered without a `results_updater` "
-        "Callable which is required."
-    )
 
 
 def _raise_missing_stratified_observation_results_updater(*args, **kwargs) -> pd.DataFrame:
@@ -168,9 +160,9 @@ class ResultsInterface:
         when: str = "collect_metrics",
         requires_columns: List[str] = [],
         requires_values: List[str] = [],
-        results_updater: Callable[
-            [pd.DataFrame, pd.DataFrame], pd.DataFrame
-        ] = _raise_missing_stratified_observation_results_updater,
+        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame] = partial(
+            StratifiedObservation._raise_missing, "results_updater"
+        ),
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,
@@ -236,12 +228,12 @@ class ResultsInterface:
         when: str = "collect_metrics",
         requires_columns: List[str] = [],
         requires_values: List[str] = [],
-        results_gatherer: Callable[
-            [pd.DataFrame], pd.DataFrame
-        ] = _raise_missing_unstratified_observation_results_gatherer,
-        results_updater: Callable[
-            [pd.DataFrame, pd.DataFrame], pd.DataFrame
-        ] = _raise_missing_unstratified_observation_results_updater,
+        results_gatherer: Callable[[pd.DataFrame], pd.DataFrame] = partial(
+            UnstratifiedObservation._raise_missing, "results_gatherer"
+        ),
+        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame] = partial(
+            UnstratifiedObservation._raise_missing, "results_updater"
+        ),
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 import pandas as pd
 
 from vivarium.framework.results.observation import (
+    AddingObservation,
+    ConcatenatingObservation,
     StratifiedObservation,
     UnstratifiedObservation,
 )
@@ -13,13 +15,6 @@ from vivarium.framework.results.observation import (
 if TYPE_CHECKING:
     # cyclic import
     from vivarium.framework.results.manager import ResultsManager
-
-
-def _raise_missing_stratified_observation_results_updater(*args, **kwargs) -> pd.DataFrame:
-    raise RuntimeError(
-        "A StratifiedObservation has been registered without a `results_updater` "
-        "Callable which is required."
-    )
 
 
 class ResultsInterface:
@@ -207,7 +202,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_stratified_observation(
+        self._manager.register_observation(
+            observation_type=StratifiedObservation,
+            is_stratified=True,
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -276,7 +273,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_unstratified_observation(
+        self._manager.register_observation(
+            observation_type=UnstratifiedObservation,
+            is_stratified=False,
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -335,7 +334,10 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_adding_observation(
+
+        self._manager.register_observation(
+            observation_type=AddingObservation,
+            is_stratified=True,
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -382,7 +384,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_concatenating_observation(
+        self._manager.register_observation(
+            observation_type=ConcatenatingObservation,
+            is_stratified=False,
             name=name,
             pop_filter=pop_filter,
             when=when,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -277,7 +277,7 @@ class ResultsManager(Manager):
         **kwargs,
     ):
         self.logger.debug(f"Registering observation {kwargs['name']}")
-        # Are we stratified or not?
+
         if is_stratified:
             additional_stratifications = kwargs.get("additional_stratifications", [])
             excluded_stratifications = kwargs.get("excluded_stratifications", [])

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -274,9 +274,14 @@ class ResultsManager(Manager):
         self,
         observation_type,
         is_stratified: bool,
+        name: str,
+        pop_filter: str,
+        when: str,
+        requires_columns: List[str],
+        requires_values: List[str],
         **kwargs,
     ):
-        self.logger.debug(f"Registering observation {kwargs['name']}")
+        self.logger.debug(f"Registering observation {name}")
 
         if is_stratified:
             additional_stratifications = kwargs.get("additional_stratifications", [])
@@ -293,18 +298,14 @@ class ResultsManager(Manager):
             del kwargs["additional_stratifications"]
             del kwargs["excluded_stratifications"]
 
-        requires_columns = kwargs.get("requires_columns", [])
-        requires_values = kwargs.get("requires_values", [])
         self._add_resources(requires_columns, SourceType.COLUMN)
         self._add_resources(requires_values, SourceType.VALUE)
-        del kwargs["requires_columns"]
-        del kwargs["requires_values"]
-
-        if observation_type == ConcatenatingObservation:
-            kwargs["included_columns"] = ["event_time"] + requires_columns + requires_values
 
         self._results_context.register_observation(
             observation_type=observation_type,
+            name=name,
+            pop_filter=pop_filter,
+            when=when,
             **kwargs,
         )
 

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -10,6 +10,7 @@ from pandas.api.types import CategoricalDtype
 
 from vivarium.framework.event import Event
 from vivarium.framework.results.context import ResultsContext
+from vivarium.framework.results.observation import ConcatenatingObservation
 from vivarium.framework.results.stratification import Stratification
 from vivarium.framework.values import Pipeline
 from vivarium.manager import Manager
@@ -269,114 +270,64 @@ class ResultsManager(Manager):
             **target_kwargs,
         )
 
-    #######################
-    # Observation methods #
-    #######################
-
-    def register_stratified_observation(
+    def register_observation(
         self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
-        self._results_context.register_stratified_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-            additional_stratifications=additional_stratifications,
-            excluded_stratifications=excluded_stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
-        )
+        observation_type,
+        is_stratified: bool,
+        **kwargs,
+    ):
+        self.logger.debug(f"Registering observation {kwargs['name']}")
+        # Are we stratified or not?
+        if is_stratified:
+            additional_stratifications = kwargs.get("additional_stratifications", [])
+            excluded_stratifications = kwargs.get("excluded_stratifications", [])
+            self._warn_check_stratifications(
+                additional_stratifications, excluded_stratifications
+            )
+            stratifications = self._get_stratifications(
+                kwargs.get("stratifications", []),
+                additional_stratifications,
+                excluded_stratifications,
+            )
+            kwargs["stratifications"] = stratifications
+            del kwargs["additional_stratifications"]
+            del kwargs["excluded_stratifications"]
+
+        requires_columns = kwargs.get("requires_columns", [])
+        requires_values = kwargs.get("requires_values", [])
         self._add_resources(requires_columns, SourceType.COLUMN)
         self._add_resources(requires_values, SourceType.VALUE)
+        del kwargs["requires_columns"]
+        del kwargs["requires_values"]
 
-    def register_unstratified_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_gatherer: Callable[[pd.DataFrame], pd.DataFrame],
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._results_context.register_unstratified_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_gatherer=results_gatherer,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-        )
-        self._add_resources(["event_time"] + requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
+        if observation_type == ConcatenatingObservation:
+            kwargs["included_columns"] = ["event_time"] + requires_columns + requires_values
 
-    def register_adding_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
-        self._results_context.register_adding_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_formatter=results_formatter,
-            additional_stratifications=additional_stratifications,
-            excluded_stratifications=excluded_stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
+        self._results_context.register_observation(
+            observation_type=observation_type,
+            **kwargs,
         )
-        self._add_resources(requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
-
-    def register_concatenating_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._results_context.register_concatenating_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            included_columns=["event_time"] + requires_columns + requires_values,
-            results_formatter=results_formatter,
-        )
-        self._add_resources(["event_time"] + requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
 
     ##################
     # Helper methods #
     ##################
+
+    def _get_stratifications(
+        self,
+        stratifications: List[str] = [],
+        additional_stratifications: List[str] = [],
+        excluded_stratifications: List[str] = [],
+    ) -> Tuple[str, ...]:
+        stratifications = list(
+            set(
+                self._results_context.default_stratifications
+                + stratifications
+                + additional_stratifications
+            )
+            - set(excluded_stratifications)
+        )
+        # Makes sure measure identifiers have fields in the same relative order.
+        return tuple(sorted(stratifications))
 
     @staticmethod
     def _initialize_stratified_results(

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -28,11 +28,8 @@ class BaseObservation(ABC):
     results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame]
 
     @classmethod
-    def _raise_missing(cls, missing_arg: str, *args, **kwargs) -> pd.DataFrame:
-        raise ValueError(
-            f"A/an {cls.__name__} has been registered without a '{missing_arg}' "
-            "Callable which is required for this observation type."
-        )
+    def _raise_missing(cls, *args, **kwargs) -> pd.DataFrame:
+        return pd.DataFrame()
 
 
 class UnstratifiedObservation(BaseObservation):

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -64,6 +64,10 @@ class UnstratifiedObservation(BaseObservation):
             results_formatter=results_formatter,
         )
 
+    @property
+    def stratifications(self) -> None:
+        return None
+
 
 class StratifiedObservation(BaseObservation):
     """Container class for managing stratified observations.

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -26,6 +26,7 @@ class BaseObservation(ABC):
     results_gatherer: Callable[..., pd.DataFrame]
     results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
     results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame]
+    stratifications: Optional[Tuple[str]]
 
 
 class UnstratifiedObservation(BaseObservation):
@@ -55,11 +56,8 @@ class UnstratifiedObservation(BaseObservation):
             results_gatherer=results_gatherer,
             results_updater=results_updater,
             results_formatter=results_formatter,
+            stratifications=None,
         )
-
-    @property
-    def stratifications(self) -> None:
-        return None
 
 
 class StratifiedObservation(BaseObservation):
@@ -93,8 +91,8 @@ class StratifiedObservation(BaseObservation):
             results_gatherer=self.gather_results,
             results_updater=results_updater,
             results_formatter=results_formatter,
+            stratifications=stratifications,
         )
-        self.stratifications = stratifications
         self.aggregator_sources = aggregator_sources
         self.aggregator = aggregator
 

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -27,6 +27,13 @@ class BaseObservation(ABC):
     results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
     results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame]
 
+    @classmethod
+    def _raise_missing(cls, missing_arg: str, *args, **kwargs) -> pd.DataFrame:
+        raise ValueError(
+            f"A/an {cls.__name__} has been registered without a '{missing_arg}' "
+            "Callable which is required for this observation type."
+        )
+
 
 class UnstratifiedObservation(BaseObservation):
     """Container class for managing unstratified observations.

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -27,10 +27,6 @@ class BaseObservation(ABC):
     results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
     results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame]
 
-    @classmethod
-    def _raise_missing(cls, *args, **kwargs) -> pd.DataFrame:
-        return pd.DataFrame()
-
 
 class UnstratifiedObservation(BaseObservation):
     """Container class for managing unstratified observations.

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -46,6 +46,7 @@ class Observer(Component, ABC):
         )
 
 
+# TODO: Move this property into Observer and get rid of StratifiedObserver
 class StratifiedObserver(Observer):
     @property
     def configuration_defaults(self) -> Dict[str, Any]:

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -216,8 +216,7 @@ class CatBombObserver(StratifiedObserver):
             aggregator=len,
         )
 
-    @staticmethod
-    def update_cats(existing_df, new_df):
+    def update_cats(self, existing_df, new_df):
         no_cats_mask = existing_df["value"] == 0
         updated_df = existing_df
         updated_df.loc[no_cats_mask, "value"] = new_df["value"]
@@ -248,8 +247,7 @@ class ValedictorianObserver(Observer):
         self.valedictorians.append(valedictorian)
         return df[df["student_id"] == valedictorian]
 
-    @staticmethod
-    def update_valedictorian(_existing_df, new_df):
+    def update_valedictorian(self, _existing_df, new_df):
         return new_df
 
 

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -203,22 +203,27 @@ class ExamScoreObserver(Observer):
         )
 
 
-class CatLivesObserver(StratifiedObserver):
-    """Observer that counts the number of cat lives per house"""
+class CatBombObserver(StratifiedObserver):
+    """Observer that counts the number of feral cats per house"""
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_adding_observation(
-            name="cat_lives",
+        builder.results.register_stratified_observation(
+            name="cat_bomb",
             pop_filter="familiar=='cat' and tracked==True",
             requires_columns=["familiar"],
+            results_updater=self.update_cats,
             excluded_stratifications=["power_level_group"],
             aggregator_sources=["student_house"],
-            aggregator=self.count_lives,
+            aggregator=len,
         )
 
     @staticmethod
-    def count_lives(group):
-        return len(group) * 9
+    def update_cats(existing_df, new_df):
+        no_cats_mask = existing_df["value"] == 0
+        updated_df = existing_df
+        updated_df.loc[no_cats_mask, "value"] = new_df["value"]
+        updated_df.loc[~no_cats_mask, "value"] *= new_df["value"]
+        return updated_df
 
 
 class ValedictorianObserver(Observer):

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -228,8 +228,12 @@ class CatBombObserver(StratifiedObserver):
 
 class ValedictorianObserver(Observer):
     """Observer that records the valedictorian at each time step. All students
-    have the same exam scores and so the valecdictorian is chosen randomly.
+    have the same exam scores and so the valedictorian is chosen randomly.
     """
+
+    def __init__(self):
+        super().__init__()
+        self.valedictorians = []
 
     def register_observations(self, builder: Builder) -> None:
         builder.results.register_unstratified_observation(
@@ -239,9 +243,10 @@ class ValedictorianObserver(Observer):
             results_updater=self.update_valedictorian,
         )
 
-    @staticmethod
-    def choose_valedictorian(df):
-        valedictorian = RNG.choice(df["student_id"])
+    def choose_valedictorian(self, df):
+        eligible_students = df.loc[~df["student_id"].isin(self.valedictorians), "student_id"]
+        valedictorian = RNG.choice(eligible_students)
+        self.valedictorians.append(valedictorian)
         return df[df["student_id"] == valedictorian]
 
     @staticmethod

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -244,15 +244,15 @@ def test_unhashable_pipeline(mocker):
     assert len(interface._manager._results_context.observations) == 0
     with pytest.raises(TypeError, match="unhashable"):
         interface.register_adding_observation(
-            "living_person_time",
-            'alive == "alive" and undead == False',
-            [],
-            _silly_aggregator,
-            [],
-            [["bad", "unhashable", "thing"]],  # unhashable first element
-            [],
-            [],
-            "collect_metrics",
+            name="living_person_time",
+            pop_filter='alive == "alive" and undead == False',
+            when="collect_metrics",
+            requires_columns=[],
+            requires_values=[["bad", "unhashable", "thing"]],  # unhashable first element
+            additional_stratifications=[],
+            excluded_stratifications=[],
+            aggregator_sources=[],
+            aggregator=_silly_aggregator,
         )
 
 

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -94,7 +94,7 @@ def test_register_unstratified_observation(mocker):
         requires_columns=["some-column", "some-other-column"],
         requires_values=["some-value", "some-other-value"],
         results_gatherer=lambda _: pd.DataFrame(),
-        results_formatter=lambda _, __: pd.DataFrame(),
+        results_updater=lambda _, __: pd.DataFrame(),
     )
     observations = interface._manager._results_context.observations
     assert len(observations) == 1

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -19,7 +19,7 @@ from tests.framework.results.helpers import (
     POWER_LEVEL_GROUP_LABELS,
     SOURCES,
     STUDENT_HOUSES,
-    CatLivesObserver,
+    CatBombObserver,
     ExamScoreObserver,
     FullyFilteredHousePointsObserver,
     Hogwarts,
@@ -450,18 +450,21 @@ def test_unused_stratifications_are_logged(caplog):
 def test_stratified_observation_results():
     components = [
         Hogwarts(),
-        CatLivesObserver(),
+        CatBombObserver(),
         HogwartsResultsStratifier(),
     ]
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
-    assert (sim.get_results()["cat_lives"]["value"] == 0.0).all()
+    assert (sim.get_results()["cat_bomb"]["value"] == 0.0).all()
     sim.step()
     num_familiars = sim.get_population().groupby(["familiar", "student_house"]).apply(len)
-    expected = num_familiars.loc["cat"] * 9.0
+    expected = num_familiars.loc["cat"] ** 1.0
     expected.name = "value"
-    assert expected.sort_values().equals(
-        sim.get_results()["cat_lives"]["value"].sort_values()
-    )
+    assert expected.sort_values().equals(sim.get_results()["cat_bomb"]["value"].sort_values())
+    sim.step()
+    num_familiars = sim.get_population().groupby(["familiar", "student_house"]).apply(len)
+    expected = num_familiars.loc["cat"] ** 2.0
+    expected.name = "value"
+    assert expected.sort_values().equals(sim.get_results()["cat_bomb"]["value"].sort_values())
 
 
 def test_unstratified_observation_results():


### PR DESCRIPTION
## Refactor observation registrations and other minor updates

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor, other
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This PR is a sort of follow-on to the previous one because that one was
already getting a bit bloated. The primary change here is that it consolidates
the context and manager observation registration functions into a single
one. Note that we have kept explicit `register_<type>_observation` functions
exposed in interface.

There are a few other minor updates as well stemming from other comments 
on the previous PR. 

Most unique changes are contained in specific commits.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
