### PR TITLE
track component being set up using a context manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 **4.1.0 - 12/16/25**
 
   - Enable changing the data of a LookupTable during the simulation loop.
+  - Refactor: use a context manager to track which component is being set up during component setup.
 
 **4.0.0 - TBD TBD TBD**
 -----------------------

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -277,16 +277,17 @@ class Component(ABC):
         builder
             The builder object used to set up the component.
         """
-        self._logger = builder.logging.get_logger(self.name)
-        self.configuration = self.get_configuration(builder)
-        self.setup(builder)
-        self._set_population_view(builder)
-        self._register_post_setup_listener(builder)
-        self._register_time_step_prepare_listener(builder)
-        self._register_time_step_listener(builder)
-        self._register_time_step_cleanup_listener(builder)
-        self._register_collect_metrics_listener(builder)
-        self._register_simulation_end_listener(builder)
+        with builder.components._tracking_setup(self):
+            self._logger = builder.logging.get_logger(self.name)
+            self.configuration = self.get_configuration(builder)
+            self.setup(builder)
+            self._set_population_view(builder)
+            self._register_post_setup_listener(builder)
+            self._register_time_step_prepare_listener(builder)
+            self._register_time_step_listener(builder)
+            self._register_time_step_cleanup_listener(builder)
+            self._register_collect_metrics_listener(builder)
+            self._register_simulation_end_listener(builder)
 
     #######################
     # Methods to override #

--- a/src/vivarium/framework/artifact/manager.py
+++ b/src/vivarium/framework/artifact/manager.py
@@ -10,7 +10,7 @@ for handling complex data bound up in a data artifact.
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -20,12 +20,10 @@ from layered_config_tree.main import LayeredConfigTree
 from vivarium.framework.artifact import ArtifactException
 from vivarium.framework.artifact.artifact import Artifact
 from vivarium.framework.lifecycle import lifecycle_states
-from vivarium.manager import Interface, Manager
-from vivarium.types import LookupTableData
+from vivarium.manager import Manager
 
 if TYPE_CHECKING:
     from vivarium.framework.engine import Builder
-    from vivarium.types import ScalarValue
 
 
 class ArtifactManager(Manager):

--- a/src/vivarium/framework/components/interface.py
+++ b/src/vivarium/framework/components/interface.py
@@ -10,6 +10,7 @@ This module provides an interface to the :class:`ComponentManager <vivarium.fram
 from __future__ import annotations
 
 from collections.abc import Sequence
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Union
 
 from vivarium import Component
@@ -98,3 +99,20 @@ class ComponentInterface(Interface):
                 If there is no component or manager currently being set up.
         """
         return self._manager.get_current_component_or_manager()
+
+    def _tracking_setup(self, component: Component | Manager) -> AbstractContextManager[None]:
+        """Context manager that tracks the component currently being set up.
+
+        Delegates to
+        :meth:`ComponentManager._tracking_setup
+        <vivarium.framework.components.manager.ComponentManager._tracking_setup>`.
+        This is intentionally private: write-access to
+        ``ComponentManager._current_component`` should remain confined to the
+        setup lifecycle.
+
+        Parameters
+        ----------
+        component
+            The component or manager currently being set up.
+        """
+        return self._manager.tracking_setup(component)

