### PR TITLE
Require 'attributes' arg when calling InteractiveContext.get_population

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.0.1 - 04/02/26**
+
+- Remove support for calling InteractiveContext.get_population() without an explicit attribute request
+
 **4.0.0 - 04/02/26**
 -----------------------
 

--- a/docs/source/concepts/lookup.rst
+++ b/docs/source/concepts/lookup.rst
@@ -282,8 +282,8 @@ and for ease of debugging. If you don't provide value column names, it will defa
 
       # value_columns implicitly set to remaining columns
     > bmi = sim.builder.lookup.build_table(data, name="bmi")
-    > population = sim.get_population()
-    > bmi(population.index).head()  # returns BMI values for the population
+    > pop_index = sim.get_population_index()
+    > bmi(pop_index).head()  # returns BMI values for the population
 
       0     20.0
       1     20.0

--- a/docs/source/tutorials/exploration.rst
+++ b/docs/source/tutorials/exploration.rst
@@ -295,7 +295,15 @@ your starting population.
 
 .. code-block:: python
 
-    pop = sim.get_population()
+    pop = sim.get_population(
+        [
+            "age",
+            "is_alive",
+            "entrance_time",
+            "lower_respiratory_infections",
+            "child_wasting_propensity",
+        ]
+    )
     print(pop.head())
 
 ::
@@ -314,7 +322,16 @@ the population as a whole.
 .. testcode::
     :hide:
 
-    pop = sim.get_population()
+    pop = sim.get_population(
+        [
+            "age",
+            "sex",
+            "is_alive",
+            "entrance_time",
+            "lower_respiratory_infections",
+            "child_wasting_propensity",
+        ]
+    )
     pop = pop.reindex(sorted(pop.columns), axis=1)
     print(pop.age.describe())
     print(pop.is_alive.value_counts())

--- a/src/vivarium/examples/boids/visualization.py
+++ b/src/vivarium/examples/boids/visualization.py
@@ -8,7 +8,7 @@ from vivarium import InteractiveContext
 def plot_boids(simulation: InteractiveContext, plot_velocity: bool=False) -> None:
     width = simulation.configuration.field.width
     height = simulation.configuration.field.height
-    pop = simulation.get_population()
+    pop = simulation.get_population(["x", "y", "color", "vx", "vy"])
 
     plt.figure(figsize=(12, 12))
     plt.scatter(pop.x, pop.y, color=pop.color)
@@ -24,7 +24,7 @@ def plot_boids(simulation: InteractiveContext, plot_velocity: bool=False) -> Non
 def plot_boids_animated(simulation: InteractiveContext) -> FuncAnimation:
     width = simulation.configuration.field.width
     height = simulation.configuration.field.height
-    pop = simulation.get_population()
+    pop = simulation.get_population(["x", "y", "color"])
 
     fig = plt.figure(figsize=(12, 12))
     ax = fig.add_subplot(111)

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -168,7 +168,7 @@ class InteractiveContext(SimulationContext):
     @overload
     def get_population(
         self,
-        attributes: str | None = None,
+        attributes: str,
         query: str = "",
         include_untracked: bool = False,
     ) -> pd.Series[Any] | pd.DataFrame:
@@ -177,7 +177,7 @@ class InteractiveContext(SimulationContext):
     @overload
     def get_population(
         self,
-        attributes: list[str] | tuple[str, ...] = ...,
+        attributes: list[str] | tuple[str, ...],
         query: str = "",
         include_untracked: bool = False,
     ) -> pd.DataFrame:
@@ -185,7 +185,7 @@ class InteractiveContext(SimulationContext):
 
     def get_population(
         self,
-        attributes: str | list[str] | tuple[str, ...] | None = None,
+        attributes: str | list[str] | tuple[str, ...],
         query: str = "",
         include_untracked: bool = False,
     ) -> pd.Series[Any] | pd.DataFrame:
@@ -194,8 +194,7 @@ class InteractiveContext(SimulationContext):
         Parameters
         ----------
         attributes
-            The attribute pipelines to include in the returned table. If None, all
-            attributes are included.
+            The attribute pipelines to include in the returned table.
         query
             Additional conditions used to filter the index.
         include_untracked
