### PR TITLE
Sbachmei/mic 6855/return query calls even if skip post processor

### DIFF
--- a/src/vivarium/framework/population/manager.py
+++ b/src/vivarium/framework/population/manager.py
@@ -614,7 +614,9 @@ class PopulationManager(Manager):
             skip_post_processor,
         )
         if skip_post_processor:
-            # FIXME [MIC-6855] Does not return requested_query_columns
+            # NOTE: This correctly returns the requested attribute even when it
+            # overlaps with query columns because we pass `requested_attributes`
+            # (not `columns_to_get`) above when `skip_post_processor` is True.
             return data
 
         # Add on any query columns that are actually requested to be returned

--- a/tests/framework/population/test_population_view.py
+++ b/tests/framework/population/test_population_view.py
@@ -227,6 +227,35 @@ def test_get_attributes_skip_post_processor_with_query(
     assert call_args[1] == {"skip_post_processor": True}
 
 
+def test_get_attributes_skip_post_processor_returns_queried_attribute(
+    pies_and_cubes_pop_mgr: PopulationManager,
+) -> None:
+    """Test that skip_post_processor returns the attribute even when it's also used in the query."""
+    pv = pies_and_cubes_pop_mgr.get_view(PieComponent())
+    full_idx = pd.RangeIndex(0, len(PIE_RECORDS))
+
+    def mock_pie_pipeline(idx: pd.Index[int], skip_post_processor: bool) -> pd.Series[Any]:
+        private_col_df = pies_and_cubes_pop_mgr._private_columns
+        assert isinstance(private_col_df, pd.DataFrame)
+        return private_col_df.loc[idx, "pie"]
+
+    pies_and_cubes_pop_mgr._attribute_pipelines["pie"].side_effect = mock_pie_pipeline  # type: ignore[attr-defined]
+
+    # No query - full attribute
+    result = pv.get_attributes(full_idx, "pie", skip_post_processor=True)
+    pd.testing.assert_series_equal(result, PIE_DF["pie"])
+
+    # Request "pie" while querying "cube"
+    result = pv.get_attributes(full_idx, "pie", query="pi > 1000", skip_post_processor=True)
+    pd.testing.assert_series_equal(result, PIE_DF.loc[PIE_DF["pi"] > 1000, "pie"])
+
+    # Request "pie" while also querying on "pie" -- the attribute should still be returned
+    result = pv.get_attributes(
+        full_idx, "pie", query="pie == 'apple'", skip_post_processor=True
+    )
+    pd.testing.assert_series_equal(result, PIE_DF.loc[PIE_DF["pie"] == "apple", "pie"])
+
+
 @pytest.mark.parametrize("register_tracked_query", [True, False])
 @pytest.mark.parametrize("include_untracked", [True, False])
 def test_get_attributes_combined_query(


### PR DESCRIPTION
## Return query calls even if skip post processor

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6855

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> Turns out this wasn't actually a bug but I've added a test

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

