### PR TITLE
Sbachmei/mic 6380/convert pipelines to attribute pipelines

### DIFF
--- a/docs/source/concepts/values.rst
+++ b/docs/source/concepts/values.rst
@@ -104,7 +104,7 @@ The values system provides four interface methods, available off the
        | pipeline and a source. Optionally provide a combiner (defaults to
        | the replace combiner) and a postprocessor. Provide dependencies (see note).
    * - | :meth:`register_rate_producer <vivarium.framework.values.manager.ValuesInterface.register_rate_producer>`
-     - | A special case of :meth:`register_value_producer <vivarium.framework.values.manager.ValuesInterface.register_value_producer>`
+     - | A special case of :meth:`register_attribute_producer <vivarium.framework.values.manager.ValuesInterface.register_attribute_producer>`
        | for rates specifically.
        | Provide a name for the pipeline and a source and the values system will
        | automatically use the rescale postprocessor. Provide dependencies (see note).

--- a/docs/source/tutorials/boids.rst
+++ b/docs/source/tutorials/boids.rst
@@ -256,8 +256,8 @@ You can find an overview of the values system :ref:`here <values_concept>`.
 
 The Builder class exposes an additional property for working with value pipelines:
 :meth:`vivarium.framework.engine.Builder.value`.
-We call the :meth:`vivarium.framework.values.manager.ValuesInterface.register_value_producer`
-method to register a new pipeline.
+We call the :meth:`vivarium.framework.values.manager.ValuesInterface.register_attribute_producer`
+method to register a new attribute pipeline.
 
 .. literalinclude:: ../../../src/vivarium/examples/boids/movement.py
    :lines: 32-34
@@ -470,11 +470,11 @@ magnitude.
    :linenos:
 
 To access the value pipeline we created in the Neighbors component, we use
-``builder.value.get_value`` in the setup method. Then, as we saw with the ``acceleration``
+``builder.value.get_attribute`` in the setup method. Then, as we saw with the ``acceleration``
 pipeline, we simply call that pipeline as a function inside ``on_time_step`` to retrieve
 its values for a specified index.
 The major new Vivarium feature seen here is that of the **value modifier**,
-which we register with :meth:`vivarium.framework.values.manager.ValuesInterface.register_value_modifier`.
+which we register with :meth:`vivarium.framework.values.manager.ValuesInterface.register_attribute_modifier`.
 As the name suggests, this allows us to modify the values in a pipeline,
 in this case adding the effect of a force to the values in the ``acceleration`` pipeline.
 We register that the ``apply_force`` method will modify the acceleration values like so:

--- a/docs/source/tutorials/disease_model.rst
+++ b/docs/source/tutorials/disease_model.rst
@@ -605,8 +605,8 @@ value over multiple components. This can be a bit difficult to grasp,
 but is vital to the way we think about components in Vivarium. The best
 way to understand this system is by :doc:`example. </concepts/values>`
 
-In our current context we register a named value "pipeline" into the
-simulation called ``'mortality_rate'`` via the ``builder.value.register_rate_producer`` 
+In our current context we register a named attribute rate "pipeline" into the
+simulation called ``'mortality_rate'`` via the ``builder.value.register_attribute_rate_producer`` 
 method. The source for a value is always a callable function or method 
 (``self.base_mortality_rate`` in this case) which typically takes in a 
 ``pandas.Index`` as its only argument. Other things are possible, but not 

--- a/docs/source/tutorials/disease_model.rst
+++ b/docs/source/tutorials/disease_model.rst
@@ -605,8 +605,8 @@ value over multiple components. This can be a bit difficult to grasp,
 but is vital to the way we think about components in Vivarium. The best
 way to understand this system is by :doc:`example. </concepts/values>`
 
-In our current context we register a named attribute rate "pipeline" into the
-simulation called ``'mortality_rate'`` via the ``builder.value.register_attribute_rate_producer`` 
+In our current context we register a named attribute "pipeline" into the
+simulation called ``'mortality_rate'`` via the ``builder.value.register_rate_producer`` 
 method. The source for a value is always a callable function or method 
 (``self.base_mortality_rate`` in this case) which typically takes in a 
 ``pandas.Index`` as its only argument. Other things are possible, but not 

--- a/src/vivarium/examples/boids/forces.py
+++ b/src/vivarium/examples/boids/forces.py
@@ -32,9 +32,9 @@ class Force(Component, ABC):
         self.config = builder.configuration[self.__class__.__name__.lower()]
         self.max_speed = builder.configuration.movement.max_speed
 
-        self.neighbors = builder.value.get_value("neighbors")
+        self.neighbors = builder.value.get_attribute("neighbors")
 
