### PR TITLE
Feature/sbachmei/remove stratified observer

### DIFF
--- a/src/vivarium/__init__.py
+++ b/src/vivarium/__init__.py
@@ -15,5 +15,5 @@ from vivarium._version import __version__
 from vivarium.component import Component
 from vivarium.framework.artifact import Artifact
 from vivarium.framework.configuration import build_model_specification
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer
 from vivarium.interface import InteractiveContext

--- a/src/vivarium/framework/results/__init__.py
+++ b/src/vivarium/framework/results/__init__.py
@@ -1,3 +1,3 @@
 from vivarium.framework.results.interface import ResultsInterface
 from vivarium.framework.results.manager import VALUE_COLUMN, ResultsManager
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Callable, Generator, List, Optional, Tuple, Union
+from typing import Callable, Generator, List, Optional, Tuple, Type, Union
 
 import pandas as pd
 from pandas.core.groupby import DataFrameGroupBy
 
 from vivarium.framework.engine import Builder
 from vivarium.framework.results.exceptions import ResultsConfigurationError
-from vivarium.framework.results.observation import (
-    AddingObservation,
-    ConcatenatingObservation,
-    StratifiedObservation,
-    UnstratifiedObservation,
-)
+from vivarium.framework.results.observation import BaseObservation
 from vivarium.framework.results.stratification import Stratification
 
 
@@ -100,93 +95,15 @@ class ResultsContext:
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
         self.stratifications.append(stratification)
 
-    def register_stratified_observation(
+    def register_observation(
         self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
+        observation_type: Type[BaseObservation],
+        **kwargs,
     ) -> None:
-        stratifications = self._get_stratifications(
-            additional_stratifications, excluded_stratifications
-        )
-        observation = StratifiedObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-            stratifications=stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
-        )
-        self.observations[when][(pop_filter, stratifications)].append(observation)
-
-    def register_unstratified_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        results_gatherer: Callable[[pd.DataFrame], pd.DataFrame],
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        observation = UnstratifiedObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_gatherer=results_gatherer,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-        )
-        self.observations[when][(pop_filter, None)].append(observation)
-
-    def register_adding_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
-    ) -> None:
-        stratifications = self._get_stratifications(
-            additional_stratifications, excluded_stratifications
-        )
-        observation = AddingObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_formatter=results_formatter,
-            stratifications=stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
-        )
-        self.observations[when][(pop_filter, stratifications)].append(observation)
-
-    def register_concatenating_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        included_columns: List[str],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        observation = ConcatenatingObservation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            included_columns=included_columns,
-            results_formatter=results_formatter,
-        )
-        self.observations[when][(pop_filter, None)].append(observation)
+        observation = observation_type(**kwargs)
+        self.observations[observation.when][
+            (observation.pop_filter, observation.stratifications)
+        ].append(observation)
 
     def gather_results(
         self, population: pd.DataFrame, event_name: str
@@ -222,18 +139,6 @@ class ResultsContext:
                     for observation in observations:
                         aggregates = observation.results_gatherer(pop_groups, stratifications)
                         yield aggregates, observation.name, observation.results_updater
-
-    def _get_stratifications(
-        self,
-        additional_stratifications: List[str] = [],
-        excluded_stratifications: List[str] = [],
-    ) -> Tuple[str, ...]:
-        stratifications = list(
-            set(self.default_stratifications) - set(excluded_stratifications)
-            | set(additional_stratifications)
-        )
-        # Makes sure measure identifiers have fields in the same relative order.
-        return tuple(sorted(stratifications))
 
     @staticmethod
     def _filter_population(population: pd.DataFrame, pop_filter: str) -> pd.DataFrame:

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -1,26 +1,18 @@
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 
 import pandas as pd
 
+from vivarium.framework.results.observation import (
+    StratifiedObservation,
+    UnstratifiedObservation,
+)
+
 if TYPE_CHECKING:
     # cyclic import
     from vivarium.framework.results.manager import ResultsManager
-
-
-def _raise_missing_unstratified_observation_results_gatherer(*args, **kwargs) -> pd.DataFrame:
-    raise RuntimeError(
-        "An UnstratifiedObservation has been registered without a `results_gatherer` "
-        "Callable which is required."
-    )
-
-
-def _raise_missing_unstratified_observation_results_updater(*args, **kwargs) -> pd.DataFrame:
-    raise RuntimeError(
-        "An UnstratifiedObservation has been registered without a `results_updater` "
-        "Callable which is required."
-    )
 
 
 def _raise_missing_stratified_observation_results_updater(*args, **kwargs) -> pd.DataFrame:
@@ -168,9 +160,9 @@ class ResultsInterface:
         when: str = "collect_metrics",
         requires_columns: List[str] = [],
         requires_values: List[str] = [],
-        results_updater: Callable[
-            [pd.DataFrame, pd.DataFrame], pd.DataFrame
-        ] = _raise_missing_stratified_observation_results_updater,
+        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame] = partial(
+            StratifiedObservation._raise_missing, "results_updater"
+        ),
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,
@@ -236,12 +228,12 @@ class ResultsInterface:
         when: str = "collect_metrics",
         requires_columns: List[str] = [],
         requires_values: List[str] = [],
