### PR TITLE
raise an error if a component attempts to access a non-existent population_view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.0.3 - 09/11/24**
+
+  - Raise an error if a component attempts to access a non-existent population_view
+
 **3.0.2 - 08/27/24**
 
   - Update results docstrings

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -162,6 +162,7 @@ class Component(ABC):
 
         Returns
         -------
+        PopulationView
             The PopulationView for this component
 
         Raises

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -21,11 +21,11 @@ from loguru._logger import Logger
 from vivarium.framework.artifact import ArtifactException
 from vivarium.framework.event import Event
 from vivarium.framework.lookup import LookupTable
+from vivarium.framework.population import PopulationError, PopulationView
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
-    from vivarium.framework.population import PopulationView, SimulantData
-
+    from vivarium.framework.population import SimulantData
 
 DEFAULT_EVENT_PRIORITY = 5
 """The default priority at which events will be triggered."""
@@ -155,6 +155,27 @@ class Component(ABC):
             self._name = ".".join([base_name] + args)
 
         return self._name
+
+    @property
+    def population_view(self) -> PopulationView:
+        """Provides the PopulationView for this component.
+
+        Returns
+        -------
+            The PopulationView for this component
+
+        Raises
+        ------
+        PopulationError
+            If the component does not have access to the state table.
+        """
+        if self._population_view is None:
+            raise PopulationError(
+                f"Component '{self.name}' does not have access to the state "
+                "table. This is likely due to a failure to set columns_required "
+                "or columns_created for this component."
+            )
+        return self._population_view
 
     @property
     def sub_components(self) -> List["Component"]:
@@ -320,7 +341,7 @@ class Component(ABC):
             Callable[[Union[str, pd.DataFrame]], List[str]]
         ] = None
         self.configuration: Optional[LayeredConfigTree] = None
-        self.population_view: Optional[PopulationView] = None
+        self._population_view: Optional[PopulationView] = None
         self.lookup_tables: Dict[str, LookupTable] = {}
 
     def setup_component(self, builder: "Builder") -> None:
@@ -702,7 +723,7 @@ class Component(ABC):
             population_view_columns = None
 
         if population_view_columns is not None:
-            self.population_view = builder.population.get_view(
+            self._population_view = builder.population.get_view(
                 population_view_columns, self.population_view_query
             )
 

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 
 import pandas as pd
 
-from vivarium import Component
 from vivarium.framework.population.exceptions import PopulationError
 from vivarium.framework.population.population_view import PopulationView
 from vivarium.manager import Manager

--- a/tests/framework/components/test_component.py
+++ b/tests/framework/components/test_component.py
@@ -16,10 +16,10 @@ from tests.helpers import (
     ParameterizedByComponent,
     SingleLookupCreator,
 )
-from vivarium import Artifact, Component, InteractiveContext
-from vivarium.framework.artifact import ArtifactException
+from vivarium import Artifact, InteractiveContext
 from vivarium.framework.engine import Builder
 from vivarium.framework.lookup.table import ScalarTable
+from vivarium.framework.population import PopulationError
 
 
 def load_cooling_time(builder: Builder) -> pd.DataFrame:
@@ -150,7 +150,11 @@ def test_component_with_no_population_view():
     InteractiveContext(components=[ColumnCreator(), component])
 
     # Assert population view is not set
-    assert component.population_view is None
+    assert component._population_view is None
+
+    # Assert trying to access the population view raises an error
+    with pytest.raises(PopulationError, match=f"'{component.name}' does not have access"):
+        _ = component.population_view
 
 
 def test_component_initializer_is_not_registered_if_not_defined():


### PR DESCRIPTION
## Raise an error if a component attempts to access a non-existent population_view
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5322

### Changes and notes
- Raise an error if a component attempts to access a non-existent population_view 

### Testing
All tests pass