### PR TITLE
Sbachmei/mic 6727/interactive context get columns method

### DIFF
--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -502,6 +502,15 @@ class PopulationManager(Manager):
     # Context API #
     ###############
 
+    def get_all_attribute_names(self) -> list[str]:
+        """Get the names of all attributes in the population.
+
+        Returns
+        -------
+            A list of all attribute names in the population.
+        """
+        return list(self._attribute_pipelines.keys())
+
     @overload
     def get_population(
         self,
@@ -593,7 +602,7 @@ class PopulationManager(Manager):
             )
 
         if attributes == "all":
-            requested_attributes = list(self._attribute_pipelines.keys())
+            requested_attributes = self.get_all_attribute_names()
         else:
             attributes = list(attributes)
             # check for duplicate request

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -195,13 +195,13 @@ class InteractiveContext(SimulationContext):
             attributes=returned_attributes, squeeze=squeeze
         )
 
+    def get_columns(self) -> list[str]:
+        """List all columns in the population state table."""
+        return self._population.get_all_attribute_names()
+
     def list_values(self) -> list[str]:
         """List the names of all value pipelines in the simulation."""
         return list(self._values.get_value_pipelines().keys())
-
-    def list_attributes(self) -> list[str]:
-        """List the names of all attribute pipelines in the simulation."""
-        return list(self._values.get_attribute_pipelines().keys())
 
     def get_value(self, value_pipeline_name: str) -> Pipeline:
         """Get the value pipeline associated with the given name."""

--- a/tests/interface/test_interactive.py
+++ b/tests/interface/test_interactive.py
@@ -7,6 +7,7 @@ from tests.framework.population.helpers import (
     assert_squeezing_single_level_single_col,
 )
 from tests.helpers import (
+    AttributePipelineCreator,
     ColumnCreator,
     MultiLevelMultiColumnCreator,
     MultiLevelSingleColumnCreator,
@@ -16,7 +17,6 @@ from vivarium import InteractiveContext
 from vivarium.framework.values import Pipeline
 
 
-@pytest.mark.skip(reason="FIXME [MIC-6394]")
 def test_list_values() -> None:
     sim = InteractiveContext()
     # a 'simulant_step_size' value is created by default upon setup
@@ -26,6 +26,26 @@ def test_list_values() -> None:
         sim.get_value("foo")
     # ensure that 'foo' did not get added to the list of values
     assert sim.list_values() == ["simulant_step_size"]
+
+
+def test_get_columns() -> None:
+    sim = InteractiveContext(
+        components=[MultiLevelMultiColumnCreator(), AttributePipelineCreator()]
+    )
+    assert set(sim.get_columns()) == set(
+        [
+            # MultiLevelMultiColumnCreator attributes
+            "some_attribute",
+            "some_other_attribute",
+            # AttributePipelineCreator attributes
+            "attribute_generating_columns_4_5",
+            "attribute_generating_column_8",
+            "test_attribute",
+            "attribute_generating_columns_6_7",
+        ]
+    )
+    # Make sure there's nothing unexpected compared to the actual population df
+    assert set(sim.get_columns()) == set(sim.get_population().columns.get_level_values(0))
 
 
 def test_get_population_squeezing() -> None:


### PR DESCRIPTION
## Interactive context get columns method

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6727

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
The method actually already existed via `list_attributes` (the complement to 
`list_values`). I decided that we probably want users to think of them actually
as columns in the state table so renamed it.

I also slightly streamlined how we're getting it w/ a bit less indirection.
There might still be room for improvement here.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