--- a/src/vivarium/framework/components/manager.py
+++ b/src/vivarium/framework/components/manager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Generic, TypeVar
 
 from layered_config_tree import (
@@ -143,10 +144,14 @@ class ComponentManager(Manager):
         """The name of this component."""
         return "component_manager"
 
-    def setup_manager(
+    def setup_manager(  # type: ignore[override]
         self, configuration: LayeredConfigTree, lifecycle_manager: LifeCycleManager
     ) -> None:
-        """Called by the simulation context."""
+        """Sets up the component manager.
+
+        It registers lifecycle constraints and stores the configuration tree. Unlike other
+        managers, this is called directly by the simulation context during its __init__.
+        """
         self._configuration = configuration
 
         lifecycle_manager.add_constraint(
@@ -275,6 +280,27 @@ class ComponentManager(Manager):
             raise LifeCycleError("No component or manager is currently being set up.")
         return self._current_component
 
+    @contextmanager
+    def tracking_setup(self, component: Component | Manager) -> Iterator[None]:
+        """Context manager that sets ``_current_component`` to ``component``
+        for the duration of the block, then restores the previous value.
+
+        Using save-and-restore rather than a plain assignment means nested
+        calls (e.g. a manager whose ``setup`` calls ``super().setup``) work
+        correctly.
+
+        Parameters
+        ----------
+        component
+            The component or manager currently being set up.
+        """
+        previous = self._current_component
+        self._current_component = component
+        try:
+            yield
+        finally:
+            self._current_component = previous
+
     def setup_components(self, builder: Builder) -> None:
         """Separately configure and set up the managers and components held by
         the component manager, in that order.
@@ -290,14 +316,10 @@ class ComponentManager(Manager):
             Interface to several simulation tools.
         """
         for manager in self._managers:
-            self._current_component = manager
-            manager.setup(builder)
+            manager.setup_manager(builder)
 
         for component in self._components:
-            self._current_component = component
             component.setup_component(builder)
-
-        self._current_component = None
 
     def apply_configuration_defaults(self, component: Component | Manager) -> None:
         try:

--- a/src/vivarium/framework/results/observer.py
+++ b/src/vivarium/framework/results/observer.py
@@ -65,9 +65,10 @@ class Observer(Component, ABC):
 
     def setup_component(self, builder: Builder) -> None:
         """Sets up the observer component."""
-        super().setup_component(builder)
-        self.register_observations(builder)
-        self.set_results_dir(builder)
+        with builder.components._tracking_setup(self):
+            super().setup_component(builder)
+            self.register_observations(builder)
+            self.set_results_dir(builder)
 
     def set_results_dir(self, builder: Builder) -> None:
         """Defines the results directory from the configuration."""

--- a/src/vivarium/manager.py
+++ b/src/vivarium/manager.py
@@ -53,10 +53,9 @@ class Manager(ABC):
         This method is run by Vivarium during the setup phase. It performs a series
         of operations to prepare the manager for the simulation.
 
-        It sets the :attr:`logger` for the manager, sets up the manager, sets the
-        population view, and registers various listeners including ``post_setup``,
-        ``simulant_initializer``, ``time_step__prepare``, ``time_step``, ``time_step__cleanup``,
-        ``collect_metrics``, and ``simulation_end`` listeners.
+        It sets up the manager, sets the population view, and registers various listeners
+        including ``post_setup``, ``simulant_initializer``, ``time_step__prepare``, ``time_step``,
+        ``time_step__cleanup``, ``collect_metrics``, and ``simulation_end`` listeners.
 
         Parameters
         ----------
@@ -64,7 +63,6 @@ class Manager(ABC):
             The builder object used to set up the manager.
         """
         with builder.components._tracking_setup(self):
-            self._logger = builder.logging.get_logger(self.name)
             self.setup(builder)
 
     #######################

--- a/src/vivarium/manager.py
+++ b/src/vivarium/manager.py
@@ -47,12 +47,37 @@ class Manager(ABC):
     # Lifecycle methods #
     #####################
 
+    def setup_manager(self, builder: Builder) -> None:
+        """Sets up the manager for a Vivarium simulation.
+
+        This method is run by Vivarium during the setup phase. It performs a series
+        of operations to prepare the manager for the simulation.
+
+        It sets the :attr:`logger` for the manager, sets up the manager, sets the
+        population view, and registers various listeners including ``post_setup``,
+        ``simulant_initializer``, ``time_step__prepare``, ``time_step``, ``time_step__cleanup``,
+        ``collect_metrics``, and ``simulation_end`` listeners.
+
+        Parameters
+        ----------
+        builder
+            The builder object used to set up the manager.
+        """
+        with builder.components._tracking_setup(self):
+            self._logger = builder.logging.get_logger(self.name)
+            self.setup(builder)
+
+    #######################
+    # Methods to override #
+    #######################
+
     def setup(self, builder: Builder) -> None:
         """Defines custom actions this manager needs to run during the setup
         lifecycle phase.
 
         This method is intended to be overridden by subclasses to perform any
-        necessary setup operations specific to the manager.
+        necessary setup operations specific to the manager. By default, it
+        does nothing.
 
         Parameters
         ----------

--- a/tests/framework/components/test_manager.py
+++ b/tests/framework/components/test_manager.py
@@ -183,7 +183,7 @@ def test_flatten_with_nested_sub_components() -> None:
 
 
 def test_setup_components(mocker: MockerFixture) -> None:
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration = {}
     mocker.patch("vivarium.framework.results.observer.Observer.set_results_dir")
     mocker.patch("vivarium.framework.results.observer.Observer.get_configuration")

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -36,7 +36,7 @@ def test_register_stratification(mocker: MockerFixture) -> None:
         # NOTE: it does not actually matter what this mapper returns for this test
         return "this was pointless"
 
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     # Set up mock builder with mocked get_attribute call for Pipelines
     mocker.patch.object(builder, "value.get_attribute")
     mgr = ResultsManager()
@@ -73,7 +73,7 @@ def test_register_binned_stratification(mocker: MockerFixture) -> None:
 
     mgr = ResultsManager()
     mgr.logger = logger
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     mocker.patch.object(builder, "value.get_attribute")
     mgr.setup(builder)
 
@@ -122,7 +122,7 @@ def test_register_binned_stratification(mocker: MockerFixture) -> None:
 def test_register_observation_raises(
     obs_type: str, missing_args: list[str], mocker: MockerFixture
 ) -> None:
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = []
     mgr = ResultsManager()
     mgr.setup(builder)
@@ -140,7 +140,7 @@ def test_register_observation_raises(
 def test_register_stratified_observation(mocker: MockerFixture) -> None:
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = ["default-stratification", "exclude-this"]
     mgr.setup(builder)
     for strat in [
@@ -207,7 +207,7 @@ def test_register_stratified_observation(mocker: MockerFixture) -> None:
 def test_register_unstratified_observation(mocker: MockerFixture) -> None:
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     mgr.setup(builder)
     assert len(interface._manager._results_context.grouped_observations) == 0
     interface.register_unstratified_observation(
@@ -288,7 +288,7 @@ def test_register_adding_observation(
 ) -> None:
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = []
     mgr.setup(builder)
     assert len(interface._manager._results_context.grouped_observations) == 0
@@ -308,7 +308,7 @@ def test_register_adding_observation(
 def test_register_multiple_adding_observations(mocker: MockerFixture) -> None:
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = []
     mgr.setup(builder)
 
@@ -354,7 +354,7 @@ def test_register_multiple_adding_observations(mocker: MockerFixture) -> None:
 def test_unhashable_pipeline(mocker: MockerFixture) -> None:
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = []
     mgr.setup(builder)
 
@@ -385,7 +385,7 @@ def test_register_adding_observation_when_options(when: str, mocker: MockerFixtu
     """Test the full interface lifecycle of adding an observation and simulation event."""
     mgr = ResultsManager()
     results_interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification = LayeredConfigTree(
         {"default": [], "excluded_categories": {}}
     )
@@ -450,7 +450,7 @@ def test_register_adding_observation_when_options(when: str, mocker: MockerFixtu
 def test_register_concatenating_observation(mocker: MockerFixture) -> None:
     mgr = ResultsManager()
     interface = ResultsInterface(mgr)
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = []
     # Set up mock builder with mocked get_attribute call for Pipelines
     mocker.patch.object(builder, "value.get_attribute")

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -114,7 +114,7 @@ def test_register_stratification(
     is_vectorized: bool,
 ) -> None:
     mgr = ResultsManager()
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification = LayeredConfigTree(
         {"default": [], "excluded_categories": {}}
     )
@@ -209,7 +209,7 @@ def test_add_observation_nop_stratifications(
     caplog: LogCaptureFixture,
 ) -> None:
     mgr = ResultsManager()
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     mgr.setup(builder)
     mgr.logger = logger
 
@@ -233,7 +233,7 @@ def test_add_observation_nop_stratifications(
 def test_setting_default_stratifications_at_setup(mocker: pytest_mock.MockFixture) -> None:
     """Test that set default stratifications happens at setup"""
     mgr = ResultsManager()
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     mocker.patch.object(mgr._results_context, "set_default_stratifications")
     mgr._results_context.set_default_stratifications.assert_not_called()  # type: ignore[attr-defined]
 
@@ -252,7 +252,7 @@ def test_setting_default_stratifications_at_setup(mocker: pytest_mock.MockFixtur
 def test__raw_results_initialized_as_empty_dict(mocker: pytest_mock.MockFixture) -> None:
     """Test that raw results are initialized as an empty dictionary"""
     mgr = ResultsManager()
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     mgr.setup(builder)
     assert mgr._raw_results == {}
 

--- a/tests/framework/results/test_stratification.py
+++ b/tests/framework/results/test_stratification.py
@@ -191,7 +191,7 @@ def test_setting_default_stratifications(
 ) -> None:
     """Test that default stratifications are set as expected."""
     mgr = ResultsManager()
-    builder = mocker.Mock()
+    builder = mocker.MagicMock()
     builder.configuration.stratification.default = default_stratifications
 
     mgr.setup(builder)

--- a/tests/interface/test_interactive.py
+++ b/tests/interface/test_interactive.py
@@ -260,7 +260,7 @@ class TestGetPopulationNestedAttributes:
         # False inside the nested source should have applied the tracked query
         assert tracked_count == pop["inner"].eq(1).sum()
 
-        self._assert_depth(sim, max_depth, 2)
+        self._assert_depth(sim, max_depth, 3)
 
     @pytest.mark.parametrize("include_untracked", [None, True, False])
     def test_get_private_columns_nested_path(
@@ -282,6 +282,7 @@ class TestGetPopulationNestedAttributes:
             outer_column=("outer", "doubled_inner"),
             expected_baseline_outer={0, 2, 4},
             expected_filtered_outer={2},
+            expected_depth=2,
         )
 
     @pytest.mark.parametrize("include_untracked", [None, True, False])
@@ -324,7 +325,7 @@ class TestGetPopulationNestedAttributes:
         outer_column: str | tuple[str, str] | None = None,
         expected_baseline_outer: set[int] | None = None,
         expected_filtered_outer: set[int] | None = None,
-        expected_depth: int = 2,
+        expected_depth: int = 3,
     ) -> None:
         """Common assertion pattern for nested query suppression tests.
 


### PR DESCRIPTION
## Track component being set up using a context manager
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6895

### Changes and notes
Track the component being set up automatically using a context manager 

### Testing
Ran make check