### PR TITLE
fix type handling for clocktime and step_size

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
   - Fix mypy errors in vivarium/framework/lookup/table.py
   - Typing changes in vivarium/framework/lookup/interpolation.py
   - Fix broken build from LayeredConfigTree typing
+  - Fix type handling for clock and step size in vivarium/framework/event.py
 
 **3.0.15 - 10/24/24**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.0.16 - 10/31/24**
+**3.0.16 - 10/30/24**
 
   - Bugfix to prevent a LookupTable from changing order of the value columns
   - Fix mypy errors in vivarium/framework/lookup/table.py

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -121,9 +121,7 @@ class EventChannel:
         event_time: ClockTime
         if isinstance(clock, int) and isinstance(step_size, int):
             event_time = clock + step_size
-        elif isinstance(clock, (pd.Timestamp, datetime)) and isinstance(
-            step_size, (pd.Timedelta, timedelta)
-        ):
+        elif isinstance(clock, datetime) and isinstance(step_size, timedelta):
             event_time = clock + step_size
         else:
             raise ValueError(

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -30,7 +30,7 @@ For more information, see the associated event
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pandas as pd
@@ -115,11 +115,28 @@ class EventChannel:
         """
         if not user_data:
             user_data = {}
+
+        clock = self.manager.clock()
+        step_size = self.manager.step_size()
+        event_time: ClockTime
+        if isinstance(clock, int) and isinstance(step_size, int):
+            event_time = clock + step_size
+        elif isinstance(clock, (pd.Timestamp, datetime)) and isinstance(
+            step_size, (pd.Timedelta, timedelta)
+        ):
+            event_time = clock + step_size
+        else:
+            raise ValueError(
+                f"Clock ({type(clock)}) and step size ({type(step_size)}) are not compatible."
+            )
+
         e = Event(
             index,
             user_data,
-            self.manager.clock() + self.manager.step_size(),  # type: ignore[operator, arg-type]
-            self.manager.step_size(),
+            # self.manager.clock() + self.manager.step_size(),
+            event_time,
+            # self.manager.step_size(),
+            step_size,
         )
 
         for priority_bucket in self.listeners:

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -133,9 +133,7 @@ class EventChannel:
         e = Event(
             index,
             user_data,
-            # self.manager.clock() + self.manager.step_size(),
             event_time,
-            # self.manager.step_size(),
             step_size,
         )
 

--- a/src/vivarium/types.py
+++ b/src/vivarium/types.py
@@ -22,5 +22,5 @@ NumberLike = Union[
 # todo need to use TypeVars here
 Time = Union[pd.Timestamp, datetime]
 Timedelta = Union[pd.Timedelta, timedelta]
-ClockTime = Union[Time, Number]
-ClockStepSize = Union[Timedelta, Number]
+ClockTime = Union[Time, int]
+ClockStepSize = Union[Timedelta, int]

--- a/src/vivarium/types.py
+++ b/src/vivarium/types.py
@@ -19,7 +19,7 @@ NumberLike = Union[
     float,
     int,
 ]
-# todo need to use TypeVars here
+# TODO: [MIC-5481] need to use TypeVars here
 Time = Union[pd.Timestamp, datetime]
 Timedelta = Union[pd.Timedelta, timedelta]
 ClockTime = Union[Time, int]


### PR DESCRIPTION
## Type handling for clock and step_size in event.py

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5480

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