@@ -206,10 +205,6 @@ class InteractiveContext(SimulationContext):
             The current state of requested population attributes.
         """
         index = self.get_population_index()
-        if attributes is None:
-            attributes = self.get_attribute_names()
-            if len(attributes) == 1:
-                attributes = attributes[0]
         if isinstance(attributes, str):
             try:
                 return self._population_view.get(

--- a/tests/examples/test_disease_model.py
+++ b/tests/examples/test_disease_model.py
@@ -29,7 +29,8 @@ def test_disease_model(fuzzy_checker: FuzzyChecker, disease_model_spec: Path) ->
 
     simulation = InteractiveContext(config)
 
-    pop = simulation.get_population()
+    all_attributes = simulation.get_attribute_names()
+    pop = simulation.get_population(all_attributes)
     expected_columns = {
         "is_alive",
         "previous_alive",

--- a/tests/framework/randomness/test_crn.py
+++ b/tests/framework/randomness/test_crn.py
@@ -219,17 +219,17 @@ def test_multi_sim_basic_reproducibility_with_same_pop_growth(
         components=[pop_class(with_crn=with_crn, sims_to_add=sims_to_add)],
         configuration=configuration,
     )
-
-    pop1 = sim1.get_population().set_index(["crn_attr1", "crn_attr2"])
-    pop2 = sim2.get_population().set_index(["crn_attr1", "crn_attr2"])
+    attribute_names = ["crn_attr1", "crn_attr2", "other_attr1"]
+    pop1 = sim1.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
+    pop2 = sim2.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
     assert_frame_equal(pop1, pop2)
 
     for i in range(2):
         sim1.step()
         sim2.step()
 
-    pop1 = sim1.get_population().set_index(["crn_attr1", "crn_attr2"])
-    pop2 = sim2.get_population().set_index(["crn_attr1", "crn_attr2"])
+    pop1 = sim1.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
+    pop2 = sim2.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
     assert_frame_equal(pop1, pop2)
 
 
@@ -260,8 +260,9 @@ def test_multi_sim_reproducibility_with_different_pop_growth(
         configuration=configuration,
     )
 
-    pop1 = sim1.get_population().set_index(["crn_attr1", "crn_attr2"])
-    pop2 = sim2.get_population().set_index(["crn_attr1", "crn_attr2"])
+    attribute_names = ["crn_attr1", "crn_attr2", "other_attr1"]
+    pop1 = sim1.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
+    pop2 = sim2.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
     initial_pop_size = len(pop1)
     assert_frame_equal(pop1, pop2)
 
@@ -270,8 +271,8 @@ def test_multi_sim_reproducibility_with_different_pop_growth(
         sim1.step()
         sim2.step()
 
-    pop1 = sim1.get_population().set_index(["crn_attr1", "crn_attr2"])
-    pop2 = sim2.get_population().set_index(["crn_attr1", "crn_attr2"])
+    pop1 = sim1.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
+    pop2 = sim2.get_population(attribute_names).set_index(["crn_attr1", "crn_attr2"])
 
     if with_crn:
         overlap = pop1.index.intersection(pop2.index)

--- a/tests/framework/test_engine.py
+++ b/tests/framework/test_engine.py
@@ -543,7 +543,7 @@ def test_private_columns_get_registered() -> None:
         "datetime_clock": [],
     }
     # Check that there are indeed other attributes registered besides via column_created
-    len(sim.get_population().columns) > 3
+    len(sim.get_population(sim.get_attribute_names()).columns) > 3
 
 
 ####################

--- a/tests/interface/test_interactive.py
+++ b/tests/interface/test_interactive.py
@@ -51,21 +51,20 @@ def test_get_attribute_names() -> None:
     sim = InteractiveContext(
         components=[MultiLevelMultiColumnCreator(), AttributePipelineCreator()]
     )
-    assert set(sim.get_attribute_names()) == set(
-        [
-            # MultiLevelMultiColumnCreator attributes
-            "some_attribute",
-            "some_other_attribute",
-            # AttributePipelineCreator attributes
-            "attribute_generating_columns_4_5",
-            "attribute_generating_column_8",
-            "test_attribute",
-            "attribute_generating_columns_6_7",
-        ]
-    )
+    expected_attributes = [
+        # MultiLevelMultiColumnCreator attributes
+        "some_attribute",
+        "some_other_attribute",
+        # AttributePipelineCreator attributes
+        "attribute_generating_columns_4_5",
+        "attribute_generating_column_8",
+        "test_attribute",
+        "attribute_generating_columns_6_7",
+    ]
+    assert set(sim.get_attribute_names()) == set(expected_attributes)
     # Make sure there's nothing unexpected compared to the actual population df
     assert set(sim.get_attribute_names()) == set(
-        sim.get_population().columns.get_level_values(0)
+        sim.get_population(expected_attributes).columns.get_level_values(0)
     )
 
 
@@ -101,10 +100,6 @@ def test_get_population_squeezing() -> None:
     unsqueezed = sim.get_population(["test_column_1"])
     squeezed = sim.get_population("test_column_1")
     assert_squeezing_single_level_single_col(unsqueezed, squeezed, "test_column_1")
-    default = sim.get_population()
-    assert isinstance(default, pd.Series)
-    assert isinstance(squeezed, pd.Series)
-    assert default.equals(squeezed)
 
     # Single-level, multiple-column -> dataframe
     component = ColumnCreator()
@@ -113,8 +108,6 @@ def test_get_population_squeezing() -> None:
     df = sim.get_population(["test_column_1", "test_column_2", "test_column_3"])
     assert isinstance(df, pd.DataFrame)
     assert not isinstance(df.columns, pd.MultiIndex)
-    default = sim.get_population()
-    assert default.equals(df)  # type: ignore[arg-type]
 
     # Multi-level, single outer, single inner -> series
     sim = InteractiveContext(components=[MultiLevelSingleColumnCreator()], setup=True)
@@ -123,10 +116,6 @@ def test_get_population_squeezing() -> None:
     assert_squeezing_multi_level_single_outer_single_inner(
         unsqueezed, squeezed, ("some_attribute", "some_column")
     )
-    default = sim.get_population()
-    assert isinstance(default, pd.Series)
-    assert isinstance(squeezed, pd.Series)
-    assert default.equals(squeezed)
 
     # Multi-level, single outer, multiple inner -> inner dataframe
     sim = InteractiveContext(components=[MultiLevelMultiColumnCreator()], setup=True)
@@ -134,9 +123,6 @@ def test_get_population_squeezing() -> None:
     unsqueezed = sim.get_population(["some_attribute"])
     squeezed = sim.get_population("some_attribute")
     assert_squeezing_multi_level_single_outer_multi_inner(unsqueezed, squeezed)
-    default = sim.get_population()
-    assert isinstance(default, pd.DataFrame)
-    assert default.equals(squeezed)
 
     # Multi-level, multiple outer -> full unsqueezed multi-level dataframe
     sim = InteractiveContext(components=[MultiLevelMultiColumnCreator()], setup=True)
@@ -144,8 +130,6 @@ def test_get_population_squeezing() -> None:
     df = sim.get_population(["some_attribute", "some_other_attribute"])
     assert isinstance(df, pd.DataFrame)
     assert isinstance(df.columns, pd.MultiIndex)
-    default = sim.get_population()
-    assert default.equals(df)  # type: ignore[arg-type]
 
 
 class TestGetPopulationNestedAttributes:
@@ -245,7 +229,7 @@ class TestGetPopulationNestedAttributes:
         max_depth = self._patch_depth_tracking(sim, mocker)
 
         # Use include_untracked=True at top level so we see all simulants
-        pop = sim.get_population(include_untracked=True)
+        pop = sim.get_population(["outer", "inner"], include_untracked=True)
         total = len(pop)
         tracked_count = pop[("outer", "tracked_count")].iloc[0]
         all_count = pop[("outer", "all_count")].iloc[0]
@@ -311,7 +295,7 @@ class TestGetPopulationNestedAttributes:
             kwargs["include_untracked"] = include_untracked
 
         max_depth = self._patch_depth_tracking(sim, mocker)
-        pop = sim.get_population(**kwargs)  # type: ignore[call-overload]
+        pop = sim.get_population(sim.get_attribute_names(), **kwargs)  # type: ignore[call-overload]
         if include_untracked is True:
             assert set(pop["inner"]) == {0, 1, 2}
             if outer_column is not None:


### PR DESCRIPTION
Require 'attributes' arg when calling InteractiveContext.get_population

## Title: Summary, imperative, start upper case, don't end with a period
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

