### PR TITLE
Albrja/mic-5585/load-backup-method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.3.14 - 03/31/25**
+
+  - Feature: Add classmethod to InteractiveContext to create instance from a backup
+
 **3.3.13 - 03/21/25**
 
   - Type-hinting: Fix mypy errors in tests/framework/results/test_observer.py

--- a/src/vivarium/framework/engine.py
+++ b/src/vivarium/framework/engine.py
@@ -354,6 +354,13 @@ class SimulationContext:
     def get_number_of_steps_remaining(self) -> int:
         return self._clock.time_steps_remaining
 
+    @classmethod
+    def load_from_backup(cls, backup_path: Path) -> "SimulationContext":
+        """Load a simulation context from a backup file."""
+        with open(backup_path, "rb") as f:
+            backup: SimulationContext = dill.load(f)
+        return backup
+
 
 class Builder:
     """Toolbox for constructing and configuring simulation components.

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -6,6 +6,7 @@ from time import time
 import dill
 import pandas as pd
 import pytest
+import pytest_mock
 
 from tests.framework.results.helpers import (
     FAMILIARS,
@@ -441,6 +442,22 @@ def test_get_results_formatting(SimulationContext, base_config):
         assert (df.loc[~filter, VALUE_COLUMN] == 0).all()
         # Check that expected groups' values are a multiple of the number of steps
         assert (df.loc[filter, VALUE_COLUMN] % num_steps == 0).all()
+
+
+def test_SimulationContext_load_from_backup(
+    mocker: pytest_mock.MockFixture,
+    SimulationContext: SimulationContext_,
+    tmpdir: Path,
+):
+    # TODO MIC-5216: Remove mocks when we can use dill in pytest.
+    mocker.patch("vivarium.framework.engine.dill.dump")
+    mocker.patch("vivarium.framework.engine.dill.load", return_value=SimulationContext())
+    sim = SimulationContext()
+    backup_path = tmpdir / "backup.pkl"
+    sim.write_backup(backup_path)
+    # Load from backup
+    sim_backup = SimulationContext.load_from_backup(backup_path)
+    assert isinstance(sim_backup, SimulationContext)
 
 
 ####################


### PR DESCRIPTION
## Albrja/mic-5585/load-backup-method

### Add class method to InteractiveContext to create instance from backup
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5585

### Changes and notes
-adds class method to create instance of InteractiveContext from class method

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

