### PR TITLE
wire up managers to be able to create columns

### DIFF
--- a/src/vivarium/framework/plugins.py
+++ b/src/vivarium/framework/plugins.py
@@ -95,6 +95,10 @@ class PluginConfigurationError(VivariumError):
 
 
 class PluginManager(Manager):
+    @property
+    def name(self) -> str:
+        return "plugin_manager"
+
     def __init__(
         self,
         plugin_configuration: (

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -87,7 +87,6 @@ class InitializerComponentSet:
                 f"You provided {initializer} which is of type {type(initializer)}."
             )
         component = initializer.__self__
-        # TODO: consider if we can initialize the tracked column with a component instead
         # TODO: raise error once all active Component implementations have been refactored
         # if not (isinstance(component, Component) or isinstance(component, PopulationManager)):
         #     raise AttributeError(
@@ -161,6 +160,10 @@ class PopulationManager(Manager):
         """The name of this component."""
         return "population_manager"
 
+    @property
+    def columns_created(self) -> list[str]:
+        return ["tracked"]
+
     def setup(self, builder: Builder) -> None:
         """Registers the population manager with other vivarium systems."""
         self.clock = builder.time.clock()
@@ -184,7 +187,7 @@ class PopulationManager(Manager):
         )
 
         self.register_simulant_initializer(
-            self.on_initialize_simulants, creates_columns="tracked"
+            self.on_initialize_simulants, creates_columns=self.columns_created
         )
         self._view = self.get_view("tracked")
 

--- a/src/vivarium/manager.py
+++ b/src/vivarium/manager.py
@@ -7,15 +7,18 @@ A base Manager class to be used to create manager for use in ``vivarium``
 simulations.
 
 """
+from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
+    from vivarium.framework.population import SimulantData
 
 
-class Manager:
-    CONFIGURATION_DEFAULTS: Dict[str, Any] = {}
+class Manager(ABC):
+    CONFIGURATION_DEFAULTS: dict[str, Any] = {}
     """A dictionary containing the defaults for any configurations managed by this
     manager. An empty dictionary indicates no managed configurations.
 
@@ -26,25 +29,57 @@ class Manager:
     ##############
 
     @property
-    def configuration_defaults(self) -> Dict[str, Any]:
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @property
+    def configuration_defaults(self) -> dict[str, Any]:
         """Provides a dictionary containing the defaults for any configurations
         managed by this manager.
 
         These default values will be stored at the `component_configs` layer of the
         simulation's LayeredConfigTree.
-
-        Returns
-        -------
-            A dictionary containing the defaults for any configurations managed by
-            this manager.
         """
         return self.CONFIGURATION_DEFAULTS
+
+    @property
+    def columns_created(self) -> list[str]:
+        """Provides names of columns created by the manager."""
+        return []
 
     #####################
     # Lifecycle methods #
     #####################
 
-    def setup(self, builder: "Builder") -> None:
+    def setup(self, builder: Builder) -> None:
+        """Defines custom actions this manager needs to run during the setup
+        lifecycle phase.
+
+        This method is intended to be overridden by subclasses to perform any
+        necessary setup operations specific to the manager. By default, it
+        does nothing.
+
+        Parameters
+        ----------
+        builder
+            The builder object used to set up the manager.
+        """
+        pass
+
+    def on_initialize_simulants(self, pop_data: SimulantData) -> None:
+        """
+        Method that vivarium will run during simulant initialization.
+
+        This method is intended to be overridden by subclasses if there are
+        operations they need to perform specifically during the simulant
+        initialization phase.
+
+        Parameters
+        ----------
+        pop_data : SimulantData
+            The data associated with the simulants being initialized.
+        """
         pass
 
 


### PR DESCRIPTION
## Wire up managers to be able to create columns
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5464

### Changes and notes
- Gives `PluginManager` a name
- Adds abstract `name` property to `Manager`
- Adds `columns_created` property to `Manager`
- Adds `on_initialize_simulants()` method to `Manager`

### Testing
All tests pass