### PR TITLE
Type-hinting: remove population files from exclude block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,6 @@ exclude = [
     'src/vivarium/examples/disease_model/observer.py',
     'src/vivarium/examples/disease_model/population.py',
     'src/vivarium/examples/disease_model/risk.py',
-    'src/vivarium/framework/population/manager.py',
-    'src/vivarium/framework/population/population_view.py',
     'src/vivarium/interface/cli.py',
     'src/vivarium/interface/interactive.py',
     'src/vivarium/testing_utilities.py',


### PR DESCRIPTION
## Type-hinting: remove population files from exclude block
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: type-hinting
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5342

### Changes and notes
I neglected to remove these lines from the pyproject.toml when I
completed this ticket. mypy still passes when they're removed

### Testing
mypy passes