### PR TITLE
change default behavior of allow_self_transitions to True

### DIFF
--- a/src/vivarium/examples/disease_model/disease.py
+++ b/src/vivarium/examples/disease_model/disease.py
@@ -213,13 +213,11 @@ class SISDiseaseModel(Component):
         susceptible_state = DiseaseState(f"susceptible_to_{self._name}", self._name)
         infected_state = DiseaseState(f"infected_with_{self._name}", self._name)
 
-        susceptible_state.allow_self_transitions()
         susceptible_state.add_disease_transition(
             infected_state,
             measure="incidence_rate",
             rate_name=f"{infected_state.state_id}.incidence_rate",
         )
-        infected_state.allow_self_transitions()
         infected_state.add_disease_transition(
             susceptible_state,
             measure="remission_rate",

--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -221,7 +221,7 @@ class State(Component):
     def __init__(
         self,
         state_id: str,
-        allow_self_transition: bool = False,
+        allow_self_transition: bool = True,
         initialization_weights: DataInput = 0.0,
     ) -> None:
         super().__init__()
@@ -339,9 +339,6 @@ class State(Component):
         self.transition_set.append(transition)
         return transition
 
-    def allow_self_transitions(self) -> None:
-        self.transition_set.allow_null_transition = True
-
     ##################
     # Helper methods #
     ##################
@@ -390,11 +387,11 @@ class TransitionSet(Component):
     #####################
 
     def __init__(
-        self, state_id: str, *transitions: Transition, allow_self_transition: bool = False
+        self, state_id: str, *transitions: Transition, allow_self_transition: bool = True
     ):
         super().__init__()
         self.state_id = state_id
-        self.allow_null_transition = allow_self_transition
+        self.allow_self_transition = allow_self_transition
         self.transitions: list[Transition] = []
         self._sub_components = self.transitions
 
@@ -494,7 +491,7 @@ class TransitionSet(Component):
         probabilities[has_default] /= total[has_default, np.newaxis]
 
         total = np.sum(probabilities, axis=1)  # All totals should be ~<= 1 at this point.
-        if self.allow_null_transition:
+        if self.allow_self_transition:
             if np.any(total > 1 + 1e-08):  # Accommodate rounding errors
                 raise ValueError(
                     f"Null transition requested with un-normalized "

--- a/tests/framework/test_state_machine.py
+++ b/tests/framework/test_state_machine.py
@@ -16,13 +16,13 @@ from vivarium.types import ClockTime, DataInput
 
 
 def test_initialize_allowing_self_transition() -> None:
-    self_transitions = State("self-transitions", allow_self_transition=True)
+    self_transitions = State("self-transitions")
     no_self_transitions = State("no-self-transitions", allow_self_transition=False)
     undefined_self_transitions = State("self-transitions")
 
-    assert self_transitions.transition_set.allow_null_transition
-    assert not no_self_transitions.transition_set.allow_null_transition
-    assert not undefined_self_transitions.transition_set.allow_null_transition
+    assert self_transitions.transition_set.allow_self_transition
+    assert not no_self_transitions.transition_set.allow_self_transition
+    assert undefined_self_transitions.transition_set.allow_self_transition
 
 
 def test_initialize_with_initial_state() -> None:
@@ -148,8 +148,8 @@ def test_transition(
             "randomness": {"key_columns": []},
         }
     )
+    start_state = State("start", allow_self_transition=False)
     done_state = State("done")
-    start_state = State("start")
     if use_transition_arg:
         start_state.add_transition(Transition(start_state, done_state))
     else:
@@ -166,9 +166,9 @@ def test_no_null_transition(base_config: LayeredConfigTree) -> None:
     base_config.update(
         {"population": {"population_size": 10000}, "randomness": {"key_columns": []}}
     )
-    a_state = State("a")
-    b_state = State("b")
-    start_state = State("start")
+    a_state = State("a", allow_self_transition=False)
+    b_state = State("b", allow_self_transition=False)
+    start_state = State("start", allow_self_transition=False)
     start_state.add_transition(
         output_state=a_state, probability_function=lambda index: pd.Series(0.4, index=index)
     )
@@ -194,8 +194,8 @@ def test_null_transition(base_config: LayeredConfigTree) -> None:
     base_config.update(
         {"population": {"population_size": 10000}, "randomness": {"key_columns": []}}
     )
-    a_state = State("a")
-    start_state = State("start", allow_self_transition=True)
+    a_state = State("a", allow_self_transition=False)
+    start_state = State("start")
     start_state.add_transition(
         output_state=a_state, probability_function=lambda index: pd.Series(0.4, index=index)
     )
@@ -223,8 +223,8 @@ def test_side_effects() -> None:
             pop = self.population_view.get_attributes(index, "count")
             self.population_view.update(pop + 1)
 
-    counting_state = CountingState("counting")
-    start_state = State("start")
+    counting_state = CountingState("counting", allow_self_transition=False)
+    start_state = State("start", allow_self_transition=False)
     start_state.add_transition(output_state=counting_state)
     counting_state.add_transition(output_state=start_state)
 


### PR DESCRIPTION
## Change default behavior of allow_self_transitions to True
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6753

### Changes and notes
- Change default behavior of allow_self_transitions to True
- Rename `TransitionSet.all_null_transition` to match the equivalent name in State

### Testing
Ran make check
Ensured VPH still works