### PR TITLE
move results initialization to Observation attributes

### DIFF
--- a/src/vivarium/framework/results/__init__.py
+++ b/src/vivarium/framework/results/__init__.py
@@ -1,3 +1,4 @@
 from vivarium.framework.results.interface import ResultsInterface
-from vivarium.framework.results.manager import VALUE_COLUMN, ResultsManager
+from vivarium.framework.results.manager import ResultsManager
+from vivarium.framework.results.observation import VALUE_COLUMN
 from vivarium.framework.results.observer import Observer

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -293,31 +293,6 @@ class ResultsManager(Manager):
     # Helper methods #
     ##################
 
-    @staticmethod
-    def _track_stratifications(
-        measure: str,
-        event_requested_stratification_names: set[str],
-        registered_stratification_names: set[str],
-        missing_stratifications: Dict[str, set[str]],
-        used_stratifications: set[str],
-    ) -> set[str]:
-        """Track used and missing stratifications for batch-logging"""
-
-        # Update the `missing_stratifications`` dict for this particular measure/observer
-        # if there are any missing stratifications
-        observer_missing_stratifications = event_requested_stratification_names.difference(
-            registered_stratification_names
-        )
-        if observer_missing_stratifications:
-            missing_stratifications[measure] = observer_missing_stratifications
-
-        # Add newly used stratifications to the running `used_stratifications` list
-        used_stratifications = used_stratifications.union(
-            event_requested_stratification_names
-        )
-
-        return used_stratifications
-
     def _get_stratifications(
         self,
         stratifications: List[str] = [],

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -321,16 +321,17 @@ class ResultsManager(Manager):
         missing_stratifications: Dict[str, set[str]],
         used_stratifications: set[str],
     ) -> set[str]:
-        """Track unused and missing stratifications for batch-logging"""
+        """Track used and missing stratifications for batch-logging"""
 
-        # Batch missing stratifications
+        # Update the `missing_stratifications`` dict for this particular measure/observer
+        # if there are any missing stratifications
         observer_missing_stratifications = event_requested_stratification_names.difference(
             registered_stratification_names
         )
         if observer_missing_stratifications:
             missing_stratifications[measure] = observer_missing_stratifications
 
-        # Add newly used stratifications
+        # Add newly used stratifications to the running `used_stratifications` list
         used_stratifications = used_stratifications.union(
             event_requested_stratification_names
         )

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -79,30 +79,6 @@ class ResultsManager(Manager):
 
         self.set_default_stratifications(builder)
 
-    @staticmethod
-    def _track_stratifications(
-        measure: str,
-        event_requested_stratification_names: set[str],
-        registered_stratification_names: set[str],
-        missing_stratifications: Dict[str, set[str]],
-        unused_stratifications: set[str],
-    ) -> set[str]:
-        """Track stratifications for batch-logging"""
-
-        # Batch missing stratifications
-        observer_missing_stratifications = event_requested_stratification_names.difference(
-            registered_stratification_names
-        )
-        if observer_missing_stratifications:
-            missing_stratifications[measure] = observer_missing_stratifications
-
-        # Remove stratifications from the running list of unused stratifications
-        unused_stratifications = unused_stratifications.difference(
-            event_requested_stratification_names
-        )
-
-        return unused_stratifications
-
     def on_post_setup(self, _: Event) -> None:
         """Initialize results with 0s DataFrame' for each measure and all stratifications"""
         registered_stratifications = self._results_context.stratifications
@@ -334,6 +310,30 @@ class ResultsManager(Manager):
     ##################
     # Helper methods #
     ##################
+
+    @staticmethod
+    def _track_stratifications(
+        measure: str,
+        event_requested_stratification_names: set[str],
+        registered_stratification_names: set[str],
+        missing_stratifications: Dict[str, set[str]],
+        unused_stratifications: set[str],
+    ) -> set[str]:
+        """Track stratifications for batch-logging"""
+
+        # Batch missing stratifications
+        observer_missing_stratifications = event_requested_stratification_names.difference(
+            registered_stratification_names
+        )
+        if observer_missing_stratifications:
+            missing_stratifications[measure] = observer_missing_stratifications
+
+        # Remove stratifications from the running list of unused stratifications
+        unused_stratifications = unused_stratifications.difference(
+            event_requested_stratification_names
+        )
+
+        return unused_stratifications
 
     def _get_stratifications(
         self,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -1,25 +1,18 @@
 from __future__ import annotations
 
-import itertools
 from collections import defaultdict
 from enum import Enum
-from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
-from pandas.api.types import CategoricalDtype
 
 from vivarium.framework.event import Event
 from vivarium.framework.results.context import ResultsContext
-from vivarium.framework.results.observation import ConcatenatingObservation
-from vivarium.framework.results.stratification import Stratification
 from vivarium.framework.values import Pipeline
 from vivarium.manager import Manager
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
-
-
-VALUE_COLUMN = "value"
 
 
 class SourceType(Enum):
@@ -93,36 +86,38 @@ class ResultsManager(Manager):
             stratification.name for stratification in registered_stratifications
         )
 
