### PR TITLE
Feature/sbachmei/mic 5163 exclude unwanted results

### DIFF
--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -95,6 +95,7 @@ configuration by simply printing it.
    sim = get_disease_model_simulation()
 
    del sim.configuration['input_data']
+   del sim.configuration['stratification']['excluded_categories']
 
 .. testcode:: configuration
 

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -17,8 +17,7 @@ setup everything it holds when the context itself is setup.
 """
 
 import inspect
-import typing
-from typing import Any, Dict, Iterator, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Sequence, Tuple, Union
 
 from layered_config_tree import (
     ConfigurationError,
@@ -31,7 +30,7 @@ from vivarium.exceptions import VivariumError
 from vivarium.framework.lifecycle import LifeCycleManager
 from vivarium.manager import Manager
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
 
 
@@ -181,7 +180,7 @@ class ComponentManager(Manager):
             self._components.add(c)
 
     def get_components_by_type(
-        self, component_type: Union[type, Tuple[type, ...]]
+        self, component_type: Union[type, Sequence[type]]
     ) -> List[Component]:
         """Get all components that are an instance of ``component_type``.
 
@@ -196,7 +195,8 @@ class ComponentManager(Manager):
             A list of components of type ``component_type``.
 
         """
-        return [c for c in self._components if isinstance(c, component_type)]
+        # Convert component_type to a tuple for isinstance
+        return [c for c in self._components if isinstance(c, tuple(component_type))]
 
     def get_component(self, name: str) -> Component:
         """Get the component with name ``name``.
@@ -348,7 +348,7 @@ class ComponentInterface:
         return self._manager.get_component(name)
 
     def get_components_by_type(
-        self, component_type: Union[type, Tuple[type, ...], list[type]]
+        self, component_type: Union[type, Sequence[type]]
     ) -> List[Component]:
         """Get all components that are an instance of ``component_type``.
 
@@ -364,7 +364,7 @@ class ComponentInterface:
             A list of components of type ``component_type``.
 
         """
-        return self._manager.get_components_by_type(tuple(component_type))
+        return self._manager.get_components_by_type(component_type)
 
     def list_components(self) -> Dict[str, Component]:
         """Get a mapping of component names to components held by the manager.

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -348,7 +348,7 @@ class ComponentInterface:
         return self._manager.get_component(name)
 
     def get_components_by_type(
-        self, component_type: Union[type, Tuple[type, ...]]
+        self, component_type: Union[type, Tuple[type, ...], list[type]]
     ) -> List[Component]:
         """Get all components that are an instance of ``component_type``.
 
@@ -364,7 +364,7 @@ class ComponentInterface:
             A list of components of type ``component_type``.
 
         """
-        return self._manager.get_components_by_type(component_type)
+        return self._manager.get_components_by_type(tuple(component_type))
 
     def list_components(self) -> Dict[str, Component]:
         """Get a mapping of component names to components held by the manager.

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -61,7 +61,7 @@ class ResultsContext:
         name: str,
         sources: List[str],
         categories: List[str],
-        excluded_categories: Optional[List[str]],
+        excluded_categories: List[str],
         mapper: Optional[Callable[[Union[pd.Series[str], pd.DataFrame]], pd.Series[str]]],
         is_vectorized: bool,
     ) -> None:
@@ -78,7 +78,7 @@ class ResultsContext:
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in the configuration.
+            If empty (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -110,10 +110,10 @@ class ResultsContext:
             )
 
         # Handle excluded categories. If excluded_categories are explicitly
-        # passed in, we use that instead of what is in the odel spec.
+        # passed in, we use that instead of what is in the model spec.
         to_exclude = (
             excluded_categories
-            if excluded_categories is not None
+            if excluded_categories
             else self.excluded_categories.get(name, [])
         )
         unknown_exclusions = set(to_exclude) - set(categories)

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -78,7 +78,7 @@ class ResultsContext:
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in th model spec.
+            If `None` (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -272,7 +272,7 @@ class ResultsContext:
         NOTE: Stratifications at this point can be an empty tuple.
         HACK: It's a bit hacky how we are handling the groupby object if there
         are no stratifications. The alternative is to use the entire population
-        #nstead of a groupby object, but then we would need to handle
+        instead of a groupby object, but then we would need to handle
         the different ways the aggregator can behave.
         """
 

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -247,23 +247,26 @@ class ResultsContext:
         self,
         population: pd.DataFrame,
         pop_filter: str,
-        stratifications: Optional[tuple[str, ...]],
+        stratification_names: Optional[tuple[str, ...]],
     ) -> pd.DataFrame:
         """Filter the population based on the filter string as well as any
         excluded stratification categories
         """
         pop = population.query(pop_filter) if pop_filter else population.copy()
-        if stratifications:
+        if stratification_names:
             # Drop all rows in the mapped_stratification columns that have NaN values
+            # (which only exist if the mapper returned an excluded category).
             pop = pop.dropna(
                 subset=[
-                    get_mapped_col_name(stratification) for stratification in stratifications
+                    get_mapped_col_name(stratification)
+                    for stratification in stratification_names
                 ]
             )
         return pop
 
+    @staticmethod
     def _get_groups(
-        self, stratifications: Tuple[str, ...], filtered_pop: pd.DataFrame
+        stratifications: Tuple[str, ...], filtered_pop: pd.DataFrame
     ) -> DataFrameGroupBy:
         """Group the population by stratifications.
         NOTE: Stratifications at this point can be an empty tuple.

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -123,7 +123,7 @@ class ResultsContext:
                 f"{categories} for stratification '{name}'."
             )
         if to_exclude:
-            self.logger.info(
+            self.logger.debug(
                 f"'{name}' has category exclusion requests: {to_exclude}\n"
                 "Removing these from the allowable categories."
             )

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -65,7 +65,7 @@ class ResultsContext:
         name: str,
         sources: List[str],
         categories: List[str],
-        excluded_categories: List[str],
+        excluded_categories: Optional[List[str]],
         mapper: Optional[Callable[[Union[pd.Series[str], pd.DataFrame]], pd.Series[str]]],
         is_vectorized: bool,
     ) -> None:
@@ -82,7 +82,7 @@ class ResultsContext:
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If empty (the default), will use exclusions as defined in the configuration.
+            If None (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -117,7 +117,7 @@ class ResultsContext:
         # passed in, we use that instead of what is in the model spec.
         to_exclude = (
             excluded_categories
-            if excluded_categories
+            if excluded_categories is not None
             else self.excluded_categories.get(name, [])
         )
         unknown_exclusions = set(to_exclude) - set(categories)

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -124,7 +124,7 @@ class ResultsInterface:
         binned_column: str,
         bin_edges: List[Union[int, float]] = [],
         labels: List[str] = [],
-        excluded_categories: Optional[List[str]] = None,
+        excluded_categories: List[str] = [],
         target_type: str = "column",
         **cut_kwargs: Dict,
     ) -> None:
@@ -144,7 +144,7 @@ class ResultsInterface:
             of `bin_edges` minus 1.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in the configuration.
+            If empty (the default), will use exclusions as defined in the configuration.
         target_type
             "column" or "value"
         **cut_kwargs
