### PR TITLE
Disallow tracked filtering on initialization or pop creation

### DIFF
--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -176,6 +176,7 @@ class PopulationManager(Manager):
         self._get_current_component_or_manager = (
             builder.components.get_current_component_or_manager
         )
+        self._get_current_state = builder.lifecycle.current_state()
 
         builder.lifecycle.add_constraint(
             self.get_view,

--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -176,7 +176,7 @@ class PopulationManager(Manager):
         self._get_current_component_or_manager = (
             builder.components.get_current_component_or_manager
         )
-        self._get_current_state = builder.lifecycle.current_state()
+        self.get_current_state = builder.lifecycle.current_state()
 
         builder.lifecycle.add_constraint(
             self.get_view,

--- a/src/vivarium/framework/population/population_view.py
+++ b/src/vivarium/framework/population/population_view.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Literal, overload
 import pandas as pd
 
 import vivarium.framework.population.utilities as pop_utils
+from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.population.exceptions import PopulationError
 
 if TYPE_CHECKING:
@@ -190,6 +191,9 @@ class PopulationView:
         squeeze: Literal[True, False] = isinstance(attributes, str)
         attributes = [attributes] if isinstance(attributes, str) else list(attributes)
 
+        include_default_query, include_untracked = self._set_query_args_if_initializing(
+            self._manager._get_current_state(), include_default_query, include_untracked
+        )
         population = self._manager.get_population(
             attributes=attributes,
             index=index,
@@ -252,6 +256,9 @@ class PopulationView:
             the various optional queries. Will always return a DataFrame.
 
         """
+        include_default_query, include_untracked = self._set_query_args_if_initializing(
+            self._manager._get_current_state(), include_default_query, include_untracked
+        )
         return pd.DataFrame(
             self._manager.get_population(
                 index=index,
@@ -380,6 +387,9 @@ class PopulationView:
             The requested and filtered population index.
         """
 
+        include_default_query, include_untracked = self._set_query_args_if_initializing(
+            self._manager._get_current_state(), include_default_query, include_untracked
+        )
         return self.get_attributes(
             index,
             attributes=[],
@@ -660,3 +670,17 @@ class PopulationView:
             self._default_query if include_default_query else "",
             self._manager.get_tracked_query() if not include_untracked else "",
         )
+
+    @staticmethod
+    def _set_query_args_if_initializing(
+        current_state: str, include_default_query: bool, include_untracked: bool
+    ) -> tuple[bool, bool]:
+        """Sets query arguments appropriately during initialization."""
+        if current_state in [
+            lifecycle_states.INITIALIZATION,
+            lifecycle_states.POPULATION_CREATION,
+        ]:
+            # Override query arguments to ensure we don't filter anything out during initialization
+            include_default_query = False
+            include_untracked = True
+        return include_default_query, include_untracked

--- a/src/vivarium/framework/population/population_view.py
+++ b/src/vivarium/framework/population/population_view.py
@@ -192,7 +192,7 @@ class PopulationView:
         attributes = [attributes] if isinstance(attributes, str) else list(attributes)
 
         include_default_query, include_untracked = self._set_query_args_if_initializing(
-            self._manager._get_current_state(), include_default_query, include_untracked
+            self._manager.get_current_state(), include_default_query, include_untracked
         )
         population = self._manager.get_population(
             attributes=attributes,
@@ -257,7 +257,7 @@ class PopulationView:
 
         """
         include_default_query, include_untracked = self._set_query_args_if_initializing(
-            self._manager._get_current_state(), include_default_query, include_untracked
+            self._manager.get_current_state(), include_default_query, include_untracked
         )
         return pd.DataFrame(
             self._manager.get_population(
@@ -388,7 +388,7 @@ class PopulationView:
         """
 
         include_default_query, include_untracked = self._set_query_args_if_initializing(
-            self._manager._get_current_state(), include_default_query, include_untracked
+            self._manager.get_current_state(), include_default_query, include_untracked
         )
         return self.get_attributes(
             index,

--- a/src/vivarium/framework/time/__init__.py
+++ b/src/vivarium/framework/time/__init__.py
@@ -1,2 +1,7 @@
 from vivarium.framework.time.interface import TimeInterface
-from vivarium.framework.time.manager import DateTimeClock, SimpleClock, SimulationClock
+from vivarium.framework.time.manager import (
+    DateTimeClock,
+    SimpleClock,
+    SimulationClock,
+    get_time_stamp,
+)

--- a/tests/framework/population/conftest.py
+++ b/tests/framework/population/conftest.py
@@ -98,5 +98,5 @@ def pies_and_cubes_pop_mgr(mocker: MockerFixture) -> PopulationManager:
         },
     )
     # Change lifecycle phase to ensure tracked queries are applied appropriately
-    mocker.patch.object(mgr, "_get_current_state", lambda: "on_time_step")
+    mocker.patch.object(mgr, "get_current_state", lambda: "on_time_step")
     return mgr

--- a/tests/framework/population/conftest.py
+++ b/tests/framework/population/conftest.py
@@ -97,4 +97,6 @@ def pies_and_cubes_pop_mgr(mocker: MockerFixture) -> PopulationManager:
             "cube_component": CUBE_COL_NAMES,
         },
     )
+    # Change lifecycle phase to ensure tracked queries are applied appropriately
+    mocker.patch.object(mgr, "_get_current_state", lambda: "on_time_step")
     return mgr

--- a/tests/framework/population/test_population_view.py
+++ b/tests/framework/population/test_population_view.py
@@ -24,6 +24,7 @@ from tests.framework.population.helpers import (
 from tests.helpers import AttributePipelineCreator, ColumnCreator, SingleColumnCreator
 from vivarium import InteractiveContext
 from vivarium.framework.engine import Builder
+from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.population import PopulationError, PopulationManager, PopulationView
 
 ##########################
@@ -901,6 +902,36 @@ def test__update_column_and_ensure_dtype_unmatched_dtype() -> None:
             existing,
             adding_simulants=False,
         )
+
+
+#################################
+# PopulationView.update helpers #
+##################################################
+# PopulationView._set_query_args_if_initializing #
+##################################################
+
+
+def test__set_query_args_if_initializing() -> None:
+    # lifecycle_states is not directly iterable so just look for constants manually
+    states = [state for state in dir(lifecycle_states) if not state.startswith("_")]
+    for current_state in states:
+        (
+            include_default_query,
+            include_untracked,
+        ) = PopulationView._set_query_args_if_initializing(
+            current_state=current_state,
+            include_default_query=True,
+            include_untracked=False,
+        )
+        if current_state in [
+            lifecycle_states.INITIALIZATION,
+            lifecycle_states.POPULATION_CREATION,
+        ]:
+            assert include_default_query is False
+            assert include_untracked is False
+        else:
+            assert include_default_query is True
+            assert include_untracked is False
 
 
 #########################

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -626,7 +626,7 @@ def test_prepare_population_all_untracked(
     pop_mgr = prepare_population_sim._population
     pop_mgr.tracked_queries = ['student_house != "slytherin"']
     # Change lifecycle phase to ensure tracked queries are applied appropriately
-    mocker.patch.object(pop_mgr, "_get_current_state", lambda: "on_time_step")
+    mocker.patch.object(pop_mgr, "get_current_state", lambda: "on_time_step")
 
     # Check that the exclusion is not applied since one of the observers allows untracked
     private_columns = pop_mgr._private_columns

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -590,7 +590,9 @@ def test_prepare_population(
         ).all()
 
 
-def test_prepare_population_all_untracked(prepare_population_sim: InteractiveContext) -> None:
+def test_prepare_population_all_untracked(
+    prepare_population_sim: InteractiveContext, mocker: pytest_mock.MockerFixture
+) -> None:
     mgr = prepare_population_sim._results
     observation1 = AddingObservation(
         name="familiar",
@@ -623,6 +625,8 @@ def test_prepare_population_all_untracked(prepare_population_sim: InteractiveCon
     # Add an untracking query
     pop_mgr = prepare_population_sim._population
     pop_mgr.tracked_queries = ['student_house != "slytherin"']
+    # Change lifecycle phase to ensure tracked queries are applied appropriately
+    mocker.patch.object(pop_mgr, "_get_current_state", lambda: "on_time_step")
 
     # Check that the exclusion is not applied since one of the observers allows untracked
     private_columns = pop_mgr._private_columns


### PR DESCRIPTION
## Disallow tracked filtering on initialization or pop creation
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6801

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
We ran into issues with initializers requesting attributes from pop view
which by default tries to filter untracked simulants out but the column
not existing yet. We decided that on initialization (and, by extension, 
population generation) we should just never try to filter out untracked
simulants; users can post-process as desired if needed.

Note that this does not cause a problem in later lifecycle phases since
by definition all initializers would have set up all columns by then.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