+        # Initialize missing and unused stratification dictionaries for batch-logging
         missing_stratifications = {}
         unused_stratifications = registered_stratification_names.copy()
+
+        kwargs = {
+            "registered_stratifications": registered_stratifications,
+            "registered_stratification_names": registered_stratification_names,
+            "missing_stratifications": missing_stratifications,
+            "unused_stratifications": unused_stratifications,
+        }
 
         for event_name in self._results_context.observations:
             for (
                 _pop_filter,
-                all_requested_stratification_names,
+                requested_stratification_names,
             ), observations in self._results_context.observations[event_name].items():
                 for observation in observations:
                     measure = observation.name
-                    if all_requested_stratification_names is not None:
-                        df, unused_stratifications = self._initialize_stratified_results(
-                            measure,
-                            all_requested_stratification_names,
-                            registered_stratifications,
-                            registered_stratification_names,
-                            missing_stratifications,
-                            unused_stratifications,
-                        )
-                    else:
-                        # Initialize a completely empty dataframe
-                        df = pd.DataFrame()
+                    kwargs["requested_stratification_names"] = requested_stratification_names
+
+                    df, unused_stratifications = observation.results_initializer(
+                        measure, **kwargs
+                    )
+                    kwargs["unused_stratifications"] = unused_stratifications
                     self._raw_results[measure] = df
 
-        if unused_stratifications:
+        if len(unused_stratifications) > 0:
             self.logger.info(
                 "The following stratifications are registered but not used by any "
                 f"observers: \n{sorted(list(unused_stratifications))}"
             )
-        if missing_stratifications:
+        if len(missing_stratifications) > 0:
             # Sort by observer/measure and then by missing stratifiction
             sorted_missing = {
                 key: sorted(list(missing_stratifications[key]))
@@ -329,56 +324,6 @@ class ResultsManager(Manager):
         )
         # Makes sure measure identifiers have fields in the same relative order.
         return tuple(sorted(stratifications))
-
-    @staticmethod
-    def _initialize_stratified_results(
-        measure: str,
-        all_requested_stratification_names: List[str],
-        registered_stratifications: List[Stratification],
-        registered_stratification_names: Set[str],
-        missing_stratifications: Dict[str, Set[str]],
-        unused_stratifications: Set[str],
-    ) -> Tuple[pd.DataFrame, Set[str]]:
-        all_requested_stratification_names = set(all_requested_stratification_names)
-
-        # Batch missing stratifications
-        observer_missing_stratifications = all_requested_stratification_names.difference(
-            registered_stratification_names
-        )
-        if observer_missing_stratifications:
-            missing_stratifications[measure] = observer_missing_stratifications
-
-            # Remove stratifications from the running list of unused stratifications
-        unused_stratifications = unused_stratifications.difference(
-            all_requested_stratification_names
-        )
-
-        # Set up the complete index of all used stratifications
-        requested_and_registered_stratifications = [
-            stratification
-            for stratification in registered_stratifications
-            if stratification.name in all_requested_stratification_names
-        ]
-        stratification_values = {
-            stratification.name: stratification.categories
-            for stratification in requested_and_registered_stratifications
-        }
-        if stratification_values:
-            stratification_names = list(stratification_values.keys())
-            df = pd.DataFrame(
-                list(itertools.product(*stratification_values.values())),
-                columns=stratification_names,
-            ).astype(CategoricalDtype)
-        else:
-            # We are aggregating the entire population so create a single-row index
-            stratification_names = ["stratification"]
-            df = pd.DataFrame(["all"], columns=stratification_names).astype(CategoricalDtype)
-
-            # Initialize a zeros dataframe
-        df[VALUE_COLUMN] = 0.0
-        df = df.set_index(stratification_names)
-
-        return df, unused_stratifications
 
     def _add_resources(self, target: List[str], target_type: SourceType) -> None:
         if len(target) == 0:

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -102,10 +102,9 @@ class ResultsManager(Manager):
                 )
                 for observation in observations:
                     measure = observation.name
