### PR TITLE
Use Observation requirements to limit expanded state table

### DIFF
--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -195,7 +195,6 @@ class ResultsContext:
         when: str,
         requires_columns: list[str],
         requires_values: list[Pipeline],
-        # todo add all requirements arguments here explicitly
         **kwargs: Any,
     ) -> Observation:
         """Add an observation to the results context.
@@ -257,7 +256,10 @@ class ResultsContext:
         return observation
 
     def gather_results(
-        self, population: pd.DataFrame, event: Event, event_observations: list[Observation]
+        self,
+        population: pd.DataFrame,
+        lifecycle_state: str,
+        event_observations: list[Observation],
     ) -> Generator[
         tuple[
             pd.DataFrame | None,
@@ -278,10 +280,8 @@ class ResultsContext:
         ----------
         population
             The current population DataFrame.
-        lifecycle_phase
-            The current lifecycle phase.
-        event
-            The current Event.
+        lifecycle_state
+            The current lifecycle state.
         event_observations
             List of observations to be gathered for this specific event. Note that this
             excludes all observations whose `to_observe` method returns False.
@@ -312,7 +312,7 @@ class ResultsContext:
         # Optimization: We store all the producers by pop_filter and stratifications
         # so that we only have to apply them once each time we compute results.
         for (pop_filter, stratification_names), observations in self.observations[
-            event.name
+            lifecycle_state
         ].items():
             # Results production can be simplified to
             # filter -> groupby -> aggregate in all situations we've seen.

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -294,9 +294,11 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         requires_columns
-            List of the state table columns that are required by either the `pop_filter` or the `aggregator`.
+            List of the state table columns that are required by either the `pop_filter` or the
+            `results_gatherer`.
         requires_values
-            List of the value pipelines that are required by either the `pop_filter` or the `aggregator`.
+            List of the value pipelines that are required by either the `pop_filter` or the
+            `results_gatherer`.
         results_gatherer
             Function that gathers the latest observation results.
         results_updater
@@ -438,7 +440,6 @@ class ResultsInterface(Interface):
         to_observe
             Function that determines whether to perform an observation on this Event.
         """
-        included_columns = ["event_time"] + requires_columns + requires_values
         self._manager.register_observation(
             observation_type=ConcatenatingObservation,
             is_stratified=False,
@@ -448,7 +449,6 @@ class ResultsInterface(Interface):
             requires_columns=requires_columns,
             requires_values=requires_values,
             results_formatter=results_formatter,
-            included_columns=included_columns,
             to_observe=to_observe,
         )
 

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -419,7 +419,7 @@ class ResultsManager(Manager):
         """Add required resources to the manager's list of required columns and values."""
         if len(target) == 0:
             return  # do nothing on empty lists
-        target_set = set(target) - {"event_time", "current_time", "event_step_size"}
+        target_set = set(target)
         if target_type == SourceType.COLUMN:
             self._required_columns.update(target_set)
         elif target_type == SourceType.VALUE:

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -144,27 +144,38 @@ class ResultsManager(Manager):
 
     def on_time_step_prepare(self, event: Event) -> None:
         """Define the listener callable for the time_step__prepare phase."""
-        self.gather_results(lifecycle_states.TIME_STEP_PREPARE, event)
+        self.gather_results(event)
 
     def on_time_step(self, event: Event) -> None:
         """Define the listener callable for the time_step phase."""
-        self.gather_results(lifecycle_states.TIME_STEP, event)
+        self.gather_results(event)
 
     def on_time_step_cleanup(self, event: Event) -> None:
         """Define the listener callable for the time_step__cleanup phase."""
-        self.gather_results(lifecycle_states.TIME_STEP_CLEANUP, event)
+        self.gather_results(event)
 
     def on_collect_metrics(self, event: Event) -> None:
         """Define the listener callable for the collect_metrics phase."""
-        self.gather_results(lifecycle_states.COLLECT_METRICS, event)
+        self.gather_results(event)
 
-    def gather_results(self, lifecycle_phase: str, event: Event) -> None:
+    def gather_results(self, event: Event) -> None:
         """Update existing results with any new results."""
-        population = self._prepare_population(event)
+        event_observations = self._results_context.get_observations(event)
+        if not event_observations:
+            return
+
+        required_columns = self._results_context.get_required_columns(
+            event_observations, self._required_columns
+        )
+        required_values = self._results_context.get_required_values(
+            event_observations, self._required_values
+        )
+        population = self._prepare_population(event, required_columns, required_values)
         if population.empty:
             return
