### PR TITLE
call get_results just once at end of sim instead of twice

### DIFF
--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -274,9 +274,8 @@ class SimulationContext:
     def report(self, print_results: bool = True) -> None:
         self._lifecycle.set_state("report")
         self.report_emitter(self.get_population().index)
-
+        results = self.get_results()
         if print_results:
-            results = self.get_results()
             for measure, df in results.items():
                 self._logger.info(f"\n{measure}:\n{pformat(df)}")
             performance_metrics = self.get_performance_metrics()
@@ -285,15 +284,15 @@ class SimulationContext:
                 float_format=lambda x: f"{x:.2f}",
             )
             self._logger.info("\n" + performance_metrics)
-        self._write_results()
+        self._write_results(results)
 
-    def _write_results(self) -> None:
+    def _write_results(self, results: dict[str, pd.DataFrame]) -> None:
         """Iterate through the measures and write out the formatted results"""
         try:
             results_dir = self.configuration.output_data.results_directory
-            for measure, results in self.get_results().items():
+            for measure, df in results.items():
                 output_file = Path(results_dir) / f"{measure}.parquet"
-                results.to_parquet(output_file, index=False)
+                df.to_parquet(output_file, index=False)
         except ConfigurationKeyError:
             self._logger.info("No results directory set; results are not written to disk.")
 


### PR DESCRIPTION
## Call 'get_results' once

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This is a minor change that just calls
'get_results' once at the end of the sim instead of twice 
(once to save results and one to print them to terminal)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

