### PR TITLE
raise error if requested pipeline does not exist in interactive context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.3.11 - 03/13/25**
+
+  - Bugfix: Raise an error in InteractiveContext if a requested pipeline does not exist
+
 **3.3.10 - 03/11/25**
 
   - Type-hinting: Fix mypy errors in tests/framework/test_state_machine.py

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -182,6 +182,8 @@ class InteractiveContext(SimulationContext):
 
     def get_value(self, value_pipeline_name: str) -> Pipeline:
         """Get the value pipeline associated with the given name."""
+        if value_pipeline_name not in self.list_values():
+            raise ValueError(f"No value pipeline '{value_pipeline_name}' registered.")
         return self._values.get_value(value_pipeline_name)
 
     def list_events(self) -> list[str]:

--- a/tests/interface/test_interactive.py
+++ b/tests/interface/test_interactive.py
@@ -1,0 +1,15 @@
+import pytest
+
+from vivarium import InteractiveContext
+from vivarium.framework.values import Pipeline
+
+
+def test_list_values():
+    sim = InteractiveContext()
+    # a 'simulant_step_size' value is created by default upon setup
+    assert sim.list_values() == ["simulant_step_size"]
+    assert isinstance(sim.get_value("simulant_step_size"), Pipeline)
+    with pytest.raises(ValueError, match="No value pipeline 'foo' registered."):
+        sim.get_value("foo")
+    # ensure that 'foo' did not get added to the list of values
+    assert sim.list_values() == ["simulant_step_size"]


### PR DESCRIPTION
## Raise if requested pipeline does not exist in InteractiveContext

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5782

### Changes and notes
Currently, when in an InteractiveContext, calling `sim.get_value("foo")` where
'foo' is a pipeline that was never registered, it returns and empty 
pipeline and adds that empty pipeline to the list returned from
`sim.get_values()`. That's bogus.

this simply checks that the pipeline exists first and then raises
a ValueError if it doesn't. 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
added a test