+
         for results_group, measure, updater in self._results_context.gather_results(
-            population, lifecycle_phase, event
+            population, event, event_observations
         ):
             if results_group is not None and measure is not None and updater is not None:
                 self._raw_results[measure] = updater(
@@ -322,8 +333,7 @@ class ResultsManager(Manager):
         """Manager-level observation registration.
 
         Adds an observation to the
-        :class:`ResultsContext <vivarium.framework.results.context.ResultsContext>`
-        as well as the observation's required resources to this manager.
+        :class:`ResultsContext <vivarium.framework.results.context.ResultsContext>`.
 
         Parameters
         ----------
@@ -341,13 +351,22 @@ class ResultsManager(Manager):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         requires_columns
-            List of the state table columns that are required by either the `pop_filter` or the `aggregator`.
+            List of the state table columns that are required to compute the observation.
         requires_values
-            List of the value pipelines that are required by either the `pop_filter` or the `aggregator`.
+            List of the value pipelines that are required to compute the observation.
         **kwargs
             Additional keyword arguments to be passed to the observation's constructor.
         """
         self.logger.debug(f"Registering observation {name}")
+
+        if any(not isinstance(column, str) for column in requires_columns):
+            raise TypeError(
+                f"All required columns must be strings, but got {requires_columns} when registering observation {name}."
+            )
+        if any(not isinstance(value, str) for value in requires_values):
+            raise TypeError(
+                f"All required values must be strings, but got {requires_values} when registering observation {name}."
+            )
 
         if is_stratified:
             # Resolve required stratifications and add to kwargs dictionary
@@ -366,14 +385,13 @@ class ResultsManager(Manager):
             del kwargs["additional_stratifications"]
             del kwargs["excluded_stratifications"]
 
-        self._add_resources(requires_columns, SourceType.COLUMN)
-        self._add_resources(requires_values, SourceType.VALUE)
-
         self._results_context.register_observation(
             observation_type=observation_type,
             name=name,
             pop_filter=pop_filter,
             when=when,
+            requires_columns=requires_columns,
+            requires_values=[self.get_value(value) for value in requires_values],
             **kwargs,
         )
 
@@ -409,18 +427,36 @@ class ResultsManager(Manager):
         elif target_type == SourceType.VALUE:
             self._required_values.update([self.get_value(target) for target in target_set])
 
-    def _prepare_population(self, event: Event) -> pd.DataFrame:
+    def _prepare_population(
+        self, event: Event, required_columns: list[str], required_values: list[Pipeline]
+    ) -> pd.DataFrame:
         """Prepare the population for results gathering."""
-        population = self.population_view.subview(list(self._required_columns)).get(
-            event.index
-        )
-        population["current_time"] = self.clock()
-        population["event_step_size"] = event.step_size
-        population["event_time"] = self.clock() + event.step_size  # type: ignore [operator]
+        required_columns = required_columns.copy()
+        population = pd.DataFrame(index=event.index)
+
+        if "current_time" in required_columns:
+            population["current_time"] = self.clock()
+            required_columns.remove("current_time")
+        if "event_step_size" in required_columns:
+            population["event_step_size"] = event.step_size
+            required_columns.remove("event_step_size")
+        if "event_time" in required_columns:
+            population["event_time"] = self.clock() + event.step_size  # type: ignore [operator]
+            required_columns.remove("event_time")
+
         for k, v in event.user_data.items():
-            population[k] = v
-        for pipeline in self._required_values:
+            if k in required_columns:
+                population[k] = v
+                required_columns.remove(k)
+
+        for pipeline in required_values:
             population[pipeline.name] = pipeline(event.index)
+
+        if required_columns:
+            population = pd.concat(
+                [self.population_view.subview(required_columns).get(event.index), population],
+                axis=1,
+            )
         return population
 
     def _warn_check_stratifications(

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -161,7 +161,7 @@ class ResultsManager(Manager):
     def gather_results(self, event: Event) -> None:
         """Update existing results with any new results."""
         event_observations = self._results_context.get_observations(event)
-        if not event_observations:
+        if not event_observations or event.index.empty:
             return
 
         required_columns = self._results_context.get_required_columns(
@@ -171,11 +171,9 @@ class ResultsManager(Manager):
             event_observations, self._required_values
         )
         population = self._prepare_population(event, required_columns, required_values)
-        if population.empty:
-            return
 
         for results_group, measure, updater in self._results_context.gather_results(
-            population, event, event_observations
+            population, event.name, event_observations
         ):
             if results_group is not None and measure is not None and updater is not None:
                 self._raw_results[measure] = updater(

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -72,6 +72,19 @@ class Hogwarts(Component):
             "potion_power",
         ]
 
+    def setup(self, builder: Builder) -> None:
+        self.grade = builder.value.register_value_producer(
+            "grade",
+            source=lambda index: self.population_view.get(index)["exam_score"].map(
+                lambda x: x // 10
+            ),
+            requires_columns=["exam_score"],
+        )
+
+    def grade_source(self, index: pd.Index[int]) -> pd.Series[str]:
+        pass_mask = self.population_view.get(index)["exam_score"] > 65
+        return pass_mask.map({True: "pass", False: "fail"})
+
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:
         size = len(pop_data.index)
         initialization_data = pd.DataFrame(

--- a/tests/framework/results/helpers.py
+++ b/tests/framework/results/helpers.py
@@ -82,7 +82,7 @@ class Hogwarts(Component):
         )
 
     def grade_source(self, index: pd.Index[int]) -> pd.Series[str]:
-        pass_mask = self.population_view.get(index)["exam_score"] > 65
+        pass_mask = self.population_view.get(index)["exam_score"] > 6
         return pass_mask.map({True: "pass", False: "fail"})
 
     def on_initialize_simulants(self, pop_data: SimulantData) -> None:

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -343,7 +343,9 @@ def test_adding_observation_gather_results(
         )
 
     i = 0
-    for result, _measure, _updater in ctx.gather_results(population, event, [observation]):
+    for result, _measure, _updater in ctx.gather_results(
+        population, event.name, [observation]
+    ):
         assert result is not None
         assert all(
             math.isclose(actual_result, expected_result, rel_tol=0.0001)
@@ -382,7 +384,9 @@ def test_concatenating_observation_gather_results(event: Event) -> None:
     filtered_pop = population.query(pop_filter)
 
     i = 0
-    for result, _measure, _updater in ctx.gather_results(population, event, [observation]):
+    for result, _measure, _updater in ctx.gather_results(
+        population, event.name, [observation]
+    ):
         assert result is not None
         assert result.equals(filtered_pop[["event_time"] + included_cols])
         i += 1
@@ -476,7 +480,9 @@ def test_gather_results_partial_stratifications_in_results(
         results_formatter=lambda: None,
     )
 
-    for results, _measure, _formatter in ctx.gather_results(population, event, [observation]):
+    for results, _measure, _formatter in ctx.gather_results(
+        population, event.name, [observation]
+    ):
         assert results is not None
         unladen_results = results.reset_index().query('familiar=="unladen_swallow"')
         assert len(unladen_results) > 0
@@ -506,7 +512,9 @@ def test_gather_results_with_empty_pop_filter(event: Event) -> None:
         results_formatter=lambda: None,
     )
 
-    for result, _measure, _updater in ctx.gather_results(population, event, [observation]):
+    for result, _measure, _updater in ctx.gather_results(
+        population, event.name, [observation]
+    ):
         assert not result
 
 
@@ -537,7 +545,7 @@ def test_gather_results_with_no_stratifications(event: Event) -> None:
             list(
                 result
                 for result, _measure, _updater in ctx.gather_results(
-                    population, event, [observation]
+                    population, event.name, [observation]
                 )
             )
         )
@@ -586,7 +594,7 @@ def test_bad_aggregator_stratification(event: Event) -> None:
 
     with pytest.raises(KeyError, match="height"):
         for result, _measure, _updater in ctx.gather_results(
-            population, event, [observation]
+            population, event.name, [observation]
         ):
             print(result)
 
@@ -664,24 +672,19 @@ def test_get_required_columns() -> None:
         **register_observation_kwargs,  # type: ignore[arg-type]
     )
 
