### PR TITLE
raise if PYTHONHASHSEED != 0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
+      - name: Set PYTHONHASHSEED
+        run: echo "PYTHONHASHSEED=0" >> $GITHUB_ENV
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -19,10 +19,11 @@ tools to easily setup and run a simulation.
 
 """
 
+import os
 from pathlib import Path
 from pprint import pformat
 from typing import Any, Dict, List, Set, Union
-import os
+
 import numpy as np
 import pandas as pd
 from layered_config_tree import LayeredConfigTree

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -22,7 +22,7 @@ tools to easily setup and run a simulation.
 from pathlib import Path
 from pprint import pformat
 from typing import Any, Dict, List, Set, Union
-
+import os
 import numpy as np
 import pandas as pd
 from layered_config_tree import LayeredConfigTree
@@ -104,6 +104,17 @@ class SimulationContext:
         sim_name: str = None,
         logging_verbosity: int = 1,
     ):
+
+        # PYTHONHASHSEED must be set outside the Python process. We don't want to
+        # be tricked if someone has modified it inside the Python process, since
+        # that will have no effect on the actual reproducibility of hashes.
+        if os.environ.get("PYTHONHASHSEED") != "0":
+            raise EnvironmentError(
+                "PYTHONHASHSEED must be set to 0 in the environment to ensure "
+                "reproducibility of hash-based operations."
+            )
+        assert os.environ.get("PYTHONHASHSEED") == "0"
+
         self._name = self._get_context_name(sim_name)
 
         # Bootstrap phase: Parse arguments, make private managers


### PR DESCRIPTION
## Bugfix: require users to set PYTHONHASHSEED to 0

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This was a bear. The short of it is that results may not be reproducible
due to randomized hashing of unordered objects (e.g. sets). This PR does two things.
1. Raises if the user hadn't set PYTHONHASHSEED to 0. This is now required.
2. Sorts all instances we can find of iterables with undefined sort order (e.g. sets)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