@@ -154,7 +154,6 @@ class ResultsInterface:
         ------
         None
         """
-        # TODO: implement excluded_categories like in `register_stratification`
         self._manager.register_binned_stratification(
             target,
             binned_column,

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -89,7 +89,7 @@ class ResultsInterface:
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in th model spec.
+            If `None` (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -73,7 +73,7 @@ class ResultsInterface:
         self,
         name: str,
         categories: List[str],
-        excluded_categories: List[str] = [],
+        excluded_categories: Optional[List[str]] = None,
         mapper: Optional[Callable[[pd.DataFrame], pd.Series[str]]] = None,
         is_vectorized: bool = False,
         requires_columns: List[str] = [],
@@ -89,7 +89,7 @@ class ResultsInterface:
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If empty (the default), will use exclusions as defined in the configuration.
+            If None (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -124,7 +124,7 @@ class ResultsInterface:
         binned_column: str,
         bin_edges: List[Union[int, float]] = [],
         labels: List[str] = [],
-        excluded_categories: List[str] = [],
+        excluded_categories: Optional[List[str]] = None,
         target_type: str = "column",
         **cut_kwargs: Dict,
     ) -> None:
@@ -144,7 +144,7 @@ class ResultsInterface:
             of `bin_edges` minus 1.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If empty (the default), will use exclusions as defined in the configuration.
+            If None (the default), will use exclusions as defined in the configuration.
         target_type
             "column" or "value"
         **cut_kwargs

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -73,6 +73,7 @@ class ResultsInterface:
         self,
         name: str,
         categories: List[str],
+        excluded_categories: Optional[List[str]] = None,
         mapper: Optional[Callable[[pd.DataFrame], pd.Series[str]]] = None,
         is_vectorized: bool = False,
         requires_columns: List[str] = [],
@@ -86,6 +87,9 @@ class ResultsInterface:
             Name of the of the column created by the stratification.
         categories
             List of string values that the mapper is allowed to output.
+        excluded_categories
+            List of mapped string values to be excluded from results processing.
+            If `None` (the default), will use exclusions as defined in th model spec.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -107,6 +111,7 @@ class ResultsInterface:
         self._manager.register_stratification(
             name,
             categories,
+            excluded_categories,
             mapper,
             is_vectorized,
             requires_columns,
@@ -145,6 +150,7 @@ class ResultsInterface:
         ------
         None
         """
+        # TODO: implement excluded_categories like in `register_stratification`
         self._manager.register_binned_stratification(
             target, target_type, binned_column, bin_edges, labels, **cut_kwargs
         )

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -73,7 +73,7 @@ class ResultsInterface:
         self,
         name: str,
         categories: List[str],
-        excluded_categories: Optional[List[str]] = None,
+        excluded_categories: List[str] = [],
         mapper: Optional[Callable[[pd.DataFrame], pd.Series[str]]] = None,
         is_vectorized: bool = False,
         requires_columns: List[str] = [],
@@ -89,7 +89,7 @@ class ResultsInterface:
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in the configuration.
+            If empty (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -124,6 +124,7 @@ class ResultsInterface:
         binned_column: str,
         bin_edges: List[Union[int, float]] = [],
         labels: List[str] = [],
+        excluded_categories: Optional[List[str]] = None,
         target_type: str = "column",
         **cut_kwargs: Dict,
     ) -> None:
@@ -141,6 +142,9 @@ class ResultsInterface:
         labels
             List of string labels for bins. The length must be equal to the length
             of `bin_edges` minus 1.
+        excluded_categories
+            List of mapped string values to be excluded from results processing.
+            If `None` (the default), will use exclusions as defined in the configuration.
         target_type
             "column" or "value"
         **cut_kwargs
@@ -152,7 +156,13 @@ class ResultsInterface:
         """
         # TODO: implement excluded_categories like in `register_stratification`
         self._manager.register_binned_stratification(
-            target, target_type, binned_column, bin_edges, labels, **cut_kwargs
+            target,
+            binned_column,
+            bin_edges,
+            labels,
+            excluded_categories,
+            target_type,
+            **cut_kwargs,
         )
 
     ###############################

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -163,7 +163,7 @@ class ResultsManager(Manager):
         self,
         name: str,
         categories: List[str],
-        excluded_categories: Optional[List[str]],
+        excluded_categories: List[str],
         mapper: Optional[Callable[[Union[pd.Series[str], pd.DataFrame]], pd.Series[str]]],
         is_vectorized: bool,
         requires_columns: List[str] = [],
@@ -179,7 +179,7 @@ class ResultsManager(Manager):
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in the configuration.
+            If empty (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -209,10 +209,11 @@ class ResultsManager(Manager):
     def register_binned_stratification(
         self,
         target: str,
-        target_type: str,
         binned_column: str,
         bin_edges: List[Union[int, float]],
         labels: List[str],
+        excluded_categories: Optional[List[str]],
+        target_type: str,
         **cut_kwargs,
     ) -> None:
         """Manager-level registration of a continuous `target` quantity to observe into bins in a `binned_column`.
@@ -221,8 +222,6 @@ class ResultsManager(Manager):
         ----------
         target
             String name of the state table column or value pipeline used to stratify.
-        target_type
-            "column" or "value"
         binned_column
             String name of the column for the binned quantities.
         bin_edges
@@ -233,6 +232,11 @@ class ResultsManager(Manager):
         labels
             List of string labels for bins. The length must equal to the length
             of `bin_edges` minus one.
+        excluded_categories
+            List of mapped string values to be excluded from results processing.
+            If `None` (the default), will use exclusions as defined in the configuration.
+        target_type
+            "column" or "value"
         **cut_kwargs
             Keyword arguments for :meth: pandas.cut.
 
@@ -261,7 +265,7 @@ class ResultsManager(Manager):
         self.register_stratification(
             name=binned_column,
             categories=labels,
-            excluded_categories=None,
+            excluded_categories=excluded_categories,
             mapper=_bin_data,
             is_vectorized=True,
             **target_kwargs,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -179,7 +179,7 @@ class ResultsManager(Manager):
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in th model spec.
+            If `None` (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -212,7 +212,7 @@ class ResultsManager(Manager):
         binned_column: str,
         bin_edges: List[Union[int, float]],
         labels: List[str],
-        excluded_categories: Optional[List[str]],
+        excluded_categories: List[str],
         target_type: str,
         **cut_kwargs,
     ) -> None:
@@ -234,7 +234,7 @@ class ResultsManager(Manager):
             of `bin_edges` minus one.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If `None` (the default), will use exclusions as defined in the configuration.
+            If empty (the default), will use exclusions as defined in the configuration.
         target_type
             "column" or "value"
         **cut_kwargs

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -35,6 +35,7 @@ class ResultsManager(Manager):
     CONFIGURATION_DEFAULTS = {
         "stratification": {
             "default": [],
+            "excluded_categories": {},
         }
     }
 
@@ -71,6 +72,8 @@ class ResultsManager(Manager):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: "Builder") -> None:
+        self._results_context.setup(builder)
+
         self.logger = builder.logging.get_logger(self.name)
         self.population_view = builder.population.get_view([])
         self.clock = builder.time.clock()
@@ -85,6 +88,7 @@ class ResultsManager(Manager):
         self.get_value = builder.value.get_value
 
         self.set_default_stratifications(builder)
+        self.set_stratification_excluded_categories(builder)
 
     def on_post_setup(self, _: Event) -> None:
         """Initialize results with 0s DataFrame' for each measure and all stratifications"""
@@ -153,6 +157,12 @@ class ResultsManager(Manager):
     def set_default_stratifications(self, builder: Builder) -> None:
         default_stratifications = builder.configuration.stratification.default
         self._results_context.set_default_stratifications(default_stratifications)
+
+    def set_stratification_excluded_categories(self, builder: Builder) -> None:
+        excluded_categories = builder.configuration.stratification.excluded_categories
+        self._results_context.set_stratification_excluded_categories(
+            excluded_categories.to_dict()
+        )
 
     def register_stratification(
         self,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -163,7 +163,7 @@ class ResultsManager(Manager):
         self,
         name: str,
         categories: List[str],
-        excluded_categories: List[str],
+        excluded_categories: Optional[List[str]],
         mapper: Optional[Callable[[Union[pd.Series[str], pd.DataFrame]], pd.Series[str]]],
         is_vectorized: bool,
         requires_columns: List[str] = [],
@@ -179,7 +179,7 @@ class ResultsManager(Manager):
             List of string values that the mapper is allowed to output.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If empty (the default), will use exclusions as defined in the configuration.
+            If None (the default), will use exclusions as defined in the configuration.
         mapper
             A callable that emits values in `categories` given inputs from columns
             and values in the `requires_columns` and `requires_values`, respectively.
@@ -212,7 +212,7 @@ class ResultsManager(Manager):
         binned_column: str,
         bin_edges: List[Union[int, float]],
         labels: List[str],
-        excluded_categories: List[str],
+        excluded_categories: Optional[List[str]],
         target_type: str,
         **cut_kwargs,
     ) -> None:
@@ -234,7 +234,7 @@ class ResultsManager(Manager):
             of `bin_edges` minus one.
         excluded_categories
             List of mapped string values to be excluded from results processing.