-    default_columns = {"a", "e"}
+    default_cols = {"a", "e"}
 
     # Test with default columns
-    assert set(ctx.get_required_columns([obs1, obs2], default_columns)) == {
-        "a",
-        "b",
-        "c",
-        "e",
-    }
-    assert set(ctx.get_required_columns([obs3], default_columns)) == {"a", "d", "e"}
-    assert set(ctx.get_required_columns([obs1, obs2, obs3], default_columns)) == {
+    assert set(ctx.get_required_columns([obs1, obs2], default_cols)) == {"a", "b", "c", "e"}
+    assert set(ctx.get_required_columns([obs3], default_cols)) == {"a", "d", "e"}
+    assert set(ctx.get_required_columns([obs1, obs2, obs3], default_cols)) == {
         "a",
         "b",
         "c",
         "d",
         "e",
     }
-    assert set(ctx.get_required_columns([], default_columns)) == {"a", "e"}
+    assert set(ctx.get_required_columns([], default_cols)) == {"a", "e"}
 
     # Test with no default columns
     assert set(ctx.get_required_columns([obs1, obs2], set())) == {"a", "b", "c"}
@@ -690,7 +693,7 @@ def test_get_required_columns() -> None:
     assert ctx.get_required_columns([], set()) == []
 
     # Default columns parameter is unaltered
-    assert default_columns == {"a", "e"}
+    assert default_cols == {"a", "e"}
 
 
 def test_get_required_values() -> None:
@@ -722,24 +725,28 @@ def test_get_required_values() -> None:
         **register_observation_kwargs,  # type: ignore[arg-type]
     )
 
