### PR TITLE
raise when registering an observation name duplicate

### DIFF
--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -55,7 +55,7 @@ class ResultsManager(Manager):
 
         NOTE: self._results_context.observations is a list where each item is a dictionary
         of the form {event_name: {(pop_filter, stratifications): List[Observation]}}.
-        We use a triple-nested for loop to iterative over only the list of Observations
+        We use a triple-nested for loop to iterate over only the list of Observations
         (i.e. we do not need the event_name, pop_filter, or stratifications).
         """
         formatted = {}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,7 +51,7 @@ class MockComponentB(Observer):
         self.builder_used_for_setup = builder
 
     def register_observations(self, builder):
-        builder.results.register_adding_observation("test", aggregator=self.counter)
+        builder.results.register_adding_observation(self.name, aggregator=self.counter)
 
     def create_lookup_tables(self, builder):
         return {}


### PR DESCRIPTION
## Raise when duplicate observation name

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5048

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This PR prevents identically-named observations from being registered
since those observation names are eventually what the results file
is called. And by extension, we no longer allow completely duplicate
observations to be registered (which previously just overwrote each other
so that only one "version" was registered) 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
replaced  a duplicate observation test with a test that asserts
the raise triggers