-            If empty (the default), will use exclusions as defined in the configuration.
+            If None (the default), will use exclusions as defined in the configuration.
         target_type
             "column" or "value"
         **cut_kwargs

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -140,7 +140,7 @@ class StratifiedObservation(BaseObservation):
     @staticmethod
     def initialize_results(
         requested_stratification_names: set[str],
-        registered_stratifications: List[Stratification],
+        registered_stratifications: list[Stratification],
     ) -> pd.DataFrame:
         """Initialize a dataframe of 0s with complete set of stratifications as the index."""
 
@@ -188,7 +188,7 @@ class StratifiedObservation(BaseObservation):
     @staticmethod
     def _aggregate(
         pop_groups: DataFrameGroupBy,
-        aggregator_sources: Optional[List[str]],
+        aggregator_sources: Optional[list[str]],
         aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
     ) -> Union[pd.Series[float], pd.DataFrame]:
         aggregates = (
@@ -236,7 +236,7 @@ class AddingObservation(StratifiedObservation):
         when: str,
         results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
         stratifications: Tuple[str, ...],
-        aggregator_sources: Optional[List[str]],
+        aggregator_sources: Optional[list[str]],
         aggregator: Callable[[pd.DataFrame], Union[float, pd.Series[float]]],
         to_observe: Callable[[Event], bool] = lambda event: True,
     ):
@@ -286,7 +286,7 @@ class ConcatenatingObservation(UnstratifiedObservation):
         name: str,
         pop_filter: str,
         when: str,
-        included_columns: List[str],
+        included_columns: list[str],
         results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
         to_observe: Callable[[Event], bool] = lambda event: True,
     ):

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -62,6 +62,11 @@ class Stratification:
             raise ValueError("The sources argument must be non-empty.")
 
     def __call__(self, population: pd.DataFrame) -> pd.DataFrame:
+        """Apply the mapper to the population 'sources' columns and add the result
+        to the population. Any excluded categories (which have already been removed
+        from self.categories) will be converted to NaNs in the new column
+        and dropped later at the observation level.
+        """
         if self.is_vectorized:
             mapped_column = self.mapper(population[self.sources])
         else:
@@ -73,7 +78,7 @@ class Stratification:
             self.categories + self.excluded_categories
         )
         if unknown_categories:
-            raise ValueError(f"Invalid values '{unknown_categories}' mapped to {self.name}.")
+            raise ValueError(f"Invalid values mapped to {self.name}: {unknown_categories}")
 
         # Convert the dtype to the allowed categories. Note that this will
         # result in Nans for any values in excluded_categories.

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -75,16 +75,11 @@ class Stratification:
         unknown_categories = set(mapped_column) - set(
             self.categories + self.excluded_categories
         )
+        # Reduce all nans to a single one
+        unknown_categories = [cat for cat in unknown_categories if not pd.isna(cat)]
+        if mapped_column.isna().any():
+            unknown_categories.append(mapped_column[mapped_column.isna()].iat[0])
         if unknown_categories:
-            # Reduce all nans to a single one
-            single_nan_list = (
-                [mapped_column[mapped_column.isna()].iat[0]]
-                if mapped_column.isna().any()
-                else []
-            )
-            unknown_categories = single_nan_list + [
-                cat for cat in unknown_categories if not pd.isna(cat)
-            ]
             raise ValueError(f"Invalid values mapped to {self.name}: {unknown_categories}")
 
         # Convert the dtype to the allowed categories. Note that this will

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -71,13 +71,19 @@ class Stratification:
             mapped_column = self.mapper(population[self.sources])
         else:
             mapped_column = population[self.sources].apply(self.mapper, axis=1)
-
-        if mapped_column.isnull().any():
-            raise ValueError(f"Null values mapped to {self.name}.")
         unknown_categories = set(mapped_column) - set(
             self.categories + self.excluded_categories
         )
         if unknown_categories:
+            # Reduce all nans to a single one
+            single_nan_list = (
+                [mapped_column[mapped_column.isna()].iat[0]]
+                if mapped_column.isna().any()
+                else []
+            )
+            unknown_categories = single_nan_list + [
+                cat for cat in unknown_categories if not pd.isna(cat)
+            ]
             raise ValueError(f"Invalid values mapped to {self.name}: {unknown_categories}")
 
         # Convert the dtype to the allowed categories. Note that this will

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -67,17 +67,19 @@ class Stratification:
         else:
             mapped_column = population[self.sources].apply(self.mapper, axis=1)
 
+        if mapped_column.isnull().any():
+            raise ValueError(f"Null values mapped to {self.name}.")
         unknown_categories = set(mapped_column) - set(
             self.categories + self.excluded_categories
         )
         if unknown_categories:
             raise ValueError(f"Invalid values '{unknown_categories}' mapped to {self.name}.")
 
-        mapped_column = mapped_column[mapped_column.isin(self.categories)]
+        # Convert the dtype to the allowed categories. Note that this will
+        # result in Nans for any values in excluded_categories.
         mapped_column = mapped_column.astype(
             CategoricalDtype(categories=self.categories, ordered=True)
         )
-        population = population.loc[mapped_column.index, :]
         population[self.name] = mapped_column
         return population
 

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Callable, List, Optional, Union
 
 import pandas as pd
-from loguru import logger
 from pandas.api.types import CategoricalDtype
 
 
@@ -61,7 +60,7 @@ class Stratification:
         if not self.sources:
             raise ValueError("The sources argument must be non-empty.")
 
