### PR TITLE
Albrja/mic-5621/observer-get-configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.4.3 - 05/23/25**
+
+  - Feature: Override get_configuration method in Observer
+
 **3.4.2 - 05/22/25**
 
   - Type-hinting: Fix mypy errors in frameworking/testing_utilties.py

--- a/src/vivarium/examples/disease_model/observer.py
+++ b/src/vivarium/examples/disease_model/observer.py
@@ -1,6 +1,7 @@
 # mypy: ignore-errors
 from typing import Any
 
+from layered_config_tree.main import LayeredConfigTree
 import pandas as pd
 
 from vivarium.framework.engine import Builder
@@ -62,6 +63,13 @@ class YllsObserver(Observer):
     #################
     # Setup methods #
     #################
+
+    def get_configuration(self, builder: "Builder") -> LayeredConfigTree | None:
+        # Use component configuration
+
+        if self.name in builder.configuration:
+            return builder.configuration.get_tree(self.name)
+        return None
 
     def register_observations(self, builder: Builder) -> None:
         builder.results.register_adding_observation(

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -1,7 +1,7 @@
 """
 =========
 Observers
-=========
+=========`
 
 An observer is a component that is responsible for registering
 :class:`observations <vivarium.framework.results.observation.Observation>`
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
+
+from layered_config_tree.main import LayeredConfigTree
 
 from vivarium import Component
 
@@ -50,6 +52,10 @@ class Observer(Component, ABC):
     def get_configuration_name(self) -> str:
         """Return the name of a concrete observer for use in the configuration"""
         return self.name.split("_observer")[0]
+
+    def get_configuration(self, builder: Builder) -> LayeredConfigTree:
+        config = builder.configuration["stratification"][self.get_configuration_name()]
+        return LayeredConfigTree(config)
 
     @abstractmethod
     def register_observations(self, builder: Builder) -> None:

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -183,6 +183,7 @@ def test_setup_components(mocker: MockerFixture) -> None:
     builder = mocker.Mock()
     builder.configuration = {}
     mocker.patch("vivarium.framework.results.observer.Observer.set_results_dir")
+    mocker.patch("vivarium.framework.results.observer.Observer.get_configuration")
     mock_a = MockComponentA("test_a")
     mock_b = MockComponentB("test_b")
     components = OrderedComponentSet(mock_a, mock_b)
@@ -206,13 +207,12 @@ def test_apply_configuration_defaults() -> None:
 
 def test_apply_configuration_defaults_no_op() -> None:
     config = build_simulation_configuration()
-    c = config.to_dict()
     cm = ComponentManager()
     cm._configuration = config
     component = MockComponentA()
 
     cm.apply_configuration_defaults(component)
-    assert config.to_dict() == c
+    assert config.to_dict() == component.configuration_defaults
 
 
 def test_apply_configuration_defaults_duplicate() -> None:
@@ -317,6 +317,6 @@ def test_component_manager_add_components_duplicated(components: list[Component]
     cm._configuration = config
     with pytest.raises(
         ComponentConfigError,
-        match=f"Attempting to add a component with duplicate name: {MockComponentA()}",
+        match="is attempting to set the configuration value mock_component_a, but it has already been set by mock_component_a",
     ):
         cm.add_components(components)

--- a/tests/framework/results/test_observer.py
+++ b/tests/framework/results/test_observer.py
@@ -1,7 +1,11 @@
+from typing import Any
+
 import pytest
 from layered_config_tree.main import LayeredConfigTree
 from pytest_mock import MockerFixture
 
+from vivarium import InteractiveContext
+from vivarium.framework.components.manager import ComponentConfigError
 from vivarium.framework.engine import Builder
 from vivarium.framework.results.observer import Observer
 
@@ -17,12 +21,19 @@ class TestDefaultObserverStratifications(Observer):
 
 
 class TestObserverStratifications(Observer):
+    @property
+    def configuration_defaults(self) -> dict[str, Any]:
+        return {
+            "stratification": {
+                self.get_configuration_name(): {
+                    "exclude": ["baz"],
+                    "include": ["foo"],
+                },
+            },
+        }
+
     def register_observations(self, builder: Builder) -> None:
         pass
-
-    @property
-    def configuration_defaults(self) -> dict[str, str]:
-        return {"foo": "bar"}
 
 
 def test_observer_instantiation() -> None:
@@ -54,3 +65,34 @@ def test_set_results_dir(
     observer.set_results_dir(builder)
 
     assert observer.results_dir == results_dir
+
+
+def test_observer_get_configuration(
+    base_config: LayeredConfigTree,
+) -> None:
+
+    observer = TestObserverStratifications()
+    sim = InteractiveContext(
+        base_config,
+        components=[observer],
+    )
+    sim_observer_config = sim.configuration["stratification"][
+        observer.get_configuration_name()
+    ]
+    # Observer.configuration calls get_configuration
+    observer_config = observer.configuration
+    assert observer_config is not None
+    assert observer_config.to_dict() == dict(sim_observer_config)
+
+
+def test_duplicated_observer_error(base_config: LayeredConfigTree) -> None:
+    observer1 = TestObserverStratifications()
+    observer2 = TestObserverStratifications()
+    with pytest.raises(
+        ComponentConfigError,
+        match="is attempting to set the configuration value test, but it has already been set",
+    ):
+        InteractiveContext(
+            base_config,
+            components=[observer1, observer2],
+        )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -18,10 +18,6 @@ class MockComponentA(Observer):
     def name(self) -> str:
         return self._name
 
-    @property
-    def configuration_defaults(self) -> dict[str, Any]:
-        return {}
-
     def __init__(self, *args: Any, name: str = "mock_component_a") -> None:
         super().__init__()
         self._name = name


### PR DESCRIPTION
## Albrja/mic-5621/observer-get-configuration

### Overrides get_configuration method in observer
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5621

### Changes and notes
-overrides get_configuration method in Observer class
-updates test component Observer classes

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

