### PR TITLE
Add backup writing to vivarium simulation Context

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if __name__ == "__main__":
         "networkx",
         "loguru",
         "pyarrow",
+        "dill",
         # Type stubs
         "pandas-stubs",
     ]

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -253,7 +253,7 @@ class SimulationContext:
         self._clock.step_forward(self.get_population().index)
 
     def step(self) -> None:
-        self._logger.debug(self._clock.time)
+        self._logger.debug(self.current_time)
         for event in self.time_step_events:
             self._logger.debug(f"Event: {event}")
             self._lifecycle.set_state(event)
@@ -272,14 +272,14 @@ class SimulationContext:
     ) -> None:
         if backup_freq:
             time_to_save = time() + backup_freq
-            while self._clock.time < self._clock.stop_time:
+            while self.current_time < self._clock.stop_time:
                 self.step()
                 if time() >= time_to_save:
                     self._logger.debug(f"Writing Simulation Backup to {backup_path}")
                     self.write_backup(backup_path)
                     time_to_save = time() + backup_freq
         else:
-            while self._clock.time < self._clock.stop_time:
+            while self.current_time < self._clock.stop_time:
                 self.step()
 
     def finalize(self) -> None:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -318,7 +318,7 @@ class SimulationContext:
 
     def write_backup(self, backup_path: Path) -> None:
         with open(backup_path, "wb") as f:
-            dill.dump(self, f)
+            dill.dump(self, f, protocol=dill.HIGHEST_PROTOCOL)
 
     def get_performance_metrics(self) -> pd.DataFrame:
         timing_dict = self._lifecycle.timings

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -247,13 +247,13 @@ class SimulationContext:
         self._lifecycle.set_state("population_creation")
         pop_params = self.configuration.population
         # Fencepost the creation of the initial population.
-        self._clock.step_backward()
+        step_backward()
         population_size = pop_params.population_size
         self.simulant_creator(population_size, {"sim_state": "setup"})
         self._clock.step_forward(self.get_population().index)
 
     def step(self) -> None:
-        self._logger.debug(self._clock.time)
+        self._logger.debug()
         for event in self.time_step_events:
             self._logger.debug(f"Event: {event}")
             self._lifecycle.set_state(event)
@@ -272,14 +272,14 @@ class SimulationContext:
     ) -> None:
         if backup_freq:
             time_to_save = time() + backup_freq
-            while self._clock.time < self._clock.stop_time:
+            while self.current_time < self._clock.stop_time:
                 self.step()
                 if time() >= time_to_save:
                     self._logger.debug(f"Writing Simulation Backup to {backup_path}")
                     self.write_backup(backup_path)
                     time_to_save = time() + backup_freq
         else:
-            while self._clock.time < self._clock.stop_time:
+            while self.current_time < self._clock.stop_time:
                 self.step()
 
     def finalize(self) -> None:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -275,6 +275,7 @@ class SimulationContext:
             while self._clock.time < self._clock.stop_time:
                 self.step()
                 if time() >= time_to_save:
+                    self._logger.debug(f"Writing Simulation Backup to {backup_path}")
                     self.write_backup(backup_path)
                     time_to_save = time() + backup_freq
         else:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -247,13 +247,13 @@ class SimulationContext:
         self._lifecycle.set_state("population_creation")
         pop_params = self.configuration.population
         # Fencepost the creation of the initial population.
-        step_backward()
+        self._clock.step_backward()
         population_size = pop_params.population_size
         self.simulant_creator(population_size, {"sim_state": "setup"})
         self._clock.step_forward(self.get_population().index)
 
     def step(self) -> None:
-        self._logger.debug()
+        self._logger.debug(self._clock.time)
         for event in self.time_step_events:
             self._logger.debug(f"Event: {event}")
             self._lifecycle.set_state(event)
@@ -272,14 +272,14 @@ class SimulationContext:
     ) -> None:
         if backup_freq:
             time_to_save = time() + backup_freq