-                    df = observation.results_initializer(
+                    self._raw_results[measure] = observation.results_initializer(
                         event_requested_stratification_names, registered_stratifications
                     )
-                    self._raw_results[measure] = df
                     if observation.stratifications is not None:
                         used_stratifications = self._track_stratifications(
                             measure,

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -70,7 +70,7 @@ class UnstratifiedObservation(BaseObservation):
 
     @staticmethod
     def initialize_results(
-        requested_stratification_names: Tuple[str],
+        requested_stratification_names: set[str],
         registered_stratifications: List[Stratification],
     ) -> pd.DataFrame:
         """Initialize an empty dataframe."""
@@ -116,7 +116,7 @@ class StratifiedObservation(BaseObservation):
 
     @staticmethod
     def initialize_results(
-        requested_stratification_names: Tuple[str],
+        requested_stratification_names: set[str],
         registered_stratifications: List[Stratification],
     ) -> pd.DataFrame:
         """Initialize a dataframe of 0s with complete set of stratifications as the index."""

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import itertools
 from abc import ABC
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Set, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -69,11 +69,12 @@ class UnstratifiedObservation(BaseObservation):
         )
 
     @staticmethod
-    def initialize_results(measure: str, **_kwargs) -> Tuple[pd.DataFrame, Set[str]]:
-        """Initialize an empty dataframe and return it along with an empty set
-        of missing stratifications.
-        """
-        return pd.DataFrame(), set()
+    def initialize_results(
+        requested_stratification_names: set[str],
+        registered_stratifications: List[Stratification],
+    ) -> pd.DataFrame:
+        """Initialize an empty dataframe."""
+        return pd.DataFrame()
 
 
 class StratifiedObservation(BaseObservation):
@@ -115,29 +116,10 @@ class StratifiedObservation(BaseObservation):
 
     @staticmethod
     def initialize_results(
-        measure: str,
-        requested_stratification_names: List[str],
+        requested_stratification_names: set[str],
         registered_stratifications: List[Stratification],
-        registered_stratification_names: Set[str],
-        missing_stratifications: Dict[str, Set[str]],
-        unused_stratifications: Set[str],
-    ) -> Tuple[pd.DataFrame, Set[str]]:
-        """Initialize a dataframe of 0s with complete set of stratifications as the
-        index and return it along with any registered but unused stratifications
-        """
-        requested_stratification_names = set(requested_stratification_names)
-
-        # Batch missing stratifications
-        observer_missing_stratifications = requested_stratification_names.difference(
-            registered_stratification_names
-        )
-        if observer_missing_stratifications:
-            missing_stratifications[measure] = observer_missing_stratifications
-
-        # Remove stratifications from the running list of unused stratifications
-        unused_stratifications = unused_stratifications.difference(
-            requested_stratification_names
-        )
+    ) -> pd.DataFrame:
+        """Initialize a dataframe of 0s with complete set of stratifications as the index."""
 
         # Set up the complete index of all used stratifications
         requested_and_registered_stratifications = [
@@ -164,7 +146,7 @@ class StratifiedObservation(BaseObservation):
         df[VALUE_COLUMN] = 0.0
         df = df.set_index(stratification_names)
 
-        return df, unused_stratifications
+        return df
 
     def gather_results(
         self,

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -70,7 +70,7 @@ class UnstratifiedObservation(BaseObservation):
 
     @staticmethod
     def initialize_results(
-        requested_stratification_names: set[str],
+        requested_stratification_names: Tuple[str],
         registered_stratifications: List[Stratification],
     ) -> pd.DataFrame:
         """Initialize an empty dataframe."""
@@ -116,7 +116,7 @@ class StratifiedObservation(BaseObservation):
 
     @staticmethod
     def initialize_results(
-        requested_stratification_names: set[str],
+        requested_stratification_names: Tuple[str],
         registered_stratifications: List[Stratification],
     ) -> pd.DataFrame:
         """Initialize a dataframe of 0s with complete set of stratifications as the index."""

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -414,10 +414,7 @@ def test_observers_with_missing_stratifications_fail():
     """
     components = [QuidditchWinsObserver(), HousePointsObserver(), Hogwarts()]
 
-    expected_missing = {  # NOTE: keep in alphabetical order
-        "house_points": ["power_level_group", "student_house"],
-        "quidditch_wins": ["familiar"],
-    }
+    expected_missing = ["familiar", "power_level_group", "student_house"]
     expected_log_msg = re.escape(
         "The following observers are requested to be stratified by stratifications "
         f"that are not registered: \n{expected_missing}"

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -432,10 +432,18 @@ def test_unused_stratifications_are_logged(caplog):
     but never actually used by an Observer
 
     The HogwartsResultsStratifier registers "student_house", "familiar", and
-    "power_level" stratifiers. However, we will only use the HousePointsObserver
-    component which only requests to be stratified by "student_house" and "power_level"
+    "power_level_group" stratifiers. However, we will only use the QuidditchWinsObserver
+    which only uses "familiar" and the MagicalAttributesObserver which only uses
+    "power_level_group". We would thus expect only "student_house" to be logged
+    as an unused stratification.
+
     """
-    components = [HousePointsObserver(), Hogwarts(), HogwartsResultsStratifier()]
+    components = [
+        Hogwarts(),
+        HogwartsResultsStratifier(),
+        QuidditchWinsObserver(),
+        MagicalAttributesObserver(),
+    ]
     InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
 
     log_split = caplog.text.split(
@@ -444,7 +452,7 @@ def test_unused_stratifications_are_logged(caplog):
     # Check that the log message is present and only exists one time
     assert len(log_split) == 2
     # Check that the log message contains the expected Stratifications
-    assert "['familiar']" in log_split[1]
+    assert "['student_house']" in log_split[1]
 
 
 def test_stratified_observation_results():


### PR DESCRIPTION
## Create `results_initializer` attribute on Observations

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4297

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This is mostly a copy/paste job that moves the initialization of results
(0s dataframe for StratifiedObservations and an empty dataframe for
UnstratifedObservations) from the results manager to a new
`results_initializer` attribute.

The tricky part that remains very ugly but I can't think of a better way offhand
is how to handle batch-logging for missing and/or unused stratifications. As always,
I'm open to better ideas!

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