-        results_gatherer: Callable[
-            [pd.DataFrame], pd.DataFrame
-        ] = _raise_missing_unstratified_observation_results_gatherer,
-        results_updater: Callable[
-            [pd.DataFrame, pd.DataFrame], pd.DataFrame
-        ] = _raise_missing_unstratified_observation_results_updater,
+        results_gatherer: Callable[[pd.DataFrame], pd.DataFrame] = partial(
+            UnstratifiedObservation._raise_missing, "results_gatherer"
+        ),
+        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame] = partial(
+            UnstratifiedObservation._raise_missing, "results_updater"
+        ),
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
         ] = lambda measure, results: results,

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Union
 import pandas as pd
 
 from vivarium.framework.results.observation import (
+    AddingObservation,
+    ConcatenatingObservation,
     StratifiedObservation,
     UnstratifiedObservation,
 )
@@ -13,13 +15,6 @@ from vivarium.framework.results.observation import (
 if TYPE_CHECKING:
     # cyclic import
     from vivarium.framework.results.manager import ResultsManager
-
-
-def _raise_missing_stratified_observation_results_updater(*args, **kwargs) -> pd.DataFrame:
-    raise RuntimeError(
-        "A StratifiedObservation has been registered without a `results_updater` "
-        "Callable which is required."
-    )
 
 
 class ResultsInterface:
@@ -207,7 +202,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_stratified_observation(
+        self._manager.register_observation(
+            observation_type=StratifiedObservation,
+            is_stratified=True,
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -276,7 +273,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_unstratified_observation(
+        self._manager.register_observation(
+            observation_type=UnstratifiedObservation,
+            is_stratified=False,
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -335,7 +334,10 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_adding_observation(
+
+        self._manager.register_observation(
+            observation_type=AddingObservation,
+            is_stratified=True,
             name=name,
             pop_filter=pop_filter,
             when=when,
@@ -382,7 +384,9 @@ class ResultsInterface:
         ------
         None
         """
-        self._manager.register_concatenating_observation(
+        self._manager.register_observation(
+            observation_type=ConcatenatingObservation,
+            is_stratified=False,
             name=name,
             pop_filter=pop_filter,
             when=when,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -277,7 +277,7 @@ class ResultsManager(Manager):
         **kwargs,
     ):
         self.logger.debug(f"Registering observation {kwargs['name']}")
-        # Are we stratified or not?
+
         if is_stratified:
             additional_stratifications = kwargs.get("additional_stratifications", [])
             excluded_stratifications = kwargs.get("excluded_stratifications", [])

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -10,6 +10,7 @@ from pandas.api.types import CategoricalDtype
 
 from vivarium.framework.event import Event
 from vivarium.framework.results.context import ResultsContext
+from vivarium.framework.results.observation import ConcatenatingObservation
 from vivarium.framework.results.stratification import Stratification
 from vivarium.framework.values import Pipeline
 from vivarium.manager import Manager
@@ -269,114 +270,64 @@ class ResultsManager(Manager):
             **target_kwargs,
         )
 
-    #######################
-    # Observation methods #
-    #######################
-
-    def register_stratified_observation(
+    def register_observation(
         self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
-        self._results_context.register_stratified_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-            additional_stratifications=additional_stratifications,
-            excluded_stratifications=excluded_stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
-        )
+        observation_type,
+        is_stratified: bool,
+        **kwargs,
+    ):
+        self.logger.debug(f"Registering observation {kwargs['name']}")
+        # Are we stratified or not?
+        if is_stratified:
+            additional_stratifications = kwargs.get("additional_stratifications", [])
+            excluded_stratifications = kwargs.get("excluded_stratifications", [])
+            self._warn_check_stratifications(
+                additional_stratifications, excluded_stratifications
+            )
+            stratifications = self._get_stratifications(
+                kwargs.get("stratifications", []),
+                additional_stratifications,
+                excluded_stratifications,
+            )
+            kwargs["stratifications"] = stratifications
+            del kwargs["additional_stratifications"]
+            del kwargs["excluded_stratifications"]
+
+        requires_columns = kwargs.get("requires_columns", [])
+        requires_values = kwargs.get("requires_values", [])
         self._add_resources(requires_columns, SourceType.COLUMN)
         self._add_resources(requires_values, SourceType.VALUE)
+        del kwargs["requires_columns"]
+        del kwargs["requires_values"]
 
-    def register_unstratified_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_gatherer: Callable[[pd.DataFrame], pd.DataFrame],
-        results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._results_context.register_unstratified_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_gatherer=results_gatherer,
-            results_updater=results_updater,
-            results_formatter=results_formatter,
-        )
-        self._add_resources(["event_time"] + requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
+        if observation_type == ConcatenatingObservation:
+            kwargs["included_columns"] = ["event_time"] + requires_columns + requires_values
 
-    def register_adding_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-        additional_stratifications: List[str],
-        excluded_stratifications: List[str],
-        aggregator_sources: Optional[List[str]],
-        aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._warn_check_stratifications(additional_stratifications, excluded_stratifications)
-        self._results_context.register_adding_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            results_formatter=results_formatter,
-            additional_stratifications=additional_stratifications,
-            excluded_stratifications=excluded_stratifications,
-            aggregator_sources=aggregator_sources,
-            aggregator=aggregator,
+        self._results_context.register_observation(
+            observation_type=observation_type,
+            **kwargs,
         )
-        self._add_resources(requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
-
-    def register_concatenating_observation(
-        self,
-        name: str,
-        pop_filter: str,
-        when: str,
-        requires_columns: List[str],
-        requires_values: List[str],
-        results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
-    ) -> None:
-        self.logger.debug(f"Registering observation {name}")
-        self._results_context.register_concatenating_observation(
-            name=name,
-            pop_filter=pop_filter,
-            when=when,
-            included_columns=["event_time"] + requires_columns + requires_values,
-            results_formatter=results_formatter,
-        )
-        self._add_resources(["event_time"] + requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
 
     ##################
     # Helper methods #
     ##################
+
+    def _get_stratifications(
+        self,
+        stratifications: List[str] = [],
+        additional_stratifications: List[str] = [],
+        excluded_stratifications: List[str] = [],
+    ) -> Tuple[str, ...]:
+        stratifications = list(
+            set(
+                self._results_context.default_stratifications
+                + stratifications
+                + additional_stratifications
+            )
+            - set(excluded_stratifications)
+        )
+        # Makes sure measure identifiers have fields in the same relative order.
+        return tuple(sorted(stratifications))
 
     @staticmethod
     def _initialize_stratified_results(

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -64,6 +64,10 @@ class UnstratifiedObservation(BaseObservation):
             results_formatter=results_formatter,
         )
 
+    @property
+    def stratifications(self) -> None:
+        return None
+
 
 class StratifiedObservation(BaseObservation):
     """Container class for managing stratified observations.

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -27,6 +27,13 @@ class BaseObservation(ABC):
     results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame]
     results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame]
 
+    @classmethod
+    def _raise_missing(cls, missing_arg: str, *args, **kwargs) -> pd.DataFrame:
+        raise ValueError(
+            f"A/an {cls.__name__} has been registered without a '{missing_arg}' "
+            "Callable which is required for this observation type."
+        )
+
 
 class UnstratifiedObservation(BaseObservation):
     """Container class for managing unstratified observations.

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -17,6 +17,17 @@ class Observer(Component, ABC):
         super().__init__()
         self.results_dir = None
 
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        return {
+            "stratification": {
+                self.name.split("_observer")[0]: {
+                    "exclude": [],
+                    "include": [],
+                },
+            },
+        }
+
     @abstractmethod
     def register_observations(self, builder: Builder) -> None:
         """(Required). Register observations with within each observer."""
@@ -34,17 +45,3 @@ class Observer(Component, ABC):
             .get("output_data", {})
             .get("results_directory", None)
         )
-
-
-# TODO: Move this property into Observer and get rid of StratifiedObserver
-class StratifiedObserver(Observer):
-    @property
-    def configuration_defaults(self) -> Dict[str, Any]:
-        return {
-            "stratification": {
-                self.name.split("_observer")[0]: {
-                    "exclude": [],
-                    "include": [],
-                },
-            },
-        }

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -36,6 +36,7 @@ class Observer(Component, ABC):
         )
 
 
+# TODO: Move this property into Observer and get rid of StratifiedObserver
 class StratifiedObserver(Observer):
     @property
     def configuration_defaults(self) -> Dict[str, Any]:

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -286,11 +286,17 @@ def test_component_manager_add_components_duplicated(components):
     config = build_simulation_configuration()
     cm = ComponentManager()
     cm.configuration = config
-    with pytest.raises(ComponentConfigError, match="duplicate name"):
+    with pytest.raises(
+        ComponentConfigError,
+        match=f"Attempting to add a component with duplicate name: {MockComponentA()}",
+    ):
         cm.add_managers(components)
 
     config = build_simulation_configuration()
     cm = ComponentManager()
     cm.configuration = config
-    with pytest.raises(ComponentConfigError, match="duplicate name"):
+    with pytest.raises(
+        ComponentConfigError,
+        match=f"Attempting to add a component with duplicate name: {MockComponentA()}",
+    ):
         cm.add_components(components)

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -8,7 +8,7 @@ from vivarium.framework.components.manager import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
 from vivarium.framework.results import VALUE_COLUMN
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer
 
 NAME = "hogwarts_house"
 SOURCES = ["first_name", "last_name"]
@@ -108,7 +108,7 @@ class Hogwarts(Component):
         self.population_view.update(update)
 
 
-class HousePointsObserver(StratifiedObserver):
+class HousePointsObserver(Observer):
     """Observer that is stratified by multiple columns (the defaults,
     'student_house' and 'power_level_group')
     """
@@ -125,7 +125,7 @@ class HousePointsObserver(StratifiedObserver):
         )
 
 
-class FullyFilteredHousePointsObserver(StratifiedObserver):
+class FullyFilteredHousePointsObserver(Observer):
     """Same as `HousePointsObserver but with a filter that leaves no simulants"""
 
     def register_observations(self, builder: Builder) -> None:
@@ -140,7 +140,7 @@ class FullyFilteredHousePointsObserver(StratifiedObserver):
         )
 
 
-class QuidditchWinsObserver(StratifiedObserver):
+class QuidditchWinsObserver(Observer):
     """Observer that is stratified by a single column ('familiar')"""
 
     def register_observations(self, builder: Builder) -> None:
@@ -157,7 +157,7 @@ class QuidditchWinsObserver(StratifiedObserver):
         )
 
 
-class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
+class NoStratificationsQuidditchWinsObserver(Observer):
     """Same as above but no stratifications at all"""
 
     def register_observations(self, builder: Builder) -> None:
@@ -173,7 +173,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
         )
 
 
-class MagicalAttributesObserver(StratifiedObserver):
+class MagicalAttributesObserver(Observer):
     """Observer whose aggregator returns a pd.Series instead of a float (which in
     turn results in a dataframe with multiple columns instead of just one
     'value' column)
@@ -202,7 +202,7 @@ class ExamScoreObserver(Observer):
         )
 
 
-class CatBombObserver(StratifiedObserver):
+class CatBombObserver(Observer):
     """Observer that counts the number of feral cats per house"""
 
     def register_observations(self, builder: Builder) -> None:

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -202,22 +202,27 @@ class ExamScoreObserver(Observer):
         )
 
 
-class CatLivesObserver(StratifiedObserver):
-    """Observer that counts the number of cat lives per house"""
+class CatBombObserver(StratifiedObserver):
+    """Observer that counts the number of feral cats per house"""
 
     def register_observations(self, builder: Builder) -> None:
-        builder.results.register_adding_observation(
-            name="cat_lives",
+        builder.results.register_stratified_observation(
+            name="cat_bomb",
             pop_filter="familiar=='cat' and tracked==True",
             requires_columns=["familiar"],
+            results_updater=self.update_cats,
             excluded_stratifications=["power_level_group"],
             aggregator_sources=["student_house"],
-            aggregator=self.count_lives,
+            aggregator=len,
         )
 
     @staticmethod
-    def count_lives(group):
-        return len(group) * 9
+    def update_cats(existing_df, new_df):
+        no_cats_mask = existing_df["value"] == 0
+        updated_df = existing_df
+        updated_df.loc[no_cats_mask, "value"] = new_df["value"]
+        updated_df.loc[~no_cats_mask, "value"] *= new_df["value"]
+        return updated_df
 
 
 class ValedictorianObserver(Observer):

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -227,8 +227,12 @@ class CatBombObserver(StratifiedObserver):
 
 class ValedictorianObserver(Observer):
     """Observer that records the valedictorian at each time step. All students
-    have the same exam scores and so the valecdictorian is chosen randomly.
+    have the same exam scores and so the valedictorian is chosen randomly.
     """
+
+    def __init__(self):
+        super().__init__()
+        self.valedictorians = []
 
     def register_observations(self, builder: Builder) -> None:
         builder.results.register_unstratified_observation(
@@ -238,9 +242,10 @@ class ValedictorianObserver(Observer):
             results_updater=self.update_valedictorian,
         )
 
-    @staticmethod
-    def choose_valedictorian(df):
-        valedictorian = RNG.choice(df["student_id"])
+    def choose_valedictorian(self, df):
+        eligible_students = df.loc[~df["student_id"].isin(self.valedictorians), "student_id"]
+        valedictorian = RNG.choice(eligible_students)
+        self.valedictorians.append(valedictorian)
         return df[df["student_id"] == valedictorian]
 
     @staticmethod

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -244,15 +244,15 @@ def test_unhashable_pipeline(mocker):
     assert len(interface._manager._results_context.observations) == 0
     with pytest.raises(TypeError, match="unhashable"):
         interface.register_adding_observation(
-            "living_person_time",
-            'alive == "alive" and undead == False',
-            [],
-            _silly_aggregator,
-            [],
-            [["bad", "unhashable", "thing"]],  # unhashable first element
-            [],
-            [],
-            "collect_metrics",
+            name="living_person_time",
+            pop_filter='alive == "alive" and undead == False',
+            when="collect_metrics",
+            requires_columns=[],
+            requires_values=[["bad", "unhashable", "thing"]],  # unhashable first element
+            additional_stratifications=[],
+            excluded_stratifications=[],
+            aggregator_sources=[],
+            aggregator=_silly_aggregator,
         )
 
 

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -19,7 +19,7 @@ from tests.framework.results.helpers import (
     POWER_LEVEL_GROUP_LABELS,
     SOURCES,
     STUDENT_HOUSES,
-    CatLivesObserver,
+    CatBombObserver,
     ExamScoreObserver,
     FullyFilteredHousePointsObserver,
     Hogwarts,
@@ -450,18 +450,21 @@ def test_unused_stratifications_are_logged(caplog):
 def test_stratified_observation_results():
     components = [
         Hogwarts(),
-        CatLivesObserver(),
+        CatBombObserver(),
         HogwartsResultsStratifier(),
     ]
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
-    assert (sim.get_results()["cat_lives"]["value"] == 0.0).all()
+    assert (sim.get_results()["cat_bomb"]["value"] == 0.0).all()
     sim.step()
     num_familiars = sim.get_population().groupby(["familiar", "student_house"]).apply(len)
-    expected = num_familiars.loc["cat"] * 9.0
+    expected = num_familiars.loc["cat"] ** 1.0
     expected.name = "value"
-    assert expected.sort_values().equals(
-        sim.get_results()["cat_lives"]["value"].sort_values()
-    )
+    assert expected.sort_values().equals(sim.get_results()["cat_bomb"]["value"].sort_values())
+    sim.step()
+    num_familiars = sim.get_population().groupby(["familiar", "student_house"]).apply(len)
+    expected = num_familiars.loc["cat"] ** 2.0
+    expected.name = "value"
+    assert expected.sort_values().equals(sim.get_results()["cat_bomb"]["value"].sort_values())
 
 
 def test_unstratified_observation_results():

--- a/tests/framework/results/test_observer.py
+++ b/tests/framework/results/test_observer.py
@@ -1,7 +1,7 @@
 import pytest
 from layered_config_tree import LayeredConfigTree
 
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer
 
 
 class TestObserver(Observer):
@@ -9,12 +9,12 @@ class TestObserver(Observer):
         pass
 
 
-class TestDefaultStratifiedObserver(StratifiedObserver):
+class TestDefaultObserverStratifications(Observer):
     def register_observations(self, builder):
         pass
 
 
-class TestStratifiedObserver(StratifiedObserver):
+class TestObserverStratifications(Observer):
     def register_observations(self, builder):
         pass
 
@@ -50,20 +50,3 @@ def test_get_formatter_attributes(is_interactive, results_dir, mocker):
     observer.get_formatter_attributes(builder)
 
     assert observer.results_dir == results_dir
-
-
-@pytest.mark.parametrize(
-    "observer, name, expected_configuration_defaults",
-    [
-        (
-            TestDefaultStratifiedObserver(),
-            "test_default_stratified_observer",
-            {"stratification": {"test_default_stratified": {"exclude": [], "include": []}}},
-        ),
-        (TestStratifiedObserver(), "test_stratified_observer", {"foo": "bar"}),
-    ],
-)
-def test_stratified_observer_instantiation(observer, name, expected_configuration_defaults):
-    obs = observer
-    assert obs.name == name
-    assert obs.configuration_defaults == expected_configuration_defaults

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,17 +2,20 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from vivarium import Component, Observer, StratifiedObserver
+from vivarium import Component, Observer
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
-from vivarium.framework.results import VALUE_COLUMN
 
 
 class MockComponentA(Observer):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def configuration_defaults(self):
+        return {}
 
     def __init__(self, *args, name="mock_component_a"):
         super().__init__()
@@ -30,7 +33,7 @@ class MockComponentA(Observer):
         return type(self) == type(other) and self.name == other.name
 
 
-class MockComponentB(StratifiedObserver):
+class MockComponentB(Observer):
     @property
     def name(self) -> str:
         return self._name


### PR DESCRIPTION
## Remove StratifiedObserver

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We weren't gaining much by having StratifiedObserver and it just seemed
weird to have that when we already have a stratified vs unstratified concept
built into the different observation types.

The weird thing here, though, is now that non-stratified Observers have this
configuration default "stratifications" floating around that just aren't being used.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass. 