-    def __call__(self, population: pd.DataFrame) -> pd.DataFrame:
+    def __call__(self, population: pd.DataFrame) -> pd.Series[str]:
         """Apply the mapper to the population 'sources' columns and add the result
         to the population. Any excluded categories (which have already been removed
         from self.categories) will be converted to NaNs in the new column
@@ -91,8 +90,7 @@ class Stratification:
         mapped_column = mapped_column.astype(
             CategoricalDtype(categories=self.categories, ordered=True)
         )
-        population[self.name] = mapped_column
-        return population
+        return mapped_column
 
     @staticmethod
     def _default_mapper(pop: pd.DataFrame) -> pd.Series[str]:

--- a/src/vivarium/framework/results/stratification.py
+++ b/src/vivarium/framework/results/stratification.py
@@ -6,6 +6,8 @@ from typing import Callable, List, Optional, Union
 import pandas as pd
 from pandas.api.types import CategoricalDtype
 
+STRATIFICATION_COLUMN_SUFFIX: str = "mapped_values"
+
 
 @dataclass
 class Stratification:
@@ -95,3 +97,17 @@ class Stratification:
     @staticmethod
     def _default_mapper(pop: pd.DataFrame) -> pd.Series[str]:
         return pop.squeeze(axis=1)
+
+
+def get_mapped_col_name(col_name: str) -> str:
+    """Return a new column name to be used for mapped values"""
+    return f"{col_name}_{STRATIFICATION_COLUMN_SUFFIX}"
+
+
+def get_original_col_name(col_name: str) -> str:
+    """Return the original column name given a modified mapped column name."""
+    return (
+        col_name[: -(len(STRATIFICATION_COLUMN_SUFFIX)) - 1]
+        if col_name.endswith(f"_{STRATIFICATION_COLUMN_SUFFIX}")
+        else col_name
+    )

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -11,11 +11,11 @@ from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.observer import Observer
 
 NAME = "hogwarts_house"
-SOURCES = ["first_name", "last_name"]
-CATEGORIES = ["hufflepuff", "ravenclaw", "slytherin", "gryffindor"]
+NAME_COLUMNS = ["first_name", "last_name"]
+HOUSE_CATEGORIES = ["hufflepuff", "ravenclaw", "slytherin", "gryffindor"]
 STUDENT_TABLE = pd.DataFrame(
     np.array([["harry", "potter"], ["severus", "snape"], ["luna", "lovegood"]]),
-    columns=SOURCES,
+    columns=NAME_COLUMNS,
 )
 STUDENT_HOUSES = pd.Series(["gryffindor", "slytherin", "ravenclaw"])
 
@@ -30,7 +30,7 @@ POWER_LEVELS = [20, 40, 60, 80]
 POWER_LEVEL_BIN_EDGES = [0, 25, 50, 75, 100]
 POWER_LEVEL_GROUP_LABELS = ["low", "medium", "high", "very high"]
 TRACKED_STATUSES = [True, False]
-RECORDS = list(itertools.product(CATEGORIES, FAMILIARS, POWER_LEVELS, TRACKED_STATUSES))
+RECORDS = list(itertools.product(HOUSE_CATEGORIES, FAMILIARS, POWER_LEVELS, TRACKED_STATUSES))
 BASE_POPULATION = pd.DataFrame(data=RECORDS, columns=COL_NAMES)
 
 HARRY_POTTER_CONFIG = {
@@ -254,10 +254,12 @@ class ValedictorianObserver(Observer):
 class HogwartsResultsStratifier(Component):
     def setup(self, builder: Builder) -> None:
         builder.results.register_stratification(
-            "student_house", list(STUDENT_HOUSES), requires_columns=["student_house"]
+            name="student_house",
+            categories=list(STUDENT_HOUSES),
+            requires_columns=["student_house"],
         )
         builder.results.register_stratification(
-            "familiar", FAMILIARS, requires_columns=["familiar"]
+            name="familiar", categories=FAMILIARS, requires_columns=["familiar"]
         )
         builder.results.register_binned_stratification(
             "power_level",
@@ -286,7 +288,7 @@ def results_formatter(
     return results[other_cols + [VALUE_COLUMN]].sort_index().reset_index()
 
 
-def sorting_hat_vector(state_table: pd.DataFrame) -> pd.Series:
+def sorting_hat_vectorized(state_table: pd.DataFrame) -> pd.Series:
     sorted_series = state_table.apply(sorting_hat_serial, axis=1)
     return sorted_series
 

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -266,7 +266,6 @@ class HogwartsResultsStratifier(Component):
             "power_level_group",
             POWER_LEVEL_BIN_EDGES,
             POWER_LEVEL_GROUP_LABELS,
-            "column",
         )
 
 
@@ -311,7 +310,7 @@ def sorting_hat_bad_mapping(simulant_row: pd.Series) -> str:
 
 
 def verify_stratification_added(
-    stratification_list, name, sources, categories, mapper, is_vectorized
+    stratification_list, name, sources, categories, excluded_categories, mapper, is_vectorized
 ):
     """Verify that a :class: `vivarium.framework.results.stratification.Stratification` is in `stratification_list`"""
     matching_stratification_found = False
@@ -319,7 +318,9 @@ def verify_stratification_added(
         # big equality check
         if (
             stratification.name == name
-            and sorted(stratification.categories) == sorted(categories)
+            and sorted(stratification.categories)
+            == sorted([cat for cat in categories if cat not in excluded_categories])
+            and sorted(stratification.excluded_categories) == sorted(excluded_categories)
             and stratification.mapper == mapper
             and stratification.is_vectorized == is_vectorized
             and sorted(stratification.sources) == sorted(sources)

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -535,16 +535,21 @@ def test__filter_population(pop_filter, stratifications):
     population = BASE_POPULATION.copy()
     if stratifications:
         # Make some of the stratifications missing to mimic mapping to excluded categories
-        population["new_col1"] = "new_value1"
-        population.loc[population["tracked"] == True, "new_col1"] = np.nan
+        population["new_col1_mapped_values"] = "new_value1"
+        population.loc[population["tracked"] == True, "new_col1_mapped_values"] = np.nan
         if len(stratifications) == 2:
-            population["new_col2"] = "new_value2"
-            population.loc[population["new_col1"].notna(), "new_col2"] = np.nan
+            population["new_col2_mapped_values"] = "new_value2"
+            population.loc[
+                population["new_col1_mapped_values"].notna(), "new_col2_mapped_values"
+            ] = np.nan
 
     filtered_pop = ResultsContext()._filter_population(
         population=population, pop_filter=pop_filter, stratifications=stratifications
     )
-    expected = population
+    expected = population.rename(
+        columns={"new_col1_mapped_values": "new_col1", "new_col2_mapped_values": "new_col2"}
+    )
+
     if pop_filter:
         familiar = pop_filter.split("==")[1].strip('"')
         expected = expected[expected["familiar"] == familiar]

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -118,6 +118,19 @@ def test_add_stratification_duplicate_category_raises(duplicates):
         )
 
 
+def test_add_stratification_bad_exception_category_raises(mocker):
+    ctx = ResultsContext()
+    mocker.patch.object(ctx, "excluded_categories", {"hogwarts_house": ["gryfflepuff"]})
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Excluded categories {'gryfflepuff'} not found in categories "
+            f"{CATEGORIES} for stratification '{NAME}'."
+        ),
+    ):
+        ctx.add_stratification(NAME, SOURCES, CATEGORIES, sorting_hat_vector, True)
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import numpy as np
 import pandas as pd
 import pytest
-from layered_config_tree import LayeredConfigTree
 from pandas.core.groupby import DataFrameGroupBy
 
 from tests.framework.results.helpers import (
@@ -48,18 +47,18 @@ def test_add_stratification(mapper, is_vectorized, mocker):
     ctx = ResultsContext()
     mocker.patch.object(ctx, "excluded_categories", {})
     assert not verify_stratification_added(
-        ctx.stratifications, NAME, NAME_COLUMNS, HOUSE_CATEGORIES, mapper, is_vectorized
+        ctx.stratifications, NAME, NAME_COLUMNS, HOUSE_CATEGORIES, [], mapper, is_vectorized
     )
     ctx.add_stratification(
         name=NAME,
         sources=NAME_COLUMNS,
         categories=HOUSE_CATEGORIES,
-        excluded_categories=None,
+        excluded_categories=[],
         mapper=mapper,
         is_vectorized=is_vectorized,
     )
     assert verify_stratification_added(
-        ctx.stratifications, NAME, NAME_COLUMNS, HOUSE_CATEGORIES, mapper, is_vectorized
+        ctx.stratifications, NAME, NAME_COLUMNS, HOUSE_CATEGORIES, [], mapper, is_vectorized
     )
 
 
@@ -106,7 +105,7 @@ def test_add_stratification_raises(name, categories, excluded_categories, msg_ma
         name="duplicate_name",
         sources=["foo"],
         categories=["bar"],
-        excluded_categories=None,
+        excluded_categories=[],
         mapper=sorting_hat_serial,
         is_vectorized=False,
     )
@@ -232,7 +231,7 @@ def test_adding_observation_gather_results(
             name="house",
             sources=["house"],
             categories=HOUSE_CATEGORIES,
-            excluded_categories=None,
+            excluded_categories=[],
             mapper=None,
             is_vectorized=True,
         )
@@ -241,7 +240,7 @@ def test_adding_observation_gather_results(
             name="familiar",
             sources=["familiar"],
             categories=FAMILIARS,
-            excluded_categories=None,
+            excluded_categories=[],
             mapper=None,
             is_vectorized=True,
         )
@@ -376,7 +375,7 @@ def test_gather_results_partial_stratifications_in_results(
             name="house",
             sources=["house"],
             categories=HOUSE_CATEGORIES,
-            excluded_categories=None,
+            excluded_categories=[],
             mapper=None,
             is_vectorized=True,
         )
@@ -385,7 +384,7 @@ def test_gather_results_partial_stratifications_in_results(
             name="familiar",
             sources=["familiar"],
             categories=FAMILIARS,
-            excluded_categories=None,
+            excluded_categories=[],
             mapper=None,
             is_vectorized=True,
         )
@@ -483,7 +482,7 @@ def test_bad_aggregator_stratification(mocked_event):
         name="house",
         sources=["house"],
         categories=HOUSE_CATEGORIES,
-        excluded_categories=None,
+        excluded_categories=[],
         mapper=None,
         is_vectorized=True,
     )
@@ -491,7 +490,7 @@ def test_bad_aggregator_stratification(mocked_event):
         name="familiar",
         sources=["familiar"],
         categories=FAMILIARS,
-        excluded_categories=None,
+        excluded_categories=[],
         mapper=None,
         is_vectorized=True,
     )

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -546,7 +546,7 @@ def test__filter_population(pop_filter, stratifications):
             population[mapped_col] = population[stratification]
 
     filtered_pop = ResultsContext()._filter_population(
-        population=population, pop_filter=pop_filter, stratifications=stratifications
+        population=population, pop_filter=pop_filter, stratification_names=stratifications
     )
     expected = population.copy()
     if pop_filter:

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -6,16 +6,17 @@ from datetime import timedelta
 import numpy as np
 import pandas as pd
 import pytest
+from layered_config_tree import LayeredConfigTree
 from pandas.core.groupby import DataFrameGroupBy
 
 from tests.framework.results.helpers import (
     BASE_POPULATION,
-    CATEGORIES,
     FAMILIARS,
+    HOUSE_CATEGORIES,
     NAME,
-    SOURCES,
+    NAME_COLUMNS,
     sorting_hat_serial,
-    sorting_hat_vector,
+    sorting_hat_vectorized,
     verify_stratification_added,
 )
 from vivarium.framework.event import Event
@@ -36,139 +37,86 @@ def mocked_event(mocker) -> Event:
 
 
 @pytest.mark.parametrize(
-    "name, sources, categories, mapper, is_vectorized",
+    "mapper, is_vectorized",
     [
-        (NAME, SOURCES, CATEGORIES, sorting_hat_vector, True),
-        (NAME, SOURCES, CATEGORIES, sorting_hat_serial, False),
+        (sorting_hat_vectorized, True),
+        (sorting_hat_serial, False),
     ],
     ids=["vectorized_mapper", "non-vectorized_mapper"],
 )
-def test_add_stratification(name, sources, categories, mapper, is_vectorized, mocker):
+def test_add_stratification(mapper, is_vectorized, mocker):
     ctx = ResultsContext()
     mocker.patch.object(ctx, "excluded_categories", {})
     assert not verify_stratification_added(
-        ctx.stratifications, name, sources, categories, mapper, is_vectorized
+        ctx.stratifications, NAME, NAME_COLUMNS, HOUSE_CATEGORIES, mapper, is_vectorized
     )
     ctx.add_stratification(
-        name=name,
-        sources=sources,
-        categories=categories,
+        name=NAME,
+        sources=NAME_COLUMNS,
+        categories=HOUSE_CATEGORIES,
         excluded_categories=None,
         mapper=mapper,
         is_vectorized=is_vectorized,
     )
     assert verify_stratification_added(
-        ctx.stratifications, name, sources, categories, mapper, is_vectorized
+        ctx.stratifications, NAME, NAME_COLUMNS, HOUSE_CATEGORIES, mapper, is_vectorized
     )
 
 
 @pytest.mark.parametrize(
-    "name, sources, categories, mapper, is_vectorized, expected_exception",
+    "name, categories, excluded_categories, msg_match",
     [
-        (  # sources not in population columns
-            NAME,
-            ["middle_initial"],
-            CATEGORIES,
-            sorting_hat_vector,
-            True,
-            TypeError,
+        (
+            "duplicate_name",
+            HOUSE_CATEGORIES,
+            [],
+            "Stratification name 'duplicate_name' is already used: ",
         ),
-        (  # is_vectorized=True with non-vectorized mapper
+        (
             NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_serial,
-            True,
-            Exception,
+            HOUSE_CATEGORIES + ["slytherin"],
+            [],
+            f"Found duplicate categories in stratification '{NAME}': ['slytherin']",
         ),
-        (  # is_vectorized=False with vectorized mapper
+        (
             NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_vector,
-            False,
-            Exception,
+            HOUSE_CATEGORIES + ["gryffindor", "slytherin"],
+            [],
+            f"Found duplicate categories in stratification '{NAME}': ['gryffindor', 'slytherin']",
+        ),
+        (
+            NAME,
+            HOUSE_CATEGORIES,
+            ["gryfflepuff"],
+            "Excluded categories {'gryfflepuff'} not found in categories",
         ),
     ],
+    ids=[
+        "duplicate_name",
+        "duplicate_category",
+        "duplicate_categories",
+        "unknown_excluded_category",
+    ],
 )
-def test_add_stratification_raises(
-    name, sources, categories, mapper, is_vectorized, expected_exception
-):
+def test_add_stratification_raises(name, categories, excluded_categories, msg_match, mocker):
     ctx = ResultsContext()
-    with pytest.raises(expected_exception):
-        raise ctx.add_stratification(
-            name=name,
-            sources=sources,
-            categories=categories,
-            excluded_categories=None,
-            mapper=mapper,
-            is_vectorized=is_vectorized,
-        )
-
-
-def test_add_stratifcation_duplicate_name_raises():
-    ctx = ResultsContext()
+    mocker.patch.object(ctx, "excluded_categories", {name: excluded_categories})
+    # Register a stratification to test against duplicate stratifications
     ctx.add_stratification(
-        name=NAME,
-        sources=SOURCES,
-        categories=CATEGORIES,
+        name="duplicate_name",
+        sources=["foo"],
+        categories=["bar"],
         excluded_categories=None,
-        mapper=sorting_hat_vector,
-        is_vectorized=True,
+        mapper=sorting_hat_serial,
+        is_vectorized=False,
     )
-    with pytest.raises(ValueError, match=f"Stratification name '{NAME}' is already used: "):
-        # register a different stratification but w/ the same name
+    with pytest.raises(ValueError, match=re.escape(msg_match)):
         ctx.add_stratification(
-            name=NAME,
-            sources=[],
-            categories=[],
-            excluded_categories=None,
-            mapper=None,
-            is_vectorized=False,
-        )
-
-
-@pytest.mark.parametrize(
-    "duplicates",
-    [
-        ["slytherin"],
-        ["gryffindor", "slytherin"],
-    ],
-)
-def test_add_stratification_duplicate_category_raises(duplicates):
-    ctx = ResultsContext()
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            f"Found duplicate categories in stratification '{NAME}': {duplicates}"
-        ),
-    ):
-        ctx.add_stratification(
-            name=NAME,
-            sources=SOURCES,
-            categories=CATEGORIES + duplicates,
-            excluded_categories=None,
-            mapper=sorting_hat_vector,
-            is_vectorized=True,
-        )
-
-
-def test_add_stratification_bad_exception_category_raises(mocker):
-    ctx = ResultsContext()
-    mocker.patch.object(ctx, "excluded_categories", {"hogwarts_house": ["gryfflepuff"]})
-    with pytest.raises(
-        ValueError,
-        match=re.escape(
-            "Excluded categories {'gryfflepuff'} not found in categories "
-            f"{CATEGORIES} for stratification '{NAME}'."
-        ),
-    ):
-        ctx.add_stratification(
-            name=NAME,
-            sources=SOURCES,
-            categories=CATEGORIES,
-            excluded_categories=None,
-            mapper=sorting_hat_vector,
+            name=name,
+            sources=NAME_COLUMNS,
+            categories=categories,
+            excluded_categories=excluded_categories,
+            mapper=sorting_hat_vectorized,
             is_vectorized=True,
         )
 
@@ -283,7 +231,7 @@ def test_adding_observation_gather_results(
         ctx.add_stratification(
             name="house",
             sources=["house"],
-            categories=CATEGORIES,
+            categories=HOUSE_CATEGORIES,
             excluded_categories=None,
             mapper=None,
             is_vectorized=True,
@@ -427,7 +375,7 @@ def test_gather_results_partial_stratifications_in_results(
         ctx.add_stratification(
             name="house",
             sources=["house"],
-            categories=CATEGORIES,
+            categories=HOUSE_CATEGORIES,
             excluded_categories=None,
             mapper=None,
             is_vectorized=True,
@@ -534,7 +482,7 @@ def test_bad_aggregator_stratification(mocked_event):
     ctx.add_stratification(
         name="house",
         sources=["house"],
-        categories=CATEGORIES,
+        categories=HOUSE_CATEGORIES,
         excluded_categories=None,
         mapper=None,
         is_vectorized=True,
@@ -610,7 +558,7 @@ def test__filter_population(pop_filter, stratifications):
     "stratifications, values",
     [
         (("familiar",), [FAMILIARS]),
-        (("familiar", "house"), [FAMILIARS, CATEGORIES]),
+        (("familiar", "house"), [FAMILIARS, HOUSE_CATEGORIES]),
         ((), "foo"),
     ],
 )

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -53,7 +53,7 @@ def test_add_stratification(mapper, is_vectorized, mocker):
         name=NAME,
         sources=NAME_COLUMNS,
         categories=HOUSE_CATEGORIES,
-        excluded_categories=[],
+        excluded_categories=None,
         mapper=mapper,
         is_vectorized=is_vectorized,
     )
@@ -105,7 +105,7 @@ def test_add_stratification_raises(name, categories, excluded_categories, msg_ma
         name="duplicate_name",
         sources=["foo"],
         categories=["bar"],
-        excluded_categories=[],
+        excluded_categories=None,
         mapper=sorting_hat_serial,
         is_vectorized=False,
     )
@@ -231,7 +231,7 @@ def test_adding_observation_gather_results(
             name="house",
             sources=["house"],
             categories=HOUSE_CATEGORIES,
-            excluded_categories=[],
+            excluded_categories=None,
             mapper=None,
             is_vectorized=True,
         )
@@ -240,7 +240,7 @@ def test_adding_observation_gather_results(
             name="familiar",
             sources=["familiar"],
             categories=FAMILIARS,
-            excluded_categories=[],
+            excluded_categories=None,
             mapper=None,
             is_vectorized=True,
         )
@@ -375,7 +375,7 @@ def test_gather_results_partial_stratifications_in_results(
             name="house",
             sources=["house"],
             categories=HOUSE_CATEGORIES,
-            excluded_categories=[],
+            excluded_categories=None,
             mapper=None,
             is_vectorized=True,
         )
@@ -384,7 +384,7 @@ def test_gather_results_partial_stratifications_in_results(
             name="familiar",
             sources=["familiar"],
             categories=FAMILIARS,
-            excluded_categories=[],
+            excluded_categories=None,
             mapper=None,
             is_vectorized=True,
         )
@@ -482,7 +482,7 @@ def test_bad_aggregator_stratification(mocked_event):
         name="house",
         sources=["house"],
         categories=HOUSE_CATEGORIES,
-        excluded_categories=[],
+        excluded_categories=None,
         mapper=None,
         is_vectorized=True,
     )
@@ -490,7 +490,7 @@ def test_bad_aggregator_stratification(mocked_event):
         name="familiar",
         sources=["familiar"],
         categories=FAMILIARS,
-        excluded_categories=[],
+        excluded_categories=None,
         mapper=None,
         is_vectorized=True,
     )

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -6,9 +6,9 @@ import pandas as pd
 import pytest
 from layered_config_tree import LayeredConfigTree
 
-from tests.framework.results.helpers import BASE_POPULATION
-from tests.framework.results.helpers import CATEGORIES as HOUSES
-from tests.framework.results.helpers import FAMILIARS, mock_get_value
+from tests.framework.results.helpers import BASE_POPULATION, FAMILIARS
+from tests.framework.results.helpers import HOUSE_CATEGORIES as HOUSES
+from tests.framework.results.helpers import mock_get_value
 from vivarium.framework.results import ResultsInterface, ResultsManager
 
 
@@ -279,10 +279,13 @@ def test_register_adding_observation_when_options(when, mocker):
 
     # register stratifications
     results_interface.register_stratification(
-        "house", HOUSES, is_vectorized=True, requires_columns=["house"]
+        name="house", categories=HOUSES, is_vectorized=True, requires_columns=["house"]
     )
     results_interface.register_stratification(
-        "familiar", FAMILIARS, is_vectorized=True, requires_columns=["familiar"]
+        name="familiar",
+        categories=FAMILIARS,
+        is_vectorized=True,
+        requires_columns=["familiar"],
     )
 
     time_step__prepare_mock_aggregator = mocker.Mock(side_effect=lambda x: 1.0)

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -4,6 +4,7 @@ from types import MethodType
 
 import pandas as pd
 import pytest
+from layered_config_tree import LayeredConfigTree
 
 from tests.framework.results.helpers import BASE_POPULATION
 from tests.framework.results.helpers import CATEGORIES as HOUSES
@@ -271,7 +272,9 @@ def test_register_adding_observation_when_options(when, mocker):
     mgr = ResultsManager()
     results_interface = ResultsInterface(mgr)
     builder = mocker.Mock()
-    builder.configuration.stratification.default = []
+    builder.configuration.stratification = LayeredConfigTree(
+        {"default": [], "excluded_categories": {}}
+    )
     mgr.setup(builder)
 
     # register stratifications

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -278,9 +278,11 @@ def test_register_adding_observation_when_options(when, mocker):
     mgr.setup(builder)
 
     # register stratifications
-    results_interface.register_stratification("house", HOUSES, None, True, ["house"], [])
     results_interface.register_stratification(
-        "familiar", FAMILIARS, None, True, ["familiar"], []
+        "house", HOUSES, is_vectorized=True, requires_columns=["house"]
+    )
+    results_interface.register_stratification(
+        "familiar", FAMILIARS, is_vectorized=True, requires_columns=["familiar"]
     )
 
     time_step__prepare_mock_aggregator = mocker.Mock(side_effect=lambda x: 1.0)

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -24,7 +24,8 @@ def _silly_aggregator(_: pd.DataFrame) -> float:
 
 def test_register_stratification(mocker):
     def _silly_mapper():
-        return "foo"
+        # NOTE: it does not actually matter what this mapper returns for this test
+        return {"some-category", "some-other-category", "some-unwanted-category"}
 
     builder = mocker.Mock()
     # Set up mock builder with mocked get_value call for Pipelines

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -4,6 +4,7 @@ from types import MethodType
 import numpy as np
 import pandas as pd
 import pytest
+from layered_config_tree import LayeredConfigTree
 from loguru import logger
 from pandas.api.types import CategoricalDtype
 
@@ -113,6 +114,9 @@ def test_register_stratification_no_pipelines(
 ):
     mgr = ResultsManager()
     builder = mocker.Mock()
+    builder.configuration.stratification = LayeredConfigTree(
+        {"default": [], "excluded_categories": {}}
+    )
     mgr.setup(builder)
     mgr.register_stratification(name, categories, mapper, is_vectorized, sources, [])
     for item in sources:
@@ -152,6 +156,9 @@ def test_register_stratification_with_pipelines(
 ):
     mgr = ResultsManager()
     builder = mocker.Mock()
+    builder.configuration.stratification = LayeredConfigTree(
+        {"default": [], "excluded_categories": {}}
+    )
     # Set up mock builder with mocked get_value call for Pipelines
     mocker.patch.object(builder, "value.get_value")
     builder.value.get_value = MethodType(mock_get_value, builder)
@@ -194,6 +201,9 @@ def test_register_stratification_with_column_and_pipelines(
 ):
     mgr = ResultsManager()
     builder = mocker.Mock()
+    builder.configuration.stratification = LayeredConfigTree(
+        {"default": [], "excluded_categories": {}}
+    )
     # Set up mock builder with mocked get_value call for Pipelines
     mocker.patch.object(builder, "value.get_value")
     builder.value.get_value = MethodType(mock_get_value, builder)

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -266,34 +266,6 @@ def test_register_stratification_with_column_and_pipelines(
 ##############################################
 
 
-@pytest.mark.parametrize("exclusions", [[], ["somewhat"], ["somewhat", "extra"]])
-def test_register_binned_stratification(exclusions, mocker):
-    mgr = ResultsManager()
-    mgr.logger = logger
-    builder = mocker.Mock()
-    mgr._results_context.setup(builder)
-    mocker.patch.object(mgr._results_context, "excluded_categories", {})
-    assert len(mgr._results_context.stratifications) == 0
-    mgr.register_binned_stratification(
-        target=BIN_SOURCE,
-        binned_column=BIN_BINNED_COLUMN,
-        bin_edges=BIN_SILLY_BIN_EDGES,
-        labels=BIN_LABELS,
-        excluded_categories=exclusions,
-        target_type="column",
-    )
-    assert len(mgr._results_context.stratifications) == 1
-    strat = mgr._results_context.stratifications[0]
-    assert strat.name == BIN_BINNED_COLUMN
-    assert strat.sources == [BIN_SOURCE]
-    assert strat.categories == [cat for cat in BIN_LABELS if cat not in exclusions]
-    assert strat.excluded_categories == exclusions
-    # Cannot access the mapper because it's in local scope, so check __repr__
-    assert "function ResultsManager.register_binned_stratification.<locals>._bin_data" in str(
-        strat.mapper
-    )
-
-
 @pytest.mark.parametrize(
     "bins, labels",
     [(BIN_SILLY_BIN_EDGES, BIN_LABELS[1:]), (BIN_SILLY_BIN_EDGES[1:], BIN_LABELS)],

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -184,7 +184,7 @@ def test_register_stratification_with_pipelines(
     mgr.register_stratification(
         name=name,
         categories=categories,
-        excluded_categories=[],
+        excluded_categories=None,
         mapper=mapper,
         is_vectorized=is_vectorized,
         requires_columns=[],
@@ -239,7 +239,7 @@ def test_register_stratification_with_column_and_pipelines(
     mgr.register_stratification(
         name=name,
         categories=categories,
-        excluded_categories=[],
+        excluded_categories=None,
         mapper=mapper,
         is_vectorized=is_vectorized,
         requires_columns=[mocked_column_name],
@@ -282,7 +282,7 @@ def test_register_binned_stratification_raises_bins_labels_mismatch(bins, labels
             binned_column=BIN_BINNED_COLUMN,
             bin_edges=bins,
             labels=labels,
-            excluded_categories=[],
+            excluded_categories=None,
             target_type="column",
         )
 
@@ -295,7 +295,7 @@ def test_binned_stratification_mapper():
         binned_column=BIN_BINNED_COLUMN,
         bin_edges=BIN_SILLY_BIN_EDGES,
         labels=BIN_LABELS,
-        excluded_categories=[],
+        excluded_categories=None,
         target_type="column",
     )
     strat = mgr._results_context.stratifications[0]

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -13,12 +13,12 @@ from tests.framework.results.helpers import (
     BIN_LABELS,
     BIN_SILLY_BIN_EDGES,
     BIN_SOURCE,
-    CATEGORIES,
     FAMILIARS,
     HARRY_POTTER_CONFIG,
+    HOUSE_CATEGORIES,
     NAME,
+    NAME_COLUMNS,
     POWER_LEVEL_GROUP_LABELS,
-    SOURCES,
     STUDENT_HOUSES,
     CatBombObserver,
     ExamScoreObserver,
@@ -32,7 +32,7 @@ from tests.framework.results.helpers import (
     ValedictorianObserver,
     mock_get_value,
     sorting_hat_serial,
-    sorting_hat_vector,
+    sorting_hat_vectorized,
     verify_stratification_added,
 )
 from vivarium.framework.results import VALUE_COLUMN
@@ -94,15 +94,15 @@ def test__get_stratifications(
     [
         (
             NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_vector,
+            NAME_COLUMNS,
+            HOUSE_CATEGORIES,
+            sorting_hat_vectorized,
             True,
         ),
         (
             NAME,
-            SOURCES,
-            CATEGORIES,
+            NAME_COLUMNS,
+            HOUSE_CATEGORIES,
             sorting_hat_serial,
             False,
         ),
@@ -125,7 +125,6 @@ def test_register_stratification_no_pipelines(
         mapper=mapper,
         is_vectorized=is_vectorized,
         requires_columns=sources,
-        requires_values=[],
     )
     for item in sources:
         assert item in mgr._required_columns
@@ -144,15 +143,15 @@ def test_register_stratification_no_pipelines(
     [
         (
             NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_vector,
+            NAME_COLUMNS,
+            HOUSE_CATEGORIES,
+            sorting_hat_vectorized,
             True,
         ),
         (
             NAME,
-            SOURCES,
-            CATEGORIES,
+            NAME_COLUMNS,
+            HOUSE_CATEGORIES,
             sorting_hat_serial,
             False,
         ),
@@ -197,15 +196,15 @@ def test_register_stratification_with_pipelines(
     [
         (  # expected Stratification for vectorized
             NAME,
-            SOURCES,
-            CATEGORIES,
-            sorting_hat_vector,
+            NAME_COLUMNS,
+            HOUSE_CATEGORIES,
+            sorting_hat_vectorized,
             True,
         ),
         (  # expected Stratification for non-vectorized
             NAME,
-            SOURCES,
-            CATEGORIES,
+            NAME_COLUMNS,
+            HOUSE_CATEGORIES,
             sorting_hat_serial,
             False,
         ),

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -118,7 +118,15 @@ def test_register_stratification_no_pipelines(
         {"default": [], "excluded_categories": {}}
     )
     mgr.setup(builder)
-    mgr.register_stratification(name, categories, mapper, is_vectorized, sources, [])
+    mgr.register_stratification(
+        name=name,
+        categories=categories,
+        excluded_categories=None,
+        mapper=mapper,
+        is_vectorized=is_vectorized,
+        requires_columns=sources,
+        requires_values=[],
+    )
     for item in sources:
         assert item in mgr._required_columns
     assert verify_stratification_added(
@@ -163,7 +171,15 @@ def test_register_stratification_with_pipelines(
     mocker.patch.object(builder, "value.get_value")
     builder.value.get_value = MethodType(mock_get_value, builder)
     mgr.setup(builder)
-    mgr.register_stratification(name, categories, mapper, is_vectorized, [], sources)
+    mgr.register_stratification(
+        name=name,
+        categories=categories,
+        excluded_categories=None,
+        mapper=mapper,
+        is_vectorized=is_vectorized,
+        requires_columns=[],
+        requires_values=sources,
+    )
     for item in sources:
         assert item in mgr._required_values
     assert verify_stratification_added(
@@ -210,7 +226,13 @@ def test_register_stratification_with_column_and_pipelines(
     mgr.setup(builder)
     mocked_column_name = "silly_column"
     mgr.register_stratification(
-        name, categories, mapper, is_vectorized, [mocked_column_name], sources
+        name=name,
+        categories=categories,
+        excluded_categories=None,
+        mapper=mapper,
+        is_vectorized=is_vectorized,
+        requires_columns=[mocked_column_name],
+        requires_values=sources,
     )
     assert mocked_column_name in mgr._required_columns
     for item in sources:

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -63,8 +63,13 @@ def test_stratified_observation__aggregate(
     - If no aggregator_resources are provided, then we want a full aggregation of the groups.
     - _aggregate can return either a pd.Series or a pd.DataFrame of any number of columns
     """
