### PR TITLE
Feature/sbachmei/mic 5127 update standard observers

### DIFF
--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -319,7 +319,7 @@ class ResultsInterface:
         requires_values: List[str] = [],
         results_formatter: Callable[
             [str, pd.DataFrame], pd.DataFrame
-        ] = lambda measure, results: results,
+        ] = lambda measure, results: results.reset_index(),
         additional_stratifications: List[str] = [],
         excluded_stratifications: List[str] = [],
         aggregator_sources: Optional[List[str]] = None,

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -136,11 +136,13 @@ class StratifiedObservation(BaseObservation):
             df = pd.DataFrame(
                 list(itertools.product(*stratification_values.values())),
                 columns=stratification_names,
-            ).astype(CategoricalDtype)
+            ).astype(CategoricalDtype())
         else:
             # We are aggregating the entire population so create a single-row index
             stratification_names = ["stratification"]
-            df = pd.DataFrame(["all"], columns=stratification_names).astype(CategoricalDtype)
+            df = pd.DataFrame(["all"], columns=stratification_names).astype(
+                CategoricalDtype()
+            )
 
         # Initialize a zeros dataframe
         df[VALUE_COLUMN] = 0.0
@@ -170,7 +172,7 @@ class StratifiedObservation(BaseObservation):
             pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)
             if aggregator_sources
             else pop_groups.apply(aggregator)
-        )
+        ).astype(float)
         return aggregates
 
     @staticmethod

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -21,12 +21,15 @@ class Observer(Component, ABC):
     def configuration_defaults(self) -> Dict[str, Any]:
         return {
             "stratification": {
-                self.name.split("_observer")[0]: {
+                self.get_configuration_name(): {
                     "exclude": [],
                     "include": [],
                 },
             },
         }
+
+    def get_configuration_name(self) -> str:
+        return self.name.split("_observer")[0]
 
     @abstractmethod
     def register_observations(self, builder: Builder) -> None:


### PR DESCRIPTION
## Minor changes required when updating mnch maternal observers

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5127

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

- reset the index in the default results_formatter to ensure that
the stratifications make it out to the written data
- specify .astype(float) to prevent warnings
- use instance of CategoricalDType to prevent warnings
- implement a `get_configuration_name` method for default_configurations

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass

