### PR TITLE
remove StratifiedObserver

### DIFF
--- a/src/vivarium/__init__.py
+++ b/src/vivarium/__init__.py
@@ -15,5 +15,5 @@ from vivarium._version import __version__
 from vivarium.component import Component
 from vivarium.framework.artifact import Artifact
 from vivarium.framework.configuration import build_model_specification
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer
 from vivarium.interface import InteractiveContext

--- a/src/vivarium/framework/results/__init__.py
+++ b/src/vivarium/framework/results/__init__.py
@@ -1,3 +1,3 @@
 from vivarium.framework.results.interface import ResultsInterface
 from vivarium.framework.results.manager import VALUE_COLUMN, ResultsManager
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -17,6 +17,17 @@ class Observer(Component, ABC):
         super().__init__()
         self.results_dir = None
 
+    @property
+    def configuration_defaults(self) -> Dict[str, Any]:
+        return {
+            "stratification": {
+                self.name.split("_observer")[0]: {
+                    "exclude": [],
+                    "include": [],
+                },
+            },
+        }
+
     @abstractmethod
     def register_observations(self, builder: Builder) -> None:
         """(Required). Register observations with within each observer."""
@@ -34,16 +45,3 @@ class Observer(Component, ABC):
             .get("output_data", {})
             .get("results_directory", None)
         )
-
-
-class StratifiedObserver(Observer):
-    @property
-    def configuration_defaults(self) -> Dict[str, Any]:
-        return {
-            "stratification": {
-                self.name.split("_observer")[0]: {
-                    "exclude": [],
-                    "include": [],
-                },
-            },
-        }

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -286,11 +286,17 @@ def test_component_manager_add_components_duplicated(components):
     config = build_simulation_configuration()
     cm = ComponentManager()
     cm.configuration = config
-    with pytest.raises(ComponentConfigError, match="duplicate name"):
+    with pytest.raises(
+        ComponentConfigError,
+        match=f"Attempting to add a component with duplicate name: {MockComponentA()}",
+    ):
         cm.add_managers(components)
 
     config = build_simulation_configuration()
     cm = ComponentManager()
     cm.configuration = config
-    with pytest.raises(ComponentConfigError, match="duplicate name"):
+    with pytest.raises(
+        ComponentConfigError,
+        match=f"Attempting to add a component with duplicate name: {MockComponentA()}",
+    ):
         cm.add_components(components)

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -8,7 +8,7 @@ from vivarium.framework.components.manager import Component
 from vivarium.framework.engine import Builder
 from vivarium.framework.population import SimulantData
 from vivarium.framework.results import VALUE_COLUMN
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer
 
 NAME = "hogwarts_house"
 SOURCES = ["first_name", "last_name"]
@@ -108,7 +108,7 @@ class Hogwarts(Component):
         self.population_view.update(update)
 
 
-class HousePointsObserver(StratifiedObserver):
+class HousePointsObserver(Observer):
     """Observer that is stratified by multiple columns (the defaults,
     'student_house' and 'power_level_group')
     """
@@ -125,7 +125,7 @@ class HousePointsObserver(StratifiedObserver):
         )
 
 
-class FullyFilteredHousePointsObserver(StratifiedObserver):
+class FullyFilteredHousePointsObserver(Observer):
     """Same as `HousePointsObserver but with a filter that leaves no simulants"""
 
     def register_observations(self, builder: Builder) -> None:
@@ -140,7 +140,7 @@ class FullyFilteredHousePointsObserver(StratifiedObserver):
         )
 
 
-class QuidditchWinsObserver(StratifiedObserver):
+class QuidditchWinsObserver(Observer):
     """Observer that is stratified by a single column ('familiar')"""
 
     def register_observations(self, builder: Builder) -> None:
@@ -157,7 +157,7 @@ class QuidditchWinsObserver(StratifiedObserver):
         )
 
 
-class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
+class NoStratificationsQuidditchWinsObserver(Observer):
     """Same as above but no stratifications at all"""
 
     def register_observations(self, builder: Builder) -> None:
@@ -173,7 +173,7 @@ class NoStratificationsQuidditchWinsObserver(StratifiedObserver):
         )
 
 
-class MagicalAttributesObserver(StratifiedObserver):
+class MagicalAttributesObserver(Observer):
     """Observer whose aggregator returns a pd.Series instead of a float (which in
     turn results in a dataframe with multiple columns instead of just one
     'value' column)
@@ -202,8 +202,8 @@ class ExamScoreObserver(Observer):
         )
 
 
-class CatLivesObserver(StratifiedObserver):
-    """Observer that counts the number of cat lives per house"""
+class CatLivesObserver(Observer):
+    """Observer that counts the number of feral cats per house"""
 
     def register_observations(self, builder: Builder) -> None:
         builder.results.register_adding_observation(

--- a/tests/framework/results/test_observer.py
+++ b/tests/framework/results/test_observer.py
@@ -1,7 +1,7 @@
 import pytest
 from layered_config_tree import LayeredConfigTree
 
-from vivarium.framework.results.observer import Observer, StratifiedObserver
+from vivarium.framework.results.observer import Observer
 
 
 class TestObserver(Observer):
@@ -9,12 +9,12 @@ class TestObserver(Observer):
         pass
 
 
-class TestDefaultStratifiedObserver(StratifiedObserver):
+class TestDefaultObserverStratifications(Observer):
     def register_observations(self, builder):
         pass
 
 
-class TestStratifiedObserver(StratifiedObserver):
+class TestObserverStratifications(Observer):
     def register_observations(self, builder):
         pass
 
@@ -50,20 +50,3 @@ def test_get_formatter_attributes(is_interactive, results_dir, mocker):
     observer.get_formatter_attributes(builder)
 
     assert observer.results_dir == results_dir
-
-
-@pytest.mark.parametrize(
-    "observer, name, expected_configuration_defaults",
-    [
-        (
-            TestDefaultStratifiedObserver(),
-            "test_default_stratified_observer",
-            {"stratification": {"test_default_stratified": {"exclude": [], "include": []}}},
-        ),
-        (TestStratifiedObserver(), "test_stratified_observer", {"foo": "bar"}),
-    ],
-)
-def test_stratified_observer_instantiation(observer, name, expected_configuration_defaults):
-    obs = observer
-    assert obs.name == name
-    assert obs.configuration_defaults == expected_configuration_defaults

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,17 +2,20 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from vivarium import Component, Observer, StratifiedObserver
+from vivarium import Component, Observer
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.population import SimulantData
-from vivarium.framework.results import VALUE_COLUMN
 
 
 class MockComponentA(Observer):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def configuration_defaults(self):
+        return {}
 
     def __init__(self, *args, name="mock_component_a"):
         super().__init__()
@@ -30,7 +33,7 @@ class MockComponentA(Observer):
         return type(self) == type(other) and self.name == other.name
 
 
-class MockComponentB(StratifiedObserver):
+class MockComponentB(Observer):
     @property
     def name(self) -> str:
         return self._name


### PR DESCRIPTION
## Remove StratifiedObserver

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We weren't gaining much by having StratifiedObserver and it just seemed
weird to have that when we already have a stratified vs unstratified concept
built into the different observation types.

The weird thing here, though, is now that non-stratified Observers have this
configuration default "stratifications" floating around that just aren't being used.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass. 
