### PR TITLE
change Event to a frozen dataclass

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @collijk @hussain-jafari @patricktnast @rmudambi @stevebachmeier
+* @albrja @hussain-jafari @patricktnast @rmudambi @stevebachmeier

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.3.7 - 02/26/25**
+
+  - Change Event class to a frozen dataclass
+
 **3.3.6 - 02/25/25**
 
   - Type-hinting: Fix mypy errors in tests/framework/randomness/test_stream.py

--- a/src/vivarium/framework/event.py
+++ b/src/vivarium/framework/event.py
@@ -29,8 +29,9 @@ For more information, see the associated event
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
@@ -42,7 +43,8 @@ if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
 
 
-class Event(NamedTuple):
+@dataclass(frozen=True)
+class Event:
     """An Event object represents the context of an event.
 
     Events themselves are just a bundle of data.  They must be emitted
@@ -50,8 +52,7 @@ class Event(NamedTuple):
     to respond to them.
     """
 
-    # FIXME [MIC-5468]: fix index type hint for mypy
-    index: pd.Index[int]  # type: ignore[assignment]
+    index: pd.Index[int]
     """An index into the population table containing all simulants affected by this event."""
     user_data: dict[str, Any]
     """Any additional data provided by the user about the event."""


### PR DESCRIPTION
## Change Event to a frozen dataclass

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5468

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The only reason to freeze is b/c a single test asserted that an Event
is immutable. If we don't care about this, I can instead unfreeze and
remove that test. However, it makes philosophical sense to me that
you would never want to change an Event.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