-        builder.value.register_value_modifier(
+        builder.value.register_attribute_modifier(
             "acceleration",
             modifier=self.apply_force,
             required_resources=self.columns_required + [self.neighbors],
@@ -47,6 +47,8 @@ class Force(Component, ABC):
     def apply_force(self, index: pd.Index[int], acceleration: pd.DataFrame) -> pd.DataFrame:
         neighbors = self.neighbors(index)
         pop = self.population_view.get(index)
+        if not isinstance(neighbors, pd.Series):
+            raise ValueError("Neighbors must be a pd.Series of ints")
         pairs = self._get_pairs(neighbors, pop)
 
         raw_force = self.calculate_force(pairs)
@@ -68,7 +70,7 @@ class Force(Component, ABC):
     def calculate_force(self, neighbors: pd.DataFrame) -> pd.DataFrame:
         pass
 
-    def _get_pairs(self, neighbors: pd.Series[int], pop: pd.DataFrame) -> pd.DataFrame:
+    def _get_pairs(self, neighbors: pd.Series[Any], pop: pd.DataFrame) -> pd.DataFrame:
         pairs = (
             pop.join(neighbors.rename("neighbors"))
             .reset_index()

--- a/src/vivarium/examples/boids/forces.py
+++ b/src/vivarium/examples/boids/forces.py
@@ -70,7 +70,6 @@ class Force(Component, ABC):
         pass
 
     def _get_pairs(self, neighbors: pd.Series[int | float], pop: pd.DataFrame) -> pd.DataFrame:
-        breakpoint()
         pairs = (
             pop.join(neighbors.rename("neighbors"))
             .reset_index()

--- a/src/vivarium/examples/boids/forces.py
+++ b/src/vivarium/examples/boids/forces.py
@@ -70,7 +70,8 @@ class Force(Component, ABC):
     def calculate_force(self, neighbors: pd.DataFrame) -> pd.DataFrame:
         pass
 
-    def _get_pairs(self, neighbors: pd.Series[Any], pop: pd.DataFrame) -> pd.DataFrame:
+    def _get_pairs(self, neighbors: pd.Series[int | float], pop: pd.DataFrame) -> pd.DataFrame:
+        breakpoint()
         pairs = (
             pop.join(neighbors.rename("neighbors"))
             .reset_index()

--- a/src/vivarium/examples/boids/forces.py
+++ b/src/vivarium/examples/boids/forces.py
@@ -37,6 +37,7 @@ class Force(Component, ABC):
             "acceleration",
             modifier=self.apply_force,
             required_resources=self.columns_required + [self.neighbors],
+            component=self,
         )
 
     ##################################

--- a/src/vivarium/examples/boids/forces.py
+++ b/src/vivarium/examples/boids/forces.py
@@ -1,7 +1,6 @@
 
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -15,7 +14,7 @@ class Force(Component, ABC):
     # Properties #
     ##############
     @property
-    def configuration_defaults(self) -> dict[str, Any]:
+    def configuration_defaults(self) -> dict[str, dict[str, float]]:
         return {
             self.__class__.__name__.lower(): {
                 "max_force": 0.03,

--- a/src/vivarium/examples/boids/movement.py
+++ b/src/vivarium/examples/boids/movement.py
@@ -32,7 +32,7 @@ class Movement(Component):
         self.config = builder.configuration
 
         self.acceleration = builder.value.register_attribute_producer(
-            "acceleration", source=self.base_acceleration
+            "acceleration", source=self.base_acceleration, component=self
         )
 
     ##################################

--- a/src/vivarium/examples/boids/movement.py
+++ b/src/vivarium/examples/boids/movement.py
@@ -31,7 +31,7 @@ class Movement(Component):
     def setup(self, builder: Builder) -> None:
         self.config = builder.configuration
 
-        self.acceleration = builder.value.register_value_producer(
+        self.acceleration = builder.value.register_attribute_producer(
             "acceleration", source=self.base_acceleration
         )
 
@@ -66,6 +66,8 @@ class Movement(Component):
         acceleration = self.acceleration(event.index)
 
         # Accelerate and limit velocity
+        if not isinstance(acceleration, pd.DataFrame):
+            raise ValueError("Acceleration must be a pd.DataFrame")
         pop[["vx", "vy"]] += acceleration.rename(columns=lambda c: f"v{c}")
         speed = np.sqrt(np.square(pop.vx) + np.square(pop.vy))
         velocity_scaling_factor = np.where(

--- a/src/vivarium/examples/boids/neighbors.py
+++ b/src/vivarium/examples/boids/neighbors.py
@@ -25,7 +25,7 @@ class Neighbors(Component):
 
         self.neighbors_calculated = False
         self._neighbors = pd.Series()
-        self.neighbors = builder.value.register_value_producer(
+        self.neighbors = builder.value.register_attribute_producer(
             "neighbors", source=self.get_neighbors, required_resources=self.columns_required
         )
 

--- a/src/vivarium/examples/boids/neighbors.py
+++ b/src/vivarium/examples/boids/neighbors.py
@@ -26,7 +26,7 @@ class Neighbors(Component):
         self.neighbors_calculated = False
         self._neighbors = pd.Series()
         self.neighbors = builder.value.register_attribute_producer(
-            "neighbors", source=self.get_neighbors, required_resources=self.columns_required
+            "neighbors", source=self.get_neighbors, component=self, required_resources=self.columns_required
         )
 
     ########################

--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -37,12 +37,14 @@ class DiseaseTransition(Transition):
         self.joint_population_attributable_fraction = builder.value.register_attribute_producer(
             f"{self.rate_name}.population_attributable_fraction",
             source=lambda index: [pd.Series(0.0, index=index)],
+            component=self,
             preferred_combiner=list_combiner,
             preferred_post_processor=union_post_processor,
         )
         self.transition_rate = builder.value.register_rate_producer(
             self.rate_name,
             source=self._risk_deleted_rate,
+            component=self,
             required_resources=[self.joint_population_attributable_fraction],
         )
 
@@ -107,6 +109,7 @@ class DiseaseState(State):
         self.excess_mortality_rate_paf = builder.value.register_attribute_producer(
             f"{self.state_id}.excess_mortality_rate.population_attributable_fraction",
             source=lambda index: [pd.Series(0.0, index=index)],
+            component=self,
             preferred_combiner=list_combiner,
             preferred_post_processor=union_post_processor,
         )
@@ -114,12 +117,14 @@ class DiseaseState(State):
         self.excess_mortality_rate = builder.value.register_rate_producer(
             f"{self.state_id}.excess_mortality_rate",
             source=self.risk_deleted_excess_mortality_rate,
+            component=self,
             required_resources=[self.excess_mortality_rate_paf],
         )
 
         builder.value.register_attribute_modifier(
             "mortality_rate",
-            self.add_in_excess_mortality,
+            modifier=self.add_in_excess_mortality,
+            component=self,
             required_resources=[self.excess_mortality_rate]
         )
 
@@ -169,11 +174,13 @@ class DiseaseModel(Machine):
         self.cause_specific_mortality_rate = builder.value.register_rate_producer(
             f"{self.state_column}.cause_specific_mortality_rate",
             source=lambda index: pd.Series(cause_specific_mortality_rate, index=index),
+            component=self,
         )
         builder.value.register_attribute_modifier(
             "mortality_rate",
             modifier=self.delete_cause_specific_mortality,
             required_resources=[self.cause_specific_mortality_rate],
+            component=self,
         )
 
     ##################################

--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -34,13 +34,13 @@ class DiseaseTransition(Transition):
         rate = builder.configuration[self.cause_key][self.measure]
 
         self.base_rate = lambda index: pd.Series(rate, index=index)
-        self.joint_population_attributable_fraction = builder.value.register_value_producer(
+        self.joint_population_attributable_fraction = builder.value.register_attribute_producer(
             f"{self.rate_name}.population_attributable_fraction",
             source=lambda index: [pd.Series(0.0, index=index)],
             preferred_combiner=list_combiner,
             preferred_post_processor=union_post_processor,
         )
-        self.transition_rate = builder.value.register_rate_producer(
+        self.transition_rate = builder.value.register_attribute_rate_producer(
             self.rate_name,
             source=self._risk_deleted_rate,
             required_resources=[self.joint_population_attributable_fraction],
@@ -104,20 +104,20 @@ class DiseaseState(State):
             self._excess_mortality_rate = 0
 
         self.clock = builder.time.clock()
-        self.excess_mortality_rate_paf = builder.value.register_value_producer(
+        self.excess_mortality_rate_paf = builder.value.register_attribute_producer(
             f"{self.state_id}.excess_mortality_rate.population_attributable_fraction",
             source=lambda index: [pd.Series(0.0, index=index)],
             preferred_combiner=list_combiner,
             preferred_post_processor=union_post_processor,
         )
 
-        self.excess_mortality_rate = builder.value.register_rate_producer(
+        self.excess_mortality_rate = builder.value.register_attribute_rate_producer(
             f"{self.state_id}.excess_mortality_rate",
             source=self.risk_deleted_excess_mortality_rate,
             required_resources=[self.excess_mortality_rate_paf],
         )
 
-        builder.value.register_value_modifier(
+        builder.value.register_attribute_modifier(
             "mortality_rate",
             self.add_in_excess_mortality,
             required_resources=[self.excess_mortality_rate]
@@ -166,11 +166,11 @@ class DiseaseModel(Machine):
         )
         cause_specific_mortality_rate = config.incidence_rate * case_fatality_rate
 
-        self.cause_specific_mortality_rate = builder.value.register_rate_producer(
+        self.cause_specific_mortality_rate = builder.value.register_attribute_rate_producer(
             f"{self.state_column}.cause_specific_mortality_rate",
             source=lambda index: pd.Series(cause_specific_mortality_rate, index=index),
         )
-        builder.value.register_value_modifier(
+        builder.value.register_attribute_modifier(
             "mortality_rate",
             modifier=self.delete_cause_specific_mortality,
             required_resources=[self.cause_specific_mortality_rate],

--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -40,7 +40,7 @@ class DiseaseTransition(Transition):
             preferred_combiner=list_combiner,
             preferred_post_processor=union_post_processor,
         )
-        self.transition_rate = builder.value.register_attribute_rate_producer(
+        self.transition_rate = builder.value.register_rate_producer(
             self.rate_name,
             source=self._risk_deleted_rate,
             required_resources=[self.joint_population_attributable_fraction],
@@ -111,7 +111,7 @@ class DiseaseState(State):
             preferred_post_processor=union_post_processor,
         )
 
-        self.excess_mortality_rate = builder.value.register_attribute_rate_producer(
+        self.excess_mortality_rate = builder.value.register_rate_producer(
             f"{self.state_id}.excess_mortality_rate",
             source=self.risk_deleted_excess_mortality_rate,
             required_resources=[self.excess_mortality_rate_paf],
@@ -166,7 +166,7 @@ class DiseaseModel(Machine):
         )
         cause_specific_mortality_rate = config.incidence_rate * case_fatality_rate
 
-        self.cause_specific_mortality_rate = builder.value.register_attribute_rate_producer(
+        self.cause_specific_mortality_rate = builder.value.register_rate_producer(
             f"{self.state_column}.cause_specific_mortality_rate",
             source=lambda index: pd.Series(cause_specific_mortality_rate, index=index),
         )

--- a/src/vivarium/examples/disease_model/intervention.py
+++ b/src/vivarium/examples/disease_model/intervention.py
@@ -34,11 +34,11 @@ class TreatmentIntervention(Component):
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         effect_size = builder.configuration[self.intervention].effect_size
-        self.effect_size = builder.value.register_value_producer(
+        self.effect_size = builder.value.register_attribute_producer(
             f"{self.intervention}.effect_size",
             source=lambda index: pd.Series(effect_size, index=index),
         )
-        builder.value.register_value_modifier(
+        builder.value.register_attribute_modifier(
             self.affected_value,
             modifier=self.intervention_effect,
             required_resources=[self.effect_size],

--- a/src/vivarium/examples/disease_model/intervention.py
+++ b/src/vivarium/examples/disease_model/intervention.py
@@ -37,10 +37,12 @@ class TreatmentIntervention(Component):
         self.effect_size = builder.value.register_attribute_producer(
             f"{self.intervention}.effect_size",
             source=lambda index: pd.Series(effect_size, index=index),
+            component=self,
         )
         builder.value.register_attribute_modifier(
             self.affected_value,
             modifier=self.intervention_effect,
+            component=self,
             required_resources=[self.effect_size],
         )
 

--- a/src/vivarium/examples/disease_model/mortality.py
+++ b/src/vivarium/examples/disease_model/mortality.py
@@ -52,7 +52,7 @@ class Mortality(Component):
         self.randomness = builder.randomness.get_stream("mortality")
 
         self.mortality_rate = builder.value.register_rate_producer(
-            "mortality_rate", source=self.base_mortality_rate
+            "mortality_rate", source=self.base_mortality_rate, component=self
         )
 
     ########################

--- a/src/vivarium/examples/disease_model/mortality.py
+++ b/src/vivarium/examples/disease_model/mortality.py
@@ -51,7 +51,7 @@ class Mortality(Component):
         self.config = builder.configuration.mortality
         self.randomness = builder.randomness.get_stream("mortality")
 
-        self.mortality_rate = builder.value.register_rate_producer(
+        self.mortality_rate = builder.value.register_attribute_rate_producer(
             "mortality_rate", source=self.base_mortality_rate
         )
 

--- a/src/vivarium/examples/disease_model/mortality.py
+++ b/src/vivarium/examples/disease_model/mortality.py
@@ -51,7 +51,7 @@ class Mortality(Component):
         self.config = builder.configuration.mortality
         self.randomness = builder.randomness.get_stream("mortality")
 
-        self.mortality_rate = builder.value.register_attribute_rate_producer(
+        self.mortality_rate = builder.value.register_rate_producer(
             "mortality_rate", source=self.base_mortality_rate
         )
 

--- a/src/vivarium/examples/disease_model/risk.py
+++ b/src/vivarium/examples/disease_model/risk.py
@@ -47,15 +47,15 @@ class Risk(Component):
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
         proportion_exposed = builder.configuration[self.risk].proportion_exposed
-        self.base_exposure_threshold = builder.value.register_value_producer(
+        self.base_exposure_threshold = builder.value.register_attribute_producer(
             f"{self.risk}.base_proportion_exposed",
             source=lambda index: pd.Series(proportion_exposed, index=index),
         )
-        self.exposure_threshold = builder.value.register_value_producer(
+        self.exposure_threshold = builder.value.register_attribute_producer(
             f"{self.risk}.proportion_exposed", source=self.base_exposure_threshold
         )
 
-        self.exposure = builder.value.register_value_producer(
+        self.exposure = builder.value.register_attribute_producer(
             f"{self.risk}.exposure",
             source=self._exposure,
             required_resources=[self.propensity_column, self.exposure_threshold],
@@ -106,23 +106,23 @@ class RiskEffect(Component):
 
     # noinspection PyAttributeOutsideInit
     def setup(self, builder: Builder) -> None:
-        self.base_risk_exposure = builder.value.get_value(
+        self.base_risk_exposure = builder.value.get_attribute(
             f"{self.risk_name}.base_proportion_exposed"
         )
-        self.actual_risk_exposure = builder.value.get_value(f"{self.risk_name}.exposure")
+        self.actual_risk_exposure = builder.value.get_attribute(f"{self.risk_name}.exposure")
 
         relative_risk = builder.configuration[self.risk].relative_risk
-        self.relative_risk = builder.value.register_value_producer(
+        self.relative_risk = builder.value.register_attribute_producer(
             f"{self.risk}.relative_risk",
             source=lambda index: pd.Series(relative_risk, index=index),
         )
 
-        builder.value.register_value_modifier(
+        builder.value.register_attribute_modifier(
             f"{self.disease_rate}.population_attributable_fraction",
             self.population_attributable_fraction,
             required_resources=[self.base_risk_exposure, self.relative_risk],
         )
-        builder.value.register_value_modifier(
+        builder.value.register_attribute_modifier(
             f"{self.disease_rate}",
             self.rate_adjustment,
             required_resources=[self.actual_risk_exposure, self.relative_risk],

--- a/src/vivarium/examples/disease_model/risk.py
+++ b/src/vivarium/examples/disease_model/risk.py
@@ -50,15 +50,19 @@ class Risk(Component):
         self.base_exposure_threshold = builder.value.register_attribute_producer(
             f"{self.risk}.base_proportion_exposed",
             source=lambda index: pd.Series(proportion_exposed, index=index),
+            component=self,
         )
         self.exposure_threshold = builder.value.register_attribute_producer(
-            f"{self.risk}.proportion_exposed", source=self.base_exposure_threshold
+            f"{self.risk}.proportion_exposed",
+            source=self.base_exposure_threshold,
+            component=self,
         )
 
         self.exposure = builder.value.register_attribute_producer(
             f"{self.risk}.exposure",
             source=self._exposure,
             required_resources=[self.propensity_column, self.exposure_threshold],
+            component=self,
         )
         self.randomness = builder.randomness.get_stream(self.risk)
 
@@ -115,16 +119,19 @@ class RiskEffect(Component):
         self.relative_risk = builder.value.register_attribute_producer(
             f"{self.risk}.relative_risk",
             source=lambda index: pd.Series(relative_risk, index=index),
+            component=self,
         )
 
         builder.value.register_attribute_modifier(
             f"{self.disease_rate}.population_attributable_fraction",
-            self.population_attributable_fraction,
+            modifier=self.population_attributable_fraction,
+            component=self,
             required_resources=[self.base_risk_exposure, self.relative_risk],
         )
         builder.value.register_attribute_modifier(
             f"{self.disease_rate}",
-            self.rate_adjustment,
+            modifier=self.rate_adjustment,
+            component=self,
             required_resources=[self.actual_risk_exposure, self.relative_risk],
         )
 

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -26,11 +26,6 @@ if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
 
 
-class SourceType(Enum):
-    COLUMN = 0
-    VALUE = 1
-
-
 class ResultsManager(Manager):
     """Backend manager object for the results management system.
 

--- a/src/vivarium/framework/time.py
+++ b/src/vivarium/framework/time.py
@@ -113,14 +113,14 @@ class SimulationClock(Manager):
         self._simulants_to_snooze = pd.Index([])
 
     def setup(self, builder: "Builder") -> None:
-        self._step_size_pipeline = builder.value.register_value_producer(
+        self._step_size_pipeline = builder.value.register_attribute_producer(
             self._pipeline_name,
             source=lambda idx: [pd.Series(np.nan, index=idx).astype("timedelta64[ns]")],
             preferred_combiner=list_combiner,
             preferred_post_processor=self.step_size_post_processor,
         )
         self.register_step_modifier = partial(
-            builder.value.register_value_modifier,
+            builder.value.register_attribute_modifier,
             self._pipeline_name,
             component=self,
         )

--- a/src/vivarium/framework/values/__init__.py
+++ b/src/vivarium/framework/values/__init__.py
@@ -22,7 +22,6 @@ from vivarium.framework.values.pipeline import (
     ValueSource,
 )
 from vivarium.framework.values.post_processors import (
-    AttributePostProcessor,
     PostProcessor,
     rescale_post_processor,
     union_post_processor,

--- a/src/vivarium/framework/values/__init__.py
+++ b/src/vivarium/framework/values/__init__.py
@@ -22,6 +22,7 @@ from vivarium.framework.values.pipeline import (
     ValueSource,
 )
 from vivarium.framework.values.post_processors import (
+    AttributePostProcessor,
     PostProcessor,
     rescale_post_processor,
     union_post_processor,

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -729,20 +729,3 @@ class ValuesInterface(Interface):
 
         """
         return self._manager.get_value(name)
-
-    def get_attribute(self, name: str) -> AttributePipeline:
-        """Retrieve the pipeline representing the named attribute.
-
-        Parameters
-        ----------
-        name
-            Name of the pipeline to return.
-
-        Returns
-        -------
-            A callable reference to the named attribute pipeline. The single
-            attribute pipeline argument must a :class:`pandas.Index` representing
-            the simulants and must return a :class:`pandas.DataFrame` with that same index.
-
-        """
-        return self._manager.get_attribute(name)

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -96,6 +96,12 @@ class ValuesManager(Manager):
             :meth:`ValuesInterface.register_value_producer`
         """
         self.logger.debug(f"Registering value pipeline {value_name}")
+        if value_name in self._attribute_pipelines:
+            self.logger.warning(
+                f"'{value_name}' already registered as an attribute pipeline."
+                "This is allowed, but be sure you register modifiers using the "
+                "correct method depending on which pipeline you intend to modify."
+            )
         pipeline = self.get_value(value_name)
         self._configure_pipeline(
             pipeline,
@@ -126,6 +132,12 @@ class ValuesManager(Manager):
             :meth:`ValuesInterface.register_attribute_producer`
         """
         self.logger.debug(f"Registering attribute pipeline {value_name}")
+        if value_name in self._value_pipelines:
+            self.logger.warning(
+                f"'{value_name}' already registered as a generic pipeline. "
+                "This is allowed, but be sure you register modifiers using the "
+                "correct method depending on which pipeline you intend to modify."
+            )
         pipeline = self.get_attribute(value_name)
         self._configure_pipeline(
             pipeline,
@@ -729,3 +741,8 @@ class ValuesInterface(Interface):
 
         """
         return self._manager.get_value(name)
+
+    # TODO: [MIC-5452] Remove this method (attributes should be obtained via population views)
+    def get_attribute(self, name: str) -> AttributePipeline:
+        """A temporary interface method to use while during population re-design."""
+        return self._manager.get_attribute(name)

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -120,7 +120,7 @@ class ValuesManager(Manager):
         self,
         value_name: str,
         source: Callable[[pd.Index[int]], Any],
-        component: Component,
+        component: Component | Manager,
         required_resources: Sequence[str | Resource] = (),
         preferred_combiner: ValueCombiner = replace_combiner,
         preferred_post_processor: PostProcessor | None = None,
@@ -188,8 +188,8 @@ class ValuesManager(Manager):
             before the pipeline modifier is called.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline modifier is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline modifier is called. This is a list of strings, pipelines,
+            or randomness streams.
         """
         self._configure_modifier(
             self.get_value(value_name),
@@ -226,8 +226,8 @@ class ValuesManager(Manager):
             The component that is registering the attribute modifier.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline modifier is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline modifier is called. This is a list of strings, pipelines,
+            or randomness streams.
         """
         self._configure_modifier(
             self.get_attribute(value_name),
@@ -287,7 +287,7 @@ class ValuesManager(Manager):
         self,
         pipeline: Pipeline | AttributePipeline,
         source: Callable[..., Any],
-        component: Component | None,
+        component: Component | Manager | None,
         requires_columns: Iterable[str] = (),
         requires_values: Iterable[str] = (),
         requires_streams: Iterable[str] = (),
@@ -441,8 +441,8 @@ class ValuesInterface(Interface):
             before the pipeline source is called.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline source is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline source is called. This is a list of strings, pipelines,
+            or randomness streams.
         preferred_combiner
             A strategy for combining the source and the results of any calls
             to mutators in the pipeline. ``vivarium`` provides the strategies
@@ -476,7 +476,7 @@ class ValuesInterface(Interface):
         self,
         value_name: str,
         source: Callable[[pd.Index[int]], Any],
-        component: Component,
+        component: Component | Manager,
         required_resources: Sequence[str | Resource] = (),
         preferred_combiner: ValueCombiner = replace_combiner,
         preferred_post_processor: PostProcessor | None = None,
@@ -493,8 +493,8 @@ class ValuesInterface(Interface):
             The component that is registering the attribute producer.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline source is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline source is called. This is a list of strings, pipelines,
+            or randomness streams.
         preferred_combiner
             A strategy for combining the source and the results of any calls
             to mutators in the pipeline. ``vivarium`` provides the strategies
@@ -525,11 +525,7 @@ class ValuesInterface(Interface):
         self,
         rate_name: str,
         source: Callable[..., Any],
-        # TODO [MIC-5452]: all calls should have a component
-        component: Component | None = None,
-        requires_columns: Iterable[str] = (),
-        requires_values: Iterable[str] = (),
-        requires_streams: Iterable[str] = (),
+        component: Component,
         required_resources: Sequence[str | Resource] = (),
     ) -> AttributePipeline:
         """Marks a ``Callable`` as the producer of a named rate.
@@ -549,20 +545,10 @@ class ValuesInterface(Interface):
             A callable source for the dynamic rate pipeline.
         component
             The component that is registering the rate producer.
-        requires_columns
-            A list of the state table columns that already need to be present
-            and populated in the state table before the pipeline source
-            is called.
-        requires_values
-            A list of the value pipelines that need to be properly sourced
-            before the pipeline source is called.
-        requires_streams
-            A list of the randomness streams that need to be properly sourced
-            before the pipeline source is called.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline source is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline source is called. This is a list of strings, pipelines,
+            or randomness streams.
 
         Returns
         -------
@@ -572,9 +558,6 @@ class ValuesInterface(Interface):
             rate_name,
             source,
             component,
-            requires_columns,
-            requires_values,
-            requires_streams,
             required_resources,
             preferred_post_processor=rescale_post_processor,
         )
@@ -618,8 +601,8 @@ class ValuesInterface(Interface):
             before the pipeline modifier is called.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline modifier is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline modifier is called. This is a list of strings, pipelines,
+            or randomness streams.
         """
         self._manager.register_value_modifier(
             value_name,
@@ -656,8 +639,8 @@ class ValuesInterface(Interface):
             The component that is registering the attribute modifier.
         required_resources
             A list of resources that need to be properly sourced before the
-            pipeline modifier is called. This is a list of strings, pipeline
-            names, or randomness streams.
+            pipeline modifier is called. This is a list of strings, pipelines,
+            or randomness streams.
         """
         self._manager.register_attribute_modifier(
             value_name,

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -117,7 +117,7 @@ class ValuesManager(Manager):
         component: Component | Manager,
         required_resources: Sequence[str | Resource] = (),
         preferred_combiner: ValueCombiner = replace_combiner,
-        preferred_post_processor: PostProcessor | None = None,
+        preferred_post_processor: AttributePostProcessor | None = None,
     ) -> AttributePipeline:
         """Marks a ``Callable`` as the producer of a named attribute.
 
@@ -467,7 +467,7 @@ class ValuesInterface(Interface):
         component: Component | Manager,
         required_resources: Sequence[str | Resource] = (),
         preferred_combiner: ValueCombiner = replace_combiner,
-        preferred_post_processor: PostProcessor | None = None,
+        preferred_post_processor: AttributePostProcessor | None = None,
     ) -> AttributePipeline:
         """Marks a ``Callable`` as the producer of a named attribute.
 

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -671,3 +671,20 @@ class ValuesInterface(Interface):
 
         """
         return self._manager.get_value(name)
+
+    def get_attribute(self, name: str) -> AttributePipeline:
+        """Retrieve the pipeline representing the named attribute.
+
+        Parameters
+        ----------
+        name
+            Name of the pipeline to return.
+
+        Returns
+        -------
+            A callable reference to the named attribute pipeline. The single
+            attribute pipeline argument must a :class:`pandas.Index` representing
+            the simulants and must return a :class:`pandas.DataFrame` with that same index.
+
+        """
+        return self._manager.get_attribute(name)

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -117,7 +117,7 @@ class ValuesManager(Manager):
         component: Component,
         required_resources: Sequence[str | Resource] = (),
         preferred_combiner: ValueCombiner = replace_combiner,
-        preferred_post_processor: AttributePostProcessor | None = None,
+        preferred_post_processor: PostProcessor | None = None,
     ) -> AttributePipeline:
         """Marks a ``Callable`` as the producer of a named attribute.
 
@@ -467,7 +467,7 @@ class ValuesInterface(Interface):
         component: Component,
         required_resources: Sequence[str | Resource] = (),
         preferred_combiner: ValueCombiner = replace_combiner,
-        preferred_post_processor: AttributePostProcessor | None = None,
+        preferred_post_processor: PostProcessor | None = None,
     ) -> AttributePipeline:
         """Marks a ``Callable`` as the producer of a named attribute.
 
@@ -557,6 +557,64 @@ class ValuesInterface(Interface):
             A callable reference to the named dynamic rate pipeline.
         """
         return self.register_value_producer(
+            rate_name,
+            source,
+            component,
+            requires_columns,
+            requires_values,
+            requires_streams,
+            required_resources,
+            preferred_post_processor=rescale_post_processor,
+        )
+
+    def register_attribute_rate_producer(
+        self,
+        rate_name: str,
+        source: Callable[[pd.Index[int]], pd.Series[Any] | pd.DataFrame],
+        # TODO [MIC-5452]: all calls should have a component
+        component: Component | None = None,
+        requires_columns: Iterable[str] = (),
+        requires_values: Iterable[str] = (),
+        requires_streams: Iterable[str] = (),
+        required_resources: Sequence[str | Resource] = (),
+    ) -> Pipeline:
+        """Marks a ``Callable`` as the producer of a named attribute rate.
+
+        This is a convenience wrapper around ``register_attribute_producer`` that
+        makes sure rate data is appropriately scaled to the size of the
+        simulation time step. It is equivalent to
+        ``register_attribute_producer(value_name, source,
+        preferred_combiner=replace_combiner,
+        preferred_post_processor=rescale_post_processor)``
+
+        Parameters
+        ----------
+        rate_name
+            The name of the new dynamic attribute rate pipeline.
+        source
+            A callable source for the dynamic attribute rate pipeline.
+        component
+            The component that is registering the attribute rate producer.
+        requires_columns
+            A list of the state table columns that already need to be present
+            and populated in the state table before the pipeline source
+            is called.
+        requires_values
+            A list of the value pipelines that need to be properly sourced
+            before the pipeline source is called.
+        requires_streams
+            A list of the randomness streams that need to be properly sourced
+            before the pipeline source is called.
+        required_resources
+            A list of resources that need to be properly sourced before the
+            pipeline source is called This is a list of strings, pipeline
+            names, or randomness streams.
+
+        Returns
+        -------
+            A callable reference to the named dynamic attribute rate pipeline.
+        """
+        return self.register_attribute_producer(
             rate_name,
             source,
             component,

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -96,12 +96,6 @@ class ValuesManager(Manager):
             :meth:`ValuesInterface.register_value_producer`
         """
         self.logger.debug(f"Registering value pipeline {value_name}")
-        if value_name in self._attribute_pipelines:
-            self.logger.warning(
-                f"'{value_name}' already registered as an attribute pipeline."
-                "This is allowed, but be sure you register modifiers using the "
-                "correct method depending on which pipeline you intend to modify."
-            )
         pipeline = self.get_value(value_name)
         self._configure_pipeline(
             pipeline,
@@ -132,12 +126,6 @@ class ValuesManager(Manager):
             :meth:`ValuesInterface.register_attribute_producer`
         """
         self.logger.debug(f"Registering attribute pipeline {value_name}")
-        if value_name in self._value_pipelines:
-            self.logger.warning(
-                f"'{value_name}' already registered as a generic pipeline. "
-                "This is allowed, but be sure you register modifiers using the "
-                "correct method depending on which pipeline you intend to modify."
-            )
         pipeline = self.get_attribute(value_name)
         self._configure_pipeline(
             pipeline,

--- a/src/vivarium/framework/values/manager.py
+++ b/src/vivarium/framework/values/manager.py
@@ -531,13 +531,13 @@ class ValuesInterface(Interface):
         requires_values: Iterable[str] = (),
         requires_streams: Iterable[str] = (),
         required_resources: Sequence[str | Resource] = (),
-    ) -> Pipeline:
+    ) -> AttributePipeline:
         """Marks a ``Callable`` as the producer of a named rate.
 
-        This is a convenience wrapper around ``register_value_producer`` that
+        This is a convenience wrapper around ``register_attribute_producer`` that
         makes sure rate data is appropriately scaled to the size of the
         simulation time step. It is equivalent to
-        ``register_value_producer(value_name, source,
+        ``register_attribute_producer(value_name, source,
         preferred_combiner=replace_combiner,
         preferred_post_processor=rescale_post_processor)``
 
@@ -567,64 +567,6 @@ class ValuesInterface(Interface):
         Returns
         -------
             A callable reference to the named dynamic rate pipeline.
-        """
-        return self.register_value_producer(
-            rate_name,
-            source,
-            component,
-            requires_columns,
-            requires_values,
-            requires_streams,
-            required_resources,
-            preferred_post_processor=rescale_post_processor,
-        )
-
-    def register_attribute_rate_producer(
-        self,
-        rate_name: str,
-        source: Callable[[pd.Index[int]], pd.Series[Any] | pd.DataFrame],
-        # TODO [MIC-5452]: all calls should have a component
-        component: Component | None = None,
-        requires_columns: Iterable[str] = (),
-        requires_values: Iterable[str] = (),
-        requires_streams: Iterable[str] = (),
-        required_resources: Sequence[str | Resource] = (),
-    ) -> Pipeline:
-        """Marks a ``Callable`` as the producer of a named attribute rate.
-
-        This is a convenience wrapper around ``register_attribute_producer`` that
-        makes sure rate data is appropriately scaled to the size of the
-        simulation time step. It is equivalent to
-        ``register_attribute_producer(value_name, source,
-        preferred_combiner=replace_combiner,
-        preferred_post_processor=rescale_post_processor)``
-
-        Parameters
-        ----------
-        rate_name
-            The name of the new dynamic attribute rate pipeline.
-        source
-            A callable source for the dynamic attribute rate pipeline.
-        component
-            The component that is registering the attribute rate producer.
-        requires_columns
-            A list of the state table columns that already need to be present
-            and populated in the state table before the pipeline source
-            is called.
-        requires_values
-            A list of the value pipelines that need to be properly sourced
-            before the pipeline source is called.
-        requires_streams
-            A list of the randomness streams that need to be properly sourced
-            before the pipeline source is called.
-        required_resources
-            A list of resources that need to be properly sourced before the
-            pipeline source is called This is a list of strings, pipeline
-            names, or randomness streams.
-
-        Returns
-        -------
-            A callable reference to the named dynamic attribute rate pipeline.
         """
         return self.register_attribute_producer(
             rate_name,

--- a/src/vivarium/framework/values/pipeline.py
+++ b/src/vivarium/framework/values/pipeline.py
@@ -13,7 +13,10 @@ from vivarium.manager import Manager
 if TYPE_CHECKING:
     from vivarium.framework.values.combiners import ValueCombiner
     from vivarium.framework.values.manager import ValuesManager
-    from vivarium.framework.values.post_processors import PostProcessor
+    from vivarium.framework.values.post_processors import (
+        AttributePostProcessor,
+        PostProcessor,
+    )
 
 T = TypeVar("T")
 
@@ -25,7 +28,7 @@ class ValueSource(Resource):
         self,
         pipeline: Pipeline,
         source: Callable[..., Any] | None,
-        component: Component | None,
+        component: Component | Manager | None,
     ) -> None:
         self._pipeline_type = (
             "attribute" if isinstance(pipeline, AttributePipeline) else "value"
@@ -219,7 +222,7 @@ class Pipeline(Resource):
 
     def set_attributes(
         self,
-        component: Component | None,
+        component: Component | Manager | None,
         source: Callable[..., Any],
         combiner: ValueCombiner,
         post_processor: PostProcessor | None,

--- a/src/vivarium/framework/values/pipeline.py
+++ b/src/vivarium/framework/values/pipeline.py
@@ -53,37 +53,6 @@ class ValueSource(Resource):
         return self._source(*args, **kwargs)
 
 
-class AttributeSource(ValueSource):
-    """A resource representing the source of an attribute pipeline.
-
-    The source of an attribute pipeline must be a callable that takes a pd.Index
-    of integers and returns a pd.DataFrame.
-    """
-
-    def __init__(
-        self,
-        pipeline: AttributePipeline,
-        source: Callable[[pd.Index[int]], Any] | None,
-        component: Component | None,
-    ) -> None:
-        super(ValueSource, self).__init__(
-            "attribute_source" if source else "missing_attribute_source",
-            pipeline.name,
-            component,
-        )
-        self._pipeline = pipeline
-        self._source = source
-
-    def __call__(self, index: pd.Index[int]) -> Any:
-        if not self._source:
-            raise DynamicValueError(
-                f"The dynamic attribute pipeline for {self.name} has no source."
-                " This likely means you are attempting to modify a value that"
-                " hasn't been created."
-            )
-        return self._source(index)
-
-
 class ValueModifier(Resource):
     """A resource representing a modifier of a value pipeline."""
 
@@ -274,21 +243,11 @@ class Pipeline(Resource):
         manager
             The simulation values manager.
         """
-        self._set_common_attributes(component, combiner, post_processor, manager)
-        self.source = ValueSource(self, source, component)
-
-    def _set_common_attributes(
-        self,
-        component: Component | None,
-        combiner: ValueCombiner,
-        post_processor: PostProcessor | None,
-        manager: ValuesManager,
-    ) -> None:
-        """Set the common attributes for all pipeline types."""
         self.component = component
         self._combiner = combiner
         self.post_processor = post_processor
         self._manager = manager
+        self.source = ValueSource(self, source, component)
 
 
 class AttributePipeline(Pipeline):

--- a/src/vivarium/framework/values/pipeline.py
+++ b/src/vivarium/framework/values/pipeline.py
@@ -56,6 +56,37 @@ class ValueSource(Resource):
         return self._source(*args, **kwargs)
 
 
+class AttributeSource(ValueSource):
+    """A resource representing the source of an attribute pipeline.
+
+    The source of an attribute pipeline must be a callable that takes a pd.Index
+    of integers and returns a pd.DataFrame.
+    """
+
+    def __init__(
+        self,
+        pipeline: AttributePipeline,
+        source: Callable[[pd.Index[int]], Any] | None,
+        component: Component | None,
+    ) -> None:
+        super(ValueSource, self).__init__(
+            "attribute_source" if source else "missing_attribute_source",
+            pipeline.name,
+            component,
+        )
+        self._pipeline = pipeline
+        self._source = source
+
+    def __call__(self, index: pd.Index[int]) -> Any:
+        if not self._source:
+            raise DynamicValueError(
+                f"The dynamic attribute pipeline for {self.name} has no source."
+                " This likely means you are attempting to modify a value that"
+                " hasn't been created."
+            )
+        return self._source(index)
+
+
 class ValueModifier(Resource):
     """A resource representing a modifier of a value pipeline."""
 
@@ -246,8 +277,18 @@ class Pipeline(Resource):
         manager
             The simulation values manager.
         """
-        self.component = component
+        self._set_common_attributes(component, combiner, post_processor, manager)
         self.source = ValueSource(self, source, component)
+
+    def _set_common_attributes(
+        self,
+        component: Component | None,
+        combiner: ValueCombiner,
+        post_processor: PostProcessor | AttributePostProcessor | None,
+        manager: ValuesManager,
+    ) -> None:
+        """Set the common attributes for all pipeline types."""
+        self.component = component
         self._combiner = combiner
         self.post_processor = post_processor
         self._manager = manager

--- a/src/vivarium/framework/values/pipeline.py
+++ b/src/vivarium/framework/values/pipeline.py
@@ -13,10 +13,7 @@ from vivarium.manager import Manager
 if TYPE_CHECKING:
     from vivarium.framework.values.combiners import ValueCombiner
     from vivarium.framework.values.manager import ValuesManager
-    from vivarium.framework.values.post_processors import (
-        AttributePostProcessor,
-        PostProcessor,
-    )
+    from vivarium.framework.values.post_processors import PostProcessor
 
 T = TypeVar("T")
 
@@ -284,7 +281,7 @@ class Pipeline(Resource):
         self,
         component: Component | None,
         combiner: ValueCombiner,
-        post_processor: PostProcessor | AttributePostProcessor | None,
+        post_processor: PostProcessor | None,
         manager: ValuesManager,
     ) -> None:
         """Set the common attributes for all pipeline types."""
@@ -298,8 +295,8 @@ class AttributePipeline(Pipeline):
     """A type of value pipeline for calculating simulant attributes.
 
     An attribute pipeline is a specific type of :class:`~vivarium.framework.values.pipeline.Pipeline`
-    where the source and callable must take a pd.Index of integers and return a pd.DataFrame
-    that has that same index.
+    where the source and callable must take a pd.Index of integers and return a pd.Series or
+    pd.DataFrame that has that same index.
 
     """
 

--- a/tests/framework/randomness/test_reproducibility.py
+++ b/tests/framework/randomness/test_reproducibility.py
@@ -23,7 +23,7 @@ def test_reproducibility(tmp_path: Path, disease_model_spec: Path) -> None:
         check=True,
     )
 
-    files = [file for file in results_dir.rglob("**/*.parquet")]
+    files = list(results_dir.rglob("**/*.parquet"))
     assert len(files) == 4
     for filename in ["dead", "ylls"]:
         df_paths = [file for file in files if file.stem == filename]

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Any, Generator
+from typing import Any
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -14,11 +14,10 @@ from tests.helpers import Listener, MockComponentA, MockComponentB, MockGenericC
 from vivarium.component import Component
 from vivarium.framework.engine import Builder, SimulationContext
 from vivarium.framework.event import Event
-from vivarium.framework.results.observer import Observer
 from vivarium.framework.time import SimulationClock, get_time_stamp
 from vivarium.framework.utilities import from_yearly
 from vivarium.framework.values import ValuesManager, rescale_post_processor
-from vivarium.types import ClockStepSize, ClockTime, NumberLike
+from vivarium.types import ClockStepSize
 
 
 @pytest.fixture

--- a/tests/framework/test_time.py
+++ b/tests/framework/test_time.py
@@ -183,10 +183,21 @@ class StepModifierWithRatePipeline(StepModifier):
             f"test_rate_{self.name}",
             source=lambda idx: pd.Series(1.75, index=idx),
             preferred_post_processor=rescale_post_processor,
+            component=self,
         )
 
     def on_time_step(self, event: Event) -> None:
         self.ts_pipeline_value = self.rate_pipeline(event.index)
+
+    def __hash__(self) -> int:
+        return hash(
+            (
+                self.name,
+                self.step_modifier_even,
+                self.step_modifier_odd,
+                self.modified_simulants,
+            )
+        )
 
 
 class StepModifierWithUntracking(StepModifierWithRatePipeline):

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -287,8 +287,15 @@ def test_attribute_pipeline_return_types(manager: ValuesManager, mocker: MockFix
     dataframe_pipeline = manager.register_attribute_producer(
         "test_dataframe_attribute", source=dataframe_attribute_source
     )
+
+    assert isinstance(series_pipeline(index), pd.Series)
+    assert series_pipeline(index).index.equals(index)
+
+    assert isinstance(dataframe_pipeline(index), pd.DataFrame)
+    assert dataframe_pipeline(index).index.equals(index)
+
     bad_pipeline = manager.register_attribute_producer(
-        "test_bad_attribute", source=bad_attribute_source  # type: ignore [arg-type]
+        "test_bad_attribute", source=bad_attribute_source, component=mocker.Mock()
     )
 
     with pytest.raises(

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -282,10 +282,10 @@ def test_attribute_pipeline_return_types(manager: ValuesManager, mocker: MockFix
         return "foo"
 
     series_pipeline = manager.register_attribute_producer(
-        "test_series_attribute", source=series_attribute_source
+        "test_series_attribute", source=series_attribute_source, component=mocker.Mock()
     )
     dataframe_pipeline = manager.register_attribute_producer(
-        "test_dataframe_attribute", source=dataframe_attribute_source
+        "test_dataframe_attribute", source=dataframe_attribute_source, component=mocker.Mock()
     )
 
     assert isinstance(series_pipeline(index), pd.Series)

--- a/tests/interface/test_interactive.py
+++ b/tests/interface/test_interactive.py
@@ -4,6 +4,7 @@ from vivarium import InteractiveContext
 from vivarium.framework.values import Pipeline
 
 
+@pytest.mark.skip(reason="FIXME [MIC-6394]")
 def test_list_values() -> None:
     sim = InteractiveContext()
     # a 'simulant_step_size' value is created by default upon setup


### PR DESCRIPTION
## Convert Pipelines to AttributePipelines

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6380

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

This does a few things:
1. (primary goal) converts the example pipelines to attribute pipelines
2. Adds the `register_attribute_modifier` interface method I forgot in the previous PR
3. Adds a `register_attribute_rate_producer` method. I wasn't going to do this at first
but realized I couldn't easily reuse the `register_rate_producer` since that immediately
calls `get_value()` whereas we need to be calling `get_attribute()`.

NOTE: I did NOT convert the one and only vivarium-level pipeline, "simulant_step_size".
I think some more discussion is needed about exactly what AttributePipelines (and
their sources and modifiers) need to return. The only thing potentially keeping this from
just being an AttributePipeline is that the source isn't returning a pd.Series, but rather a 
_list_ of pd.Series! But since the post-processor is a list combiner, the _callable_ does
indeed return a pd.Series. It should be easy to convert if we decide to. In fact, I tried it
and only one test failed (because the mocking was no longer being done correctly).

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tests pass. 

NOTE: I did NOT run the boids example to make sure it works. I'm not really even sure how.