-    default_values = {Pipeline("x"), Pipeline("v")}
+    default_vals = {Pipeline("x"), Pipeline("v")}
 
     # Test with default values
-    assert set(p.name for p in ctx.get_required_values([obs1, obs2], default_values)) == {
+    assert set(p.name for p in ctx.get_required_values([obs1, obs2], default_vals)) == {
         "x",
         "y",
         "z",
         "v",
     }
-    assert set(p.name for p in ctx.get_required_values([obs3], default_values)) == {
+    assert set(p.name for p in ctx.get_required_values([obs3], default_vals)) == {
         "x",
         "w",
         "v",
     }
-    assert set(
-        p.name for p in ctx.get_required_values([obs1, obs2, obs3], default_values)
-    ) == {"x", "y", "z", "w", "v"}
-    assert set(p.name for p in ctx.get_required_values([], default_values)) == {"x", "v"}
+    assert set(p.name for p in ctx.get_required_values([obs1, obs2, obs3], default_vals)) == {
+        "x",
+        "y",
+        "z",
+        "w",
+        "v",
+    }
+    assert set(p.name for p in ctx.get_required_values([], default_vals)) == {"x", "v"}
 
     # Test with no default values
     assert set(p.name for p in ctx.get_required_values([obs1, obs2], set())) == {
@@ -757,7 +764,7 @@ def test_get_required_values() -> None:
     assert ctx.get_required_values([], set()) == []
 
     # Default values parameter is unaltered
-    assert set(p.name for p in default_values) == {"x", "v"}
+    assert set(p.name for p in default_vals) == {"x", "v"}
 
 
 @pytest.mark.parametrize(

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -531,6 +531,29 @@ def test_gather_results_with_no_observations(mocker: pytest_mock.MockerFixture) 
     mgr._results_context.gather_results.assert_not_called()  # type: ignore[attr-defined]
 
 
+def test_gather_results_with_empty_index(mocker: pytest_mock.MockerFixture) -> None:
+    """Test that gather_results short-circuits when an event has an empty index."""
+
+    mgr = ResultsManager()
+    mgr.population_view = mocker.Mock()
+    mgr._results_context = mocker.Mock()
+    mgr._results_context.get_observations.return_value = [mocker.Mock(spec=AddingObservation)]  # type: ignore[attr-defined]
+
+    event = Event(
+        name=lifecycle_states.COLLECT_METRICS,
+        index=pd.Index([]),
+        user_data={},
+        time=0,
+        step_size=1,
+    )
+
+    mgr.gather_results(event)
+
+    mgr._results_context.get_observations.assert_called_once_with(event)  # type: ignore[attr-defined]
+    mgr.population_view.subview.assert_not_called()  # type: ignore[attr-defined]
+    mgr._results_context.gather_results.assert_not_called()  # type: ignore[attr-defined]
+
+
 @pytest.fixture(scope="module")
 def prepare_population_sim() -> InteractiveContext:
     return InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=[Hogwarts()])

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -37,7 +37,9 @@ from tests.framework.results.helpers import (
     sorting_hat_vectorized,
     verify_stratification_added,
 )
+from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
+from vivarium.framework.population import PopulationView
 from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.context import ResultsContext
 from vivarium.framework.results.manager import ResultsManager
@@ -504,6 +506,82 @@ def test_unused_stratifications_are_logged(caplog: LogCaptureFixture) -> None:
     assert len(log_split) == 2
     # Check that the log message contains the expected Stratifications
     assert "['student_house']" in log_split[1]
+
+
+def test_gather_results_with_no_observations(mocker: pytest_mock.MockerFixture) -> None:
+    """Test that gather_results short-circuits when there are no observations for an event."""
+
+    mgr = ResultsManager()
+    mgr.population_view = mocker.Mock()
+    mgr._results_context = mocker.Mock()
+    mgr._results_context.get_observations.return_value = []  # type: ignore[attr-defined]
+
+    event = Event(
+        name=lifecycle_states.COLLECT_METRICS,
+        index=pd.Index([0]),
+        user_data={},
+        time=0,
+        step_size=1,
+    )
+
+    mgr.gather_results(event)
+
+    mgr._results_context.get_observations.assert_called_once_with(event)  # type: ignore[attr-defined]
+    mgr.population_view.subview.assert_not_called()  # type: ignore[attr-defined]
+    mgr._results_context.gather_results.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="module")
+def prepare_population_sim() -> InteractiveContext:
+    return InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=[Hogwarts()])
+
+
+@pytest.mark.parametrize(
+    "required_columns, required_value_names",
+    [
+        ([], []),
+        (["familiar", "house_points"], []),
+        ([], ["grade"]),
+        (["familiar"], ["grade"]),
+        (["current_time", "event_time", "event_step_size", "familiar"], []),
+        (["train"], []),
+    ],
+    ids=[
+        "no_columns_no_values",
+        "columns_required_no_values",
+        "no_columns_values_required",
+        "columns_and_values_required",
+        "time_data_and_columns",
+        "user_data",
+    ],
+)
+def test_prepare_population(
+    prepare_population_sim: InteractiveContext,
+    required_columns: list[str],
+    required_value_names: list[str],
+) -> None:
+    mgr = prepare_population_sim._results
+    required_values = [
+        prepare_population_sim.get_value(value) for value in required_value_names
+    ]
+    event = Event(
+        name=lifecycle_states.COLLECT_METRICS,
+        index=prepare_population_sim.get_population().index,
+        user_data={"train": "Hogwarts Express", "Headmaster": "Albus Dumbledore"},
+        time=prepare_population_sim._clock.time + prepare_population_sim._clock.step_size,  # type: ignore [operator]
+        step_size=prepare_population_sim._clock.step_size,
+    )
+
+    population = mgr._prepare_population(event, required_columns, required_values)
+
+    expected_columns = required_columns + required_value_names
+    assert set(population.columns) == set(expected_columns)
+    if "current_time" in required_columns:
+        assert (population["current_time"] == prepare_population_sim._clock.time).all()
+    if "event_time" in required_columns:
+        assert (population["event_time"] == event.time).all()
+    if "event_step_size" in required_columns:
+        assert (population["event_step_size"] == event.step_size).all()
 
 
 def test_stratified_observation_results() -> None:

--- a/tests/framework/results/test_observation.py
+++ b/tests/framework/results/test_observation.py
@@ -23,6 +23,8 @@ def stratified_observation() -> StratifiedObservation:
         name="stratified_observation_name",
         pop_filter="",
         when="whenevs",
+        requires_columns=[],
+        requires_values=[],
         results_updater=lambda _, __: pd.DataFrame(),
         results_formatter=lambda _, __: pd.DataFrame(),
         stratifications=(),
@@ -37,7 +39,8 @@ def concatenating_observation() -> ConcatenatingObservation:
         name="concatenating_observation_name",
         pop_filter="",
         when="whenevs",
-        included_columns=["some-col", "some-other-col"],
+        requires_columns=["some-col", "some-other-col"],
+        requires_values=[],
         results_formatter=lambda _, __: pd.DataFrame(),
     )
 
@@ -223,6 +226,8 @@ def test_adding_observation_results_updater(new_observations: pd.DataFrame) -> N
         name="adding_observation_name",
         pop_filter="",
         when="whenevs",
+        requires_columns=[],
+        requires_values=[],
         results_formatter=lambda _, __: pd.DataFrame(),
         stratifications=(),
         aggregator_sources=None,


### PR DESCRIPTION
## Use Observation requirements to limit expanded state table
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6272

### Changes and notes
- Use Observation requirements to limit expanded state table
- Only add columns/values if they are needed by an observation that  is actually being observed during this Event
- This does not address stratifications that might be unused
- Had to add required_columns/values to Observation objects

Other changes:
- Updated `ctx.register_observation()` to return the Observation for  ease of use in tests
- Fixed a docstring in register_unstratified_observation()
- Refactored ConcatenatingObservation to compute columns to include  more effectively
- Cleaned up an error case if you pass something other than a string to  required_columns/values

### Testing
All tests pass
Added new tests for:
- `ctx.get_observations()`
- `ctx.get_required_columns()`
- `ctx.get_required_values()`
- `mgr.gather_results()` when there are no observations
- `mgr.gather_results()` when the Event has an empty index
- `mgr._prepare_population()` which previously had no tests.

