### PR TITLE
State.transition_effect(): name pop update with the model name

### DIFF
--- a/src/vivarium/framework/state_machine.py
+++ b/src/vivarium/framework/state_machine.py
@@ -289,7 +289,7 @@ class State(Component):
         population_view
             A view of the internal state of the simulation.
         """
-        population_view.update(pd.Series(self.state_id, index=index))
+        population_view.update(pd.Series(self.state_id, index=index, name=self.model))
         self.transition_side_effect(index, event_time)
 
     def cleanup_effect(self, index: pd.Index[int], event_time: ClockTime) -> None:


### PR DESCRIPTION
## State.transition_effect(): name pop update with the model name

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

We cannot update a popview with an unnamed series if that population view
contains more than one private column (b/c it can't know which column you're
trying to update). This showed up for transition_effect when updating the
nutrition optimization - child model b/c the WastingModel has a custom
private column for initial_propensity.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

