### PR TITLE
Bugfix/sbachmei/mic 5138 enforce pythonhashseed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
+      - name: Set PYTHONHASHSEED
+        run: echo "PYTHONHASHSEED=42" >> $GITHUB_ENV
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -19,6 +19,7 @@ tools to easily setup and run a simulation.
 
 """
 
+import os
 from pathlib import Path
 from pprint import pformat
 from typing import Any, Dict, List, Set, Union
@@ -104,6 +105,18 @@ class SimulationContext:
         sim_name: str = None,
         logging_verbosity: int = 1,
     ):
+
+        # PYTHONHASHSEED must be set outside the Python process. We don't want to
+        # be tricked if someone has modified it inside the Python process, since
+        # that will have no effect on the actual reproducibility of hashes.
+        if os.environ.get("PYTHONHASHSEED") != "42":
+            raise EnvironmentError(
+                "PYTHONHASHSEED must be set to 42 in the environment to ensure "
+                "reproducibility of hash-based operations.\n"
+                "Please run 'export PYTHONHASHSEED=42' from the command line "
+                "(or add to your .bashrc) before running the simulation."
+            )
+
         self._name = self._get_context_name(sim_name)
 
         # Bootstrap phase: Parse arguments, make private managers


### PR DESCRIPTION
## Bugfix: require users to set PYTHONHASHSEED to 0

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This was a bear. The short of it is that results may not be reproducible
due to randomized hashing of unordered objects (e.g. sets). This PR raises 
if the user hadn't set PYTHONHASHSEED to 42.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