-            while self.current_time < self._clock.stop_time:
+            while self._clock.time < self._clock.stop_time:
                 self.step()
                 if time() >= time_to_save:
                     self._logger.debug(f"Writing Simulation Backup to {backup_path}")
                     self.write_backup(backup_path)
                     time_to_save = time() + backup_freq
         else:
-            while self.current_time < self._clock.stop_time:
+            while self._clock.time < self._clock.stop_time:
                 self.step()
 
     def finalize(self) -> None:

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -21,7 +21,6 @@ tools to easily setup and run a simulation.
 
 from pathlib import Path
 from pprint import pformat
-from time import time
 from typing import Any, Dict, List, Optional, Set, Union
 
 import dill

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -350,7 +350,7 @@ def test_SimulationContext_report_write(SimulationContext, base_config, componen
 
 
 def test_SimulationContext_write_backup(mocker, SimulationContext, tmpdir):
-    # TODO: Remove mocks when we can use dill in pytest.
+    # TODO MIC-5216: Remove mocks when we can use dill in pytest.
     mocker.patch("vivarium.framework.engine.dill.dump")
     mocker.patch("vivarium.framework.engine.dill.load", return_value=SimulationContext())
     sim = SimulationContext()

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -347,6 +347,16 @@ def test_SimulationContext_report_write(SimulationContext, base_config, componen
         assert results.equals(written_results)
 
 
+def test_SimulationContext_write_backup(SimulationContext, tmpdir):
+    sim = SimulationContext()
+    backup_path = tmpdir / "backup.pkl"
+    sim.write_backup(backup_path)
+    assert backup_path.exists()
+    with open(backup_path, "rb") as f:
+        sim_backup = dill.load(f)
+    assert isinstance(sim_backup, SimulationContext)
+
+
 def test_get_results_formatting(SimulationContext, base_config):
     """Test formatted results are as expected"""
     components = [

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -1,12 +1,12 @@
 import math
 from itertools import product
 from pathlib import Path
+from time import time
 from typing import Dict, List
 
 import dill
 import pandas as pd
 import pytest
-from time import time
 
 from tests.framework.results.helpers import (
     FAMILIARS,

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -2,6 +2,7 @@ import math
 from itertools import product
 from pathlib import Path
 from typing import Dict, List
+
 import dill
 import pandas as pd
 import pytest

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -2,7 +2,7 @@ import math
 from itertools import product
 from pathlib import Path
 from typing import Dict, List
-
+import dill
 import pandas as pd
 import pytest
 
@@ -346,7 +346,7 @@ def test_SimulationContext_report_write(SimulationContext, base_config, componen
         written_results = pd.read_parquet(results_root / f"{measure}.parquet")
         assert results.equals(written_results)
 
-
+@pytest.mark.skip(reason="TODO: Figure out how to make Dill serialize in pytest")
 def test_SimulationContext_write_backup(SimulationContext, tmpdir):
     sim = SimulationContext()
     backup_path = tmpdir / "backup.pkl"

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -346,6 +346,7 @@ def test_SimulationContext_report_write(SimulationContext, base_config, componen
         written_results = pd.read_parquet(results_root / f"{measure}.parquet")
         assert results.equals(written_results)
 
+
 @pytest.mark.skip(reason="TODO: Figure out how to make Dill serialize in pytest")
 def test_SimulationContext_write_backup(SimulationContext, tmpdir):
     sim = SimulationContext()


### PR DESCRIPTION
## Add backup writing to vivarium simulation Context
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5203

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This is a prerequisite for the simulation backups in psimulate. I elected to make the SimulationContext pickle itself, and also make a new public "past stop time" method that we can use from VCT.

For mysterious reasons, we can't pickle the sim object within a pytest context unless I globally disable cap logging with "pytest -s". Pickling works just fine in normal use, and trying to disable caplog or capsys etc. per-test hasn't worked so far. this appears to be something wrong on `dill`'s end, cf
https://github.com/uqfoundation/dill/issues/663
https://github.com/pytest-dev/pytest/issues/10845
https://github.com/pytest-dev/pytest/issues/12448
For now I've put in a skipped test.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