+
+    filtered_pop = BASE_POPULATION.copy()
+    for stratification in stratifications:
+        mapped_col = f"{stratification}_mapped_values"
+        filtered_pop[mapped_col] = filtered_pop[stratification]
     groups = ResultsContext()._get_groups(
-        stratifications=stratifications, filtered_pop=BASE_POPULATION
+        stratifications=stratifications, filtered_pop=filtered_pop
     )
     aggregates = stratified_observation._aggregate(
         pop_groups=groups,
@@ -166,10 +171,16 @@ def test_stratified_observation__expand_index(aggregates, stratified_observation
 )
 def test_stratified_observation_results_gatherer(stratifications, stratified_observation):
     ctx = ResultsContext()
+    # Append the post-stratified columns
+    filtered_population = BASE_POPULATION.copy()
+    for stratification in stratifications:
+        mapped_col = f"{stratification}_mapped_values"
+        filtered_population[mapped_col] = filtered_population[stratification]
     pop_groups = ctx._get_groups(
-        stratifications=stratifications, filtered_pop=BASE_POPULATION
+        stratifications=stratifications, filtered_pop=filtered_population
     )
     df = stratified_observation.results_gatherer(pop_groups, stratifications)
+    ctx._rename_index(df)
     assert set(df.columns) == set(["value"])
     expected_idx_names = (
         list(stratifications) if len(stratifications) > 0 else ["stratification"]

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from tests.framework.results.helpers import BASE_POPULATION, CATEGORIES, FAMILIARS
+from tests.framework.results.helpers import BASE_POPULATION, FAMILIARS, HOUSE_CATEGORIES
 from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.context import ResultsContext
 from vivarium.framework.results.observation import (
@@ -74,7 +74,7 @@ def test_stratified_observation__aggregate(
     if aggregator == len:
         if stratifications:
             stratification_idx = (
-                set(itertools.product(*(FAMILIARS, CATEGORIES)))
+                set(itertools.product(*(FAMILIARS, HOUSE_CATEGORIES)))
                 if "house" in stratifications
                 else set(FAMILIARS)
             )
@@ -88,7 +88,7 @@ def test_stratified_observation__aggregate(
         expected = BASE_POPULATION[["power_level", "tracked"]].sum() / groups.ngroups
         if stratifications:
             stratification_idx = (
-                set(itertools.product(*(FAMILIARS, CATEGORIES)))
+                set(itertools.product(*(FAMILIARS, HOUSE_CATEGORIES)))
                 if "house" in stratifications
                 else set(FAMILIARS)
             )

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -180,7 +180,7 @@ def test_stratified_observation_results_gatherer(stratifications, stratified_obs
         stratifications=stratifications, filtered_pop=filtered_population
     )
     df = stratified_observation.results_gatherer(pop_groups, stratifications)
-    ctx._rename_index(df)
+    ctx._rename_stratification_columns(df)
     assert set(df.columns) == set(["value"])
     expected_idx_names = (
         list(stratifications) if len(stratifications) > 0 else ["stratification"]

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pandas as pd
 import pytest
 
 from tests.framework.results.helpers import (
@@ -90,12 +92,19 @@ def test_stratification_init_raises(sources, categories):
             False,
             Exception,
         ),
+        (
+            SOURCES,
+            lambda df: pd.Series(np.nan, index=df.index),
+            True,
+            ValueError,
+        ),
     ],
     ids=[
         "category_not_in_categories",
         "source_not_in_population_columns",
         "vectorized_with_serial_mapper",
         "not_vectorized_with_serial_mapper",
+        "mapper_returns_null",
     ],
 )
 def test_stratification_call_raises(sources, mapper, is_vectorized, expected_exception):

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -93,7 +93,7 @@ def test_stratification_init_raises(sources, categories, mapper, msg_match):
             sorting_hat_bad_mapping,
             False,
             ValueError,
-            "Invalid values mapped to hogwarts_house: {'pancakes'}",
+            "Invalid values mapped to hogwarts_house: ['pancakes']",
         ),
         (
             ["middle_initial"],
@@ -121,7 +121,7 @@ def test_stratification_init_raises(sources, categories, mapper, msg_match):
             lambda df: pd.Series(np.nan, index=df.index),
             True,
             ValueError,
-            "Null values mapped to hogwarts_house.",
+            f"Invalid values mapped to hogwarts_house: [{np.nan}]",
         ),
     ],
     ids=[

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -41,7 +41,7 @@ def test_stratification(mapper, is_vectorized):
         mapper=mapper,
         is_vectorized=is_vectorized,
     )
-    output = my_stratification(STUDENT_TABLE)[NAME]
+    output = my_stratification(STUDENT_TABLE)
     assert output.eq(STUDENT_HOUSES).all()
 
 

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -18,108 +18,74 @@ from vivarium.framework.results.stratification import Stratification
 # Tests #
 #########
 @pytest.mark.parametrize(
-    "name, sources, categories, mapper, is_vectorized, expected_output",
+    "mapper, is_vectorized",
     [
         (  # expected output for vectorized
-            NAME,
-            SOURCES,
-            CATEGORIES,
             sorting_hat_vector,
             True,
-            STUDENT_HOUSES,
         ),
         (  # expected output for non-vectorized
-            NAME,
-            SOURCES,
-            CATEGORIES,
             sorting_hat_serial,
             False,
-            STUDENT_HOUSES,
         ),
     ],
     ids=["vectorized_mapper", "non-vectorized_mapper"],
 )
-def test_stratification(name, sources, categories, mapper, is_vectorized, expected_output):
-    my_stratification = Stratification(name, sources, categories, mapper, is_vectorized)
-    output = my_stratification(STUDENT_TABLE)[name]
-    assert output.eq(expected_output).all()
+def test_stratification(mapper, is_vectorized):
+    my_stratification = Stratification(NAME, SOURCES, CATEGORIES, [], mapper, is_vectorized)
+    output = my_stratification(STUDENT_TABLE)[NAME]
+    assert output.eq(STUDENT_HOUSES).all()
 
 
 @pytest.mark.parametrize(
-    "name, sources, categories, mapper, is_vectorized, expected_exception",
+    "sources, categories",
     [
         (  # empty sources list with no defined mapper (default mapper)
-            NAME,
             [],
             CATEGORIES,
-            None,
-            True,
-            ValueError,
         ),
         (  # sources list with more than one column with no defined mapper (default mapper)
-            NAME,
             SOURCES,
             CATEGORIES,
-            None,
-            True,
-            ValueError,
         ),
         (  # empty sources list with no defined mapper (default mapper)
-            NAME,
             [],
             CATEGORIES,
-            None,
-            True,
-            ValueError,
         ),
         (  # empty categories list
-            NAME,
             SOURCES,
             [],
-            None,
-            True,
-            ValueError,
         ),
     ],
 )
-def test_stratification_init_raises(
-    name, sources, categories, mapper, is_vectorized, expected_exception
-):
-    with pytest.raises(expected_exception):
-        assert Stratification(name, sources, categories, mapper, is_vectorized)
+def test_stratification_init_raises(sources, categories):
+    with pytest.raises(ValueError):
+        assert Stratification(NAME, sources, categories, [], None, True)
 
 
 @pytest.mark.parametrize(
-    "name, sources, categories, mapper, is_vectorized, expected_exception",
+    "sources, mapper, is_vectorized, expected_exception",
     [
         (
-            NAME,
             SOURCES,
-            CATEGORIES,
             sorting_hat_bad_mapping,
             False,
             ValueError,
         ),
         (
-            NAME,
             ["middle_initial"],
-            CATEGORIES,
             sorting_hat_vector,
             True,
             KeyError,
         ),
         (
-            NAME,
             SOURCES,
-            CATEGORIES,
             sorting_hat_serial,
             True,
             Exception,
         ),
         (
-            NAME,
             SOURCES,
-            CATEGORIES,
             sorting_hat_vector,
             False,
             Exception,
@@ -132,10 +98,8 @@ def test_stratification_init_raises(
         "not_vectorized_with_serial_mapper",
     ],
 )
-def test_stratification_call_raises(
-    name, sources, categories, mapper, is_vectorized, expected_exception
-):
-    my_stratification = Stratification(name, sources, categories, mapper, is_vectorized)
+def test_stratification_call_raises(sources, mapper, is_vectorized, expected_exception):
+    my_stratification = Stratification(NAME, sources, CATEGORIES, [], mapper, is_vectorized)
     with pytest.raises(expected_exception):
         raise my_stratification(STUDENT_TABLE)
 

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -15,7 +15,11 @@ from tests.framework.results.helpers import (
     sorting_hat_vectorized,
 )
 from vivarium.framework.results.manager import ResultsManager
-from vivarium.framework.results.stratification import Stratification
+from vivarium.framework.results.stratification import (
+    Stratification,
+    get_mapped_col_name,
+    get_original_col_name,
+)
 
 
 @pytest.mark.parametrize(
@@ -152,3 +156,22 @@ def test_setting_default_stratifications(default_stratifications, mocker):
     mgr.setup(builder)
 
     assert mgr._results_context.default_stratifications == default_stratifications
+
+
+def test_get_mapped_column_name():
+    assert get_mapped_col_name("foo") == "foo_mapped_values"
+
+
+@pytest.mark.parametrize(
+    "col_name, expected",
+    [
+        ("foo_mapped_values", "foo"),
+        ("foo", "foo"),
+        ("foo_mapped_values_mapped_values", "foo_mapped_values"),
+        ("foo_mapped_values2", "foo_mapped_values2"),
+        ("_mapped_values_foo", "_mapped_values_foo"),
+        ("_mapped_values_foo_mapped_values", "_mapped_values_foo"),
+    ],
+)
+def test_get_original_col_name(col_name, expected):
+    assert get_original_col_name(col_name) == expected


### PR DESCRIPTION
## Implement excluded results via model spec

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5163

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> This implements the ability to exclude results via the model spec
with a new `stratification: excluded_categories` key.

The work got a bit bigger than expected b/c we had to handle (1) typical
results that are actual Stratification objects (2) non-typical results that
are not Stratification objects but get handled on a case-by-case bases
(e.g. ylds which you cannot stratify by cause b/c you can have multiple per
person), and (3) results that have an extra unique category that are
not explicitly requested but come "for free" (e.g. all_causes for deaths
and other_causes for disability).

At a high level, what we're doing is modifying what is happening during
ResultsContext.gather_results():

-  We extract any excluded categories for a given result measure and
drop them from the column mapping during each Stratification.__call__ 
- Then, for each (pop_filter, stratfiications) tuple that gets registered
from observations, we _filter_population to both query the defined
pop_filter and also remove any rows that have NaNs in
columns we are stratifying by.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass and I ran some small simulations against the maternal
and child models.

