### PR TITLE
raise when stratification has duplicate categories

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -92,6 +92,13 @@ class ResultsContext:
             raise ValueError(
                 f"Stratification name '{name}' is already used: {str(already_used[0])}."
             )
+        unique_categories = set(categories)
+        if len(categories) != len(unique_categories):
+            for category in unique_categories:
+                categories.remove(category)
+            raise ValueError(
+                f"Found duplicate categories in stratification '{name}': {categories}."
+            )
         stratification = Stratification(name, sources, categories, mapper, is_vectorized)
         self.stratifications.append(stratification)
 

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+import re
 from datetime import timedelta
 
 import pandas as pd
@@ -22,6 +23,11 @@ from vivarium.framework.results.observation import (
     AddingObservation,
     ConcatenatingObservation,
 )
+
+
+def _aggregate_state_person_time(x: pd.DataFrame) -> float:
+    """Helper aggregator function for observation testing"""
+    return len(x) * (28 / 365.25)
 
 
 @pytest.mark.parametrize(
@@ -88,9 +94,17 @@ def test_add_stratifcation_duplicate_name_raises():
         ctx.add_stratification(NAME, [], [], None, False)
 
 
-def _aggregate_state_person_time(x: pd.DataFrame) -> float:
-    """Helper aggregator function for observation testing"""
-    return len(x) * (28 / 365.25)
+def test_add_stratification_duplicate_category_raises():
+    ctx = ResultsContext()
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            f"Found duplicate categories in stratification '{NAME}': ['slytherin']"
+        ),
+    ):
+        ctx.add_stratification(
+            NAME, SOURCES, CATEGORIES + ["slytherin"], sorting_hat_vector, True
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -94,16 +94,23 @@ def test_add_stratifcation_duplicate_name_raises():
         ctx.add_stratification(NAME, [], [], None, False)
 
 
-def test_add_stratification_duplicate_category_raises():
+@pytest.mark.parametrize(
+    "duplicates",
+    [
+        ["slytherin"],
+        ["gryffindor", "slytherin"],
+    ],
+)
+def test_add_stratification_duplicate_category_raises(duplicates):
     ctx = ResultsContext()
     with pytest.raises(
         ValueError,
         match=re.escape(
-            f"Found duplicate categories in stratification '{NAME}': ['slytherin']"
+            f"Found duplicate categories in stratification '{NAME}': {duplicates}"
         ),
     ):
         ctx.add_stratification(
-            NAME, SOURCES, CATEGORIES + ["slytherin"], sorting_hat_vector, True
+            NAME, SOURCES, CATEGORIES + duplicates, sorting_hat_vector, True
         )
 
 


### PR DESCRIPTION
## Raise when duplicate stratification categories
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-3475

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass
