### PR TITLE
create resource types

### DIFF
--- a/src/vivarium/framework/randomness/stream.py
+++ b/src/vivarium/framework/randomness/stream.py
@@ -37,6 +37,7 @@ from scipy import stats
 
 from vivarium.framework.randomness.exceptions import RandomnessError
 from vivarium.framework.randomness.index_map import IndexMap
+from vivarium.framework.resource import Resource
 from vivarium.framework.utilities import rate_to_probability
 from vivarium.types import ClockTime, NumericArray
 
@@ -62,26 +63,13 @@ def get_hash(key: str) -> int:
     return int(hashlib.sha1(key.encode("utf8")).hexdigest(), 16) % max_allowable_numpy_seed
 
 
-class RandomnessStream:
+class RandomnessStream(Resource):
     """A stream for producing common random numbers.
 
     `RandomnessStream` objects provide an interface to Vivarium's
     common random number generation.  They provide a number of methods
     for doing common simulation tasks that require random numbers like
     making decisions among a number of choices.
-
-    Attributes
-    ----------
-    key
-        The name of the randomness stream.
-    clock
-        A way to get the current simulation time.
-    seed
-        An extra number used to seed the random number generation.
-    index_map
-        A key-index mapping with a fectorized hash and vectorized lookups.
-    initializes_crn_attributes
-        A boolean indicating whether the stram is used to initialize CRN attributes.
 
     Notes
     -----
@@ -105,15 +93,17 @@ class RandomnessStream:
         index_map: IndexMap,
         initializes_crn_attributes: bool = False,
     ):
+        super().__init__("stream", key)
         self.key = key
+        """The name of the randomness stream."""
         self.clock = clock
+        """A way to get the current simulation time."""
         self.seed = seed
+        """An extra number used to seed the random number generation."""
         self.index_map = index_map
+        """A key-index mapping with a vectorized hash and vectorized lookups."""
         self.initializes_crn_attributes = initializes_crn_attributes
-
-    @property
-    def name(self) -> str:
-        return f"randomness_stream_{self.key}"
+        """A boolean indicating whether the stream is used to initialize CRN attributes."""
 
     def _key(self, additional_key: Any = None) -> str:
         """Construct a hashable key from this object's state.

--- a/src/vivarium/framework/resource/resource.py
+++ b/src/vivarium/framework/resource/resource.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from vivarium.framework.resource.exceptions import ResourceError
+from dataclasses import dataclass
 
 RESOURCE_TYPES = {
     "value",
@@ -12,20 +12,30 @@ RESOURCE_TYPES = {
 }
 
 
+@dataclass
 class Resource:
-    """A generic resource.
+    """A generic resource representing a node in the dependency graph."""
 
-    These resources may be required to build up the dependency graph.
-    """
+    resource_type: str
+    """The type of the resource."""
+    name: str
+    """The name of the resource."""
 
-    def __init__(self, type: str, name: str):
-        if type not in RESOURCE_TYPES:
-            raise ResourceError(f"Unknown resource type: {type}")
+    @property
+    def resource_id(self) -> str:
+        """The long name of the resource, including the type."""
+        return f"{self.resource_type}.{self.name}"
 
-        self.type = type
-        """The type of the resource."""
-        self.name = name
-        """The name of the resource."""
 
-    def __str__(self) -> str:
-        return f"{self.type}.{self.name}"
+class NullResource(Resource):
+    """A node in the dependency graph that does not produce any resources."""
+
+    def __init__(self, index: int):
+        super().__init__("null", f"{index}")
+
+
+class Column(Resource):
+    """A resource representing a column in the state table."""
+
+    def __init__(self, name: str):
+        super().__init__("column", name)

--- a/tests/framework/resource/test_resource.py
+++ b/tests/framework/resource/test_resource.py
@@ -1,6 +1,6 @@
 from vivarium.framework.resource import Resource
 
 
-def test_to_string() -> None:
+def test_resource_id() -> None:
     resource = Resource("value_source", "test")
-    assert str(resource) == "value_source.test"
+    assert resource.resource_id == "value_source.test"

--- a/tests/framework/resource/test_resource_group.py
+++ b/tests/framework/resource/test_resource_group.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-import pytest
+from datetime import datetime
 
 from vivarium.framework.randomness import RandomnessStream
 from vivarium.framework.randomness.index_map import IndexMap
-from vivarium.framework.resource import Resource
-from vivarium.framework.resource.exceptions import ResourceError
 from vivarium.framework.resource.group import ResourceGroup
-from vivarium.framework.values import Pipeline
+from vivarium.framework.resource.resource import Column
+from vivarium.framework.values import Pipeline, ValueSource
 
 
 def dummy_producer() -> str:
@@ -18,11 +17,11 @@ def test_resource_group() -> None:
     r_type = "column"
     r_names = [str(i) for i in range(5)]
     r_producer = dummy_producer
-    r_dependencies: list[str | Pipeline | RandomnessStream | Resource] = [
-        "an_interesting_column",
+    r_dependencies = [
+        Column("an_interesting_column"),
         Pipeline("baz"),
-        RandomnessStream("bar", lambda x: x, 1, IndexMap()),
-        Resource("value_source", "foo"),
+        RandomnessStream("bar", lambda: datetime.now(), 1, IndexMap()),
+        ValueSource("foo"),
     ]
 
     rg = ResourceGroup(r_type, r_names, r_producer, r_dependencies)
@@ -37,24 +36,3 @@ def test_resource_group() -> None:
         "value_source.foo",
     ]
     assert list(rg) == rg.names
-
-
-@pytest.mark.parametrize(
-    "dependency, expected_key",
-    [
-        ("an_interesting_column", "column.an_interesting_column"),
-        (Pipeline("baz"), "value.baz"),
-        (RandomnessStream("bar", lambda x: x, 1, IndexMap()), "stream.bar"),
-        (Resource("value_source", "foo"), "value_source.foo"),
-    ],
-)
-def test__get_dependency_key(
-    dependency: str | Pipeline | RandomnessStream | Resource, expected_key: str
-) -> None:
-    key = ResourceGroup._get_dependency_key(dependency)
-    assert key == expected_key
-
-
-def test__get_dependency_key_unknown_type() -> None:
-    with pytest.raises(ResourceError, match="unknown type"):
-        ResourceGroup._get_dependency_key(1)  # type: ignore [arg-type]


### PR DESCRIPTION
## Create resource types
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5380

### Changes and notes
- Creates Resource types for each of type of resource
- Makes Pipeline and RandomnessStream inherit from Resource
- Simplified typing of `required_resources` to be `Iterable[str | Resource]
- Simplified logic to convert from deprecated resource requirements in
  initializer registration

### Testing
All existing tests pass
Added one new test