### PR TITLE
Remove duplicated --runslow option and slow test hooks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.6.7 - 02/23/26**
+
+  - Bugfix: Remove duplicated pytest options
+
 **3.6.6 - 01/06/26**
 
   - Fail deployment if changelog date is not current date

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,24 +19,6 @@ from vivarium.framework.configuration import (
 from vivarium.testing_utilities import metadata
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
-
-
-def pytest_configure(config: pytest.Config) -> None:
-    config.addinivalue_line("markers", "slow: mark test as slow to run")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
-
-
 @pytest.fixture(scope="session")
 def fuzzy_checker() -> FuzzyChecker:
     return FuzzyChecker()


### PR DESCRIPTION
## Remove duplicated --runslow option and slow test hooks
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6848

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

