### PR TITLE
fix type hint in get_output_model_name_string method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+**3.5.2 - 09/23/25**
+
+  - Fix type hint in get_output_model_name_string() utility method
+
+  - Hotfix: fix a bug that caused errors when an observation was inactive while having 
+    different stratifications from other active observations.
+
 **3.5.1 - 09/22/25**
 
   - Hotfix: fix a bug that caused errors when an observation was inactive while having 

--- a/src/vivarium/interface/utilities.py
+++ b/src/vivarium/interface/utilities.py
@@ -112,7 +112,7 @@ def raise_if_not_setup(system_type: str) -> Callable[..., Any]:
 
 
 def get_output_model_name_string(
-    artifact_path: str | Path,
+    artifact_path: str | Path | None,
     model_spec_path: str | Path,
 ) -> str:
     """Find a good string to use as model name in output path creation.


### PR DESCRIPTION
## Fix type hint in get_output_model_name_string method

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6441

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

This was causing an incorrect mypy error in vct.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

