### PR TITLE
Fix dataframegroupby.apply future warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.4.7 - 07/17/25**
+
+  - Hush FutureWarnings: add include_groups=False to apply call in StratifiedObservation
+
 **3.4.6 - 07/15/25**
 
   - Support pinning of vivarium_build_utils; pin vivarium_build_utils>=1.1.0,<2.0.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.4.7 - 07/17/25**
+**3.4.7 - 07/18/25**
 
   - Hush FutureWarnings: add include_groups=False to apply call in StratifiedObservation
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         "vivarium_build_utils>=1.1.0,<2.0.0",
         "layered_config_tree>=2.1.0",
         "numpy<2.0.0",
-        "pandas",
+        "pandas>=2.2.0",
         "pyyaml>=5.1",
         "scipy",
         "click",

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -340,7 +340,7 @@ class StratifiedObservation(Observation):
         aggregates = (
             pop_groups[aggregator_sources].apply(aggregator).fillna(0.0)  # type: ignore [arg-type]
             if aggregator_sources
-            else pop_groups.apply(aggregator)  # type: ignore [arg-type]
+            else pop_groups.apply(aggregator, include_groups=False)  # type: ignore [arg-type]
         ).astype(float)
         return aggregates
 


### PR DESCRIPTION
## Fix dataframegroupby.apply future warnings

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6165

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

The issue:
https://stackoverflow.com/questions/77969964/deprecation-warning-with-groupby-apply
https://pandas.pydata.org/docs/reference/api/pandas.core.groupby.DataFrameGroupBy.apply.html

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
All tests pass w/ the changes

