### PR TITLE
Albrja/mic 6867/observer priority

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.1.2 - 04/28/26**
+
+- Add support for observations to specify priority for lifecycle events
+
 **4.1.1 - 04/21/26**
 
 - Raise error if registering duplicate Pipelines

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
-**4.1.2 - 04/28/26**
+**4.1.2 - 04/29/26**
 
 - Add support for observations to specify priority for lifecycle events
+- Added priority attribute to `Event`
 
 **4.1.1 - 04/21/26**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**4.1.2 - 04/29/26**
+**4.1.2 - 05/04/26**
 
 - Add support for observations to specify priority for lifecycle events
 - Added priority attribute to `Event`

--- a/src/vivarium/component.py
+++ b/src/vivarium/component.py
@@ -33,6 +33,9 @@ if TYPE_CHECKING:
     from vivarium.framework.population import PopulationView
     from vivarium.types import DataInput
 
+NUM_EVENT_PRIORITIES = 10
+"""The number of priority levels available for event listeners."""
+
 DEFAULT_EVENT_PRIORITY = 5
 """The default priority at which events will be triggered."""
 

--- a/src/vivarium/framework/event/interface.py
+++ b/src/vivarium/framework/event/interface.py
@@ -32,7 +32,7 @@ class EventInterface(Interface):
 
     def get_emitter(
         self, event_name: str
-    ) -> Callable[[pd.Index[int], dict[str, Any] | None], Event]:
+    ) -> Callable[[pd.Index[int], dict[str, Any] | None], None]:
         """Gets an emitter for a named ``Event``.
 
         Parameters

--- a/src/vivarium/framework/event/manager.py
+++ b/src/vivarium/framework/event/manager.py
@@ -56,6 +56,8 @@ class Event:
     size plus the current time step size."""
     step_size: ClockStepSize
     """The current step size at the time of the event."""
+    priority: int
+    """The priority level of this event. Events with lower priority levels are emitted first."""
 
     def split(self, new_index: pd.Index[int]) -> "Event":
         """Creates a copy of this event with a new index.
@@ -73,7 +75,9 @@ class Event:
         -------
             The new event.
         """
-        return Event(self.name, new_index, self.user_data, self.time, self.step_size)
+        return Event(
+            self.name, new_index, self.user_data, self.time, self.step_size, self.priority
+        )
 
     def __repr__(self) -> str:
         return f"Event(name={self.name}, user_data={self.user_data}, time={self.time}, step_size={self.step_size})"
@@ -91,7 +95,7 @@ class EventChannel:
         self.manager = manager
         self.listeners: list[list[Callable[[Event], None]]] = [[] for _ in range(10)]
 
-    def emit(self, index: pd.Index[int], user_data: dict[str, Any] | None = None) -> Event:
+    def emit(self, index: pd.Index[int], user_data: dict[str, Any] | None = None) -> None:
         """Notifies all listeners to this channel that an event has occurred.
 
         Events are emitted to listeners in order of priority (with order 0 being
@@ -121,18 +125,19 @@ class EventChannel:
                 f"Clock ({type(clock)}) and step size ({type(step_size)}) are not compatible."
             )
 
-        e = Event(
-            self.event_name,
-            index,
-            user_data,
-            event_time,
-            step_size,
-        )
+        for priority, listeners in enumerate(self.listeners):
+            # Create an event for each priority in each lifecycle phase
+            e = Event(
+                self.event_name,
+                index,
+                user_data,
+                event_time,
+                step_size,
+                priority,
+            )
 
-        for priority_bucket in self.listeners:
-            for listener in priority_bucket:
+            for listener in listeners:
                 listener(e)
-        return e
 
     def __repr__(self) -> str:
         return f"EventChannel(listeners: {[listener for bucket in self.listeners for listener in bucket]})"

--- a/src/vivarium/framework/event/manager.py
+++ b/src/vivarium/framework/event/manager.py
@@ -200,7 +200,7 @@ class EventManager(Manager):
 
     def get_emitter(
         self, event_name: str
-    ) -> Callable[[pd.Index[int], dict[str, Any] | None], Event]:
+    ) -> Callable[[pd.Index[int], dict[str, Any] | None], None]:
         """Gets an emitter function for the named event.
 
         Parameters

--- a/src/vivarium/framework/event/manager.py
+++ b/src/vivarium/framework/event/manager.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
+from vivarium.component import NUM_EVENT_PRIORITIES
 from vivarium.framework.lifecycle import ConstraintError, lifecycle_states
 from vivarium.manager import Manager
 from vivarium.types import ClockStepSize, ClockTime
@@ -93,7 +94,9 @@ class EventChannel:
         self.event_name = event_name
         self.name = f"event_channel_{event_name}"
         self.manager = manager
-        self.listeners: list[list[Callable[[Event], None]]] = [[] for _ in range(10)]
+        self.listeners: list[list[Callable[[Event], None]]] = [
+            [] for _ in range(NUM_EVENT_PRIORITIES)
+        ]
 
     def emit(self, index: pd.Index[int], user_data: dict[str, Any] | None = None) -> None:
         """Notifies all listeners to this channel that an event has occurred.

--- a/src/vivarium/framework/event/manager.py
+++ b/src/vivarium/framework/event/manager.py
@@ -58,7 +58,7 @@ class Event:
     step_size: ClockStepSize
     """The current step size at the time of the event."""
     priority: int
-    """The priority level of this event. Events with lower priority levels are emitted first."""
+    """The priority of the lifecycle phase this Event is emitted in. Events with lower priority levels are emitted first."""
 
     def split(self, new_index: pd.Index[int]) -> "Event":
         """Creates a copy of this event with a new index.

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -222,6 +222,7 @@ class ResultsContext:
         name: str,
         population_filter: PopulationFilter,
         when: str,
+        priority: int,
         requires_attributes: list[str],
         stratifications: tuple[str, ...] | None,
         **kwargs: Any,
@@ -265,6 +266,7 @@ class ResultsContext:
             population_filter=population_filter,
             when=when,
             requires_attributes=requires_attributes,
+            priority=priority,
             **kwargs,
         )
         self.observations[name] = observation
@@ -358,14 +360,15 @@ class ResultsContext:
         Returns
         -------
             A list of Observations for the given event. Only includes observations
-            whose `to_observe` method returns True.
+            whose ``priority`` matches the event priority and whose ``to_observe``
+            method returns True.
         """
         return [
             observation
             for stratification_observations in self.grouped_observations[event.name].values()
             for observations in stratification_observations.values()
             for observation in observations
-            if observation.to_observe(event)
+            if observation.priority == event.priority and observation.to_observe(event)
         ]
 
     def get_stratifications(self, observations: list[Observation]) -> list[Stratification]:

--- a/src/vivarium/framework/results/context.py
+++ b/src/vivarium/framework/results/context.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.framework.event import Event
 from vivarium.framework.population import utilities as pop_utils
 from vivarium.framework.results.exceptions import ResultsConfigurationError
@@ -222,9 +223,9 @@ class ResultsContext:
         name: str,
         population_filter: PopulationFilter,
         when: str,
-        priority: int,
         requires_attributes: list[str],
         stratifications: tuple[str, ...] | None,
+        priority: int = DEFAULT_EVENT_PRIORITY,
         **kwargs: Any,
     ) -> Observation:
         """Adds an observation to the results context.

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple, Sequence, Union
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.results.observation import (
@@ -195,6 +196,7 @@ class ResultsInterface(Interface):
         pop_filter: str = "",
         include_untracked: bool = False,
         when: str = lifecycle_states.COLLECT_METRICS,
+        priority: int = DEFAULT_EVENT_PRIORITY,
         requires_attributes: list[str] = [],
         results_updater: ResultsUpdater = _required_function_placeholder,
         results_formatter: ResultsFormatter = _default_stratified_observation_formatter,
@@ -219,6 +221,9 @@ class ResultsInterface(Interface):
         when
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
+        priority
+            The priority level of this observation within its lifecycle phase.
+            Observations with lower priority values are observed first.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_updater
@@ -249,6 +254,7 @@ class ResultsInterface(Interface):
             name=name,
             population_filter=PopulationFilter(pop_filter, include_untracked),
             when=when,
+            priority=priority,
             requires_attributes=requires_attributes,
             results_updater=results_updater,
             results_formatter=results_formatter,
@@ -265,6 +271,7 @@ class ResultsInterface(Interface):
         pop_filter: str = "",
         include_untracked: bool = False,
         when: str = lifecycle_states.COLLECT_METRICS,
+        priority: int = DEFAULT_EVENT_PRIORITY,
         requires_attributes: list[str] = [],
         results_gatherer: ResultsGatherer = _required_function_placeholder,
         results_updater: ResultsUpdater = _required_function_placeholder,
@@ -286,6 +293,9 @@ class ResultsInterface(Interface):
         when
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
+        priority
+            The priority level of this observation within its lifecycle phase.
+            Observations with lower priority values are observed first.
         requires_attributes
             The population attributes that are required by the `results_gatherer`.
         results_gatherer
@@ -312,6 +322,7 @@ class ResultsInterface(Interface):
             name=name,
             population_filter=PopulationFilter(pop_filter, include_untracked),
             when=when,
+            priority=priority,
             requires_attributes=requires_attributes,
             results_updater=results_updater,
             results_gatherer=results_gatherer,
@@ -325,6 +336,7 @@ class ResultsInterface(Interface):
         pop_filter: str = "",
         include_untracked: bool = False,
         when: str = lifecycle_states.COLLECT_METRICS,
+        priority: int = DEFAULT_EVENT_PRIORITY,
         requires_attributes: list[str] = [],
         results_formatter: ResultsFormatter = _default_stratified_observation_formatter,
         additional_stratifications: list[str] = [],
@@ -355,6 +367,9 @@ class ResultsInterface(Interface):
         when
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
+        priority
+            The priority level of this observation within its lifecycle phase.
+            Observations with lower priority values are observed first.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_formatter
@@ -377,6 +392,7 @@ class ResultsInterface(Interface):
             name=name,
             population_filter=PopulationFilter(pop_filter, include_untracked),
             when=when,
+            priority=priority,
             requires_attributes=requires_attributes,
             results_formatter=results_formatter,
             additional_stratifications=additional_stratifications,
@@ -392,6 +408,7 @@ class ResultsInterface(Interface):
         pop_filter: str = "",
         include_untracked: bool = False,
         when: str = lifecycle_states.COLLECT_METRICS,
+        priority: int = DEFAULT_EVENT_PRIORITY,
         requires_attributes: list[str] = [],
         results_formatter: ResultsFormatter = _default_unstratified_observation_formatter,
         to_observe: Callable[[Event], bool] = lambda event: True,
@@ -418,6 +435,9 @@ class ResultsInterface(Interface):
         when
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
+        priority
+            The priority level of this observation within its lifecycle phase.
+            Observations with lower priority values are observed first.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_formatter
@@ -430,6 +450,7 @@ class ResultsInterface(Interface):
             name=name,
             population_filter=PopulationFilter(pop_filter, include_untracked),
             when=when,
+            priority=priority,
             requires_attributes=requires_attributes,
             results_formatter=results_formatter,
             to_observe=to_observe,

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -222,8 +222,7 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority level of this observation within its lifecycle phase.
-            Observations with lower priority values are observed first.
+            The priority level of the lifecycle phase (see `when`) that this observation will record.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_updater

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -293,8 +293,7 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority of the lifecycle phase this observation will record. Observations
-            with lower priority levels are recorded first.
+            The priority level of the lifecycle phase (see `when`) that this observation will record.
         requires_attributes
             The population attributes that are required by the `results_gatherer`.
         results_gatherer
@@ -367,8 +366,7 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority of the lifecycle phase this observation will record. Observations
-            with lower priority levels are recorded first.
+            The priority level of the lifecycle phase (see `when`) that this observation will record.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_formatter
@@ -435,8 +433,7 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority of the lifecycle phase this observation will record. Observations
-            with lower priority levels are recorded first.
+            The priority level of the lifecycle phase (see `when`) that this observation will record.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_formatter

--- a/src/vivarium/framework/results/interface.py
+++ b/src/vivarium/framework/results/interface.py
@@ -293,8 +293,8 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority level of this observation within its lifecycle phase.
-            Observations with lower priority values are observed first.
+            The priority of the lifecycle phase this observation will record. Observations
+            with lower priority levels are recorded first.
         requires_attributes
             The population attributes that are required by the `results_gatherer`.
         results_gatherer
@@ -367,8 +367,8 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority level of this observation within its lifecycle phase.
-            Observations with lower priority values are observed first.
+            The priority of the lifecycle phase this observation will record. Observations
+            with lower priority levels are recorded first.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_formatter
@@ -435,8 +435,8 @@ class ResultsInterface(Interface):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority level of this observation within its lifecycle phase.
-            Observations with lower priority values are observed first.
+            The priority of the lifecycle phase this observation will record. Observations
+            with lower priority levels are recorded first.
         requires_attributes
             The population attributes that are required by the `aggregator`.
         results_formatter

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 import pandas as pd
 
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.results.context import ResultsContext
@@ -75,16 +76,24 @@ class ResultsManager(Manager):
         self.step_size = builder.time.step_size()
 
         builder.event.register_listener(lifecycle_states.POST_SETUP, self.on_post_setup)
-        builder.event.register_listener(
-            lifecycle_states.TIME_STEP_PREPARE, self.on_time_step_prepare
-        )
-        builder.event.register_listener(lifecycle_states.TIME_STEP, self.on_time_step)
-        builder.event.register_listener(
-            lifecycle_states.TIME_STEP_CLEANUP, self.on_time_step_cleanup
-        )
-        builder.event.register_listener(
-            lifecycle_states.COLLECT_METRICS, self.on_collect_metrics
-        )
+
+        for priority in range(10):
+            builder.event.register_listener(
+                lifecycle_states.TIME_STEP_PREPARE,
+                self.on_time_step_prepare,
+                priority=priority,
+            )
+            builder.event.register_listener(
+                lifecycle_states.TIME_STEP, self.on_time_step, priority=priority
+            )
+            builder.event.register_listener(
+                lifecycle_states.TIME_STEP_CLEANUP,
+                self.on_time_step_cleanup,
+                priority=priority,
+            )
+            builder.event.register_listener(
+                lifecycle_states.COLLECT_METRICS, self.on_collect_metrics, priority=priority
+            )
 
         self.set_default_stratifications(builder)
 
@@ -254,7 +263,8 @@ class ResultsManager(Manager):
         name: str,
         population_filter: PopulationFilter,
         when: str,
-        requires_attributes: list[str],
+        priority: int = DEFAULT_EVENT_PRIORITY,
+        requires_attributes: list[str] = [],
         **kwargs: Any,
     ) -> None:
         """Registers an observation to the results system.
@@ -274,6 +284,9 @@ class ResultsManager(Manager):
         when
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
+        priority
+            The priority level of this observation within its lifecycle phase.
+            Observations with lower priority values are observed first.
         requires_attributes
             The population attributes that are required to compute the observation.
         **kwargs
@@ -303,6 +316,7 @@ class ResultsManager(Manager):
             name=name,
             population_filter=population_filter,
             when=when,
+            priority=priority,
             requires_attributes=requires_attributes,
             stratifications=stratifications,
             **kwargs,

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Sequence
 
 import pandas as pd
 
-from vivarium.component import DEFAULT_EVENT_PRIORITY
+from vivarium.component import DEFAULT_EVENT_PRIORITY, NUM_EVENT_PRIORITIES
 from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.results.context import ResultsContext
@@ -77,7 +77,9 @@ class ResultsManager(Manager):
 
         builder.event.register_listener(lifecycle_states.POST_SETUP, self.on_post_setup)
 
-        for priority in range(10):
+        # Register at every priority level so that observations fire in the
+        # correct priority order relative to other components' listeners.
+        for priority in range(NUM_EVENT_PRIORITIES):
             builder.event.register_listener(
                 lifecycle_states.TIME_STEP_PREPARE,
                 self.on_time_step_prepare,
@@ -293,6 +295,12 @@ class ResultsManager(Manager):
             Additional keyword arguments to be passed to the observation's constructor.
         """
         self.logger.debug(f"Registering observation {name}")
+
+        if not (0 <= priority < NUM_EVENT_PRIORITIES):
+            raise ValueError(
+                f"Priority must be an integer in range [0, {NUM_EVENT_PRIORITIES}), "
+                f"but got {priority} when registering observation '{name}'."
+            )
 
         if any(not isinstance(attribute, str) for attribute in requires_attributes):
             raise TypeError(

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -287,8 +287,7 @@ class ResultsManager(Manager):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority of the lifecycle phase this observation will record. Observations
-            with lower priority levels are recorded first.
+            The priority level of the lifecycle phase (see `when`) that this observation will record.
         requires_attributes
             The population attributes that are required to compute the observation.
         **kwargs

--- a/src/vivarium/framework/results/manager.py
+++ b/src/vivarium/framework/results/manager.py
@@ -287,8 +287,8 @@ class ResultsManager(Manager):
             Name of the lifecycle phase the observation should happen. Valid values are:
             "time_step__prepare", "time_step", "time_step__cleanup", or "collect_metrics".
         priority
-            The priority level of this observation within its lifecycle phase.
-            Observations with lower priority values are observed first.
+            The priority of the lifecycle phase this observation will record. Observations
+            with lower priority levels are recorded first.
         requires_attributes
             The population attributes that are required to compute the observation.
         **kwargs

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -84,6 +84,8 @@ class Observation(ABC):
     """Method or function that determines whether to perform an observation on this Event."""
     stratifications: tuple[Stratification, ...] | None = None
     """Optional tuple of the Stratifications this observation should use."""
+    priority: int = 5
+    """The priority level of this observation. Observations with lower priority levels are observed first."""
 
     def observe(
         self,

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -30,6 +30,7 @@ import pandas as pd
 from pandas.api.types import CategoricalDtype
 from pandas.core.groupby.generic import DataFrameGroupBy
 
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.exceptions import VivariumError
 from vivarium.framework.event import Event
 from vivarium.framework.results.stratification import Stratification, get_original_col_name
@@ -84,7 +85,7 @@ class Observation(ABC):
     """Method or function that determines whether to perform an observation on this Event."""
     stratifications: tuple[Stratification, ...] | None = None
     """Optional tuple of the Stratifications this observation should use."""
-    priority: int = 5
+    priority: int = DEFAULT_EVENT_PRIORITY
     """The priority level of this observation. Observations with lower priority levels are observed first."""
 
     def observe(
@@ -155,6 +156,7 @@ class UnstratifiedObservation(Observation):
         results_updater: Callable[[pd.DataFrame, pd.DataFrame], pd.DataFrame],
         results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
         to_observe: Callable[[Event], bool] = lambda event: True,
+        priority: int = DEFAULT_EVENT_PRIORITY,
     ):
         def _wrap_results_gatherer(
             df: pd.DataFrame | DataFrameGroupBy[tuple[str, ...] | str, bool],
@@ -177,6 +179,7 @@ class UnstratifiedObservation(Observation):
             results_updater=results_updater,
             results_formatter=results_formatter,
             to_observe=to_observe,
+            priority=priority,
         )
 
     @classmethod
@@ -240,6 +243,7 @@ class StratifiedObservation(Observation):
         aggregator_sources: list[str] | None,
         aggregator: Callable[[pd.DataFrame], float | pd.Series[float]],
         to_observe: Callable[[Event], bool] = lambda event: True,
+        priority: int = DEFAULT_EVENT_PRIORITY,
     ):
         super().__init__(
             name=name,
@@ -251,6 +255,7 @@ class StratifiedObservation(Observation):
             results_updater=results_updater,
             results_formatter=results_formatter,
             to_observe=to_observe,
+            priority=priority,
         )
         self.aggregator_sources = aggregator_sources
         self.aggregator = aggregator
@@ -437,6 +442,7 @@ class AddingObservation(StratifiedObservation):
         aggregator_sources: list[str] | None,
         aggregator: Callable[[pd.DataFrame], float | pd.Series[float]],
         to_observe: Callable[[Event], bool] = lambda event: True,
+        priority: int = DEFAULT_EVENT_PRIORITY,
     ):
         super().__init__(
             name=name,
@@ -448,6 +454,7 @@ class AddingObservation(StratifiedObservation):
             aggregator_sources=aggregator_sources,
             aggregator=aggregator,
             to_observe=to_observe,
+            priority=priority,
         )
 
     @staticmethod
@@ -520,6 +527,7 @@ class ConcatenatingObservation(UnstratifiedObservation):
         requires_attributes: list[str],
         results_formatter: Callable[[str, pd.DataFrame], pd.DataFrame],
         to_observe: Callable[[Event], bool] = lambda event: True,
+        priority: int = DEFAULT_EVENT_PRIORITY,
     ):
         requires_attributes = ["event_time"] + requires_attributes
         super().__init__(
@@ -531,6 +539,7 @@ class ConcatenatingObservation(UnstratifiedObservation):
             results_updater=self.concatenate_results,
             results_formatter=results_formatter,
             to_observe=to_observe,
+            priority=priority,
         )
 
     def get_results_of_interest(self, pop: pd.DataFrame) -> pd.DataFrame:

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -32,6 +32,7 @@ from pandas.core.groupby.generic import DataFrameGroupBy
 
 from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.exceptions import VivariumError
+from vivarium.framework import lifecycle
 from vivarium.framework.event import Event
 from vivarium.framework.results.stratification import Stratification, get_original_col_name
 
@@ -86,8 +87,7 @@ class Observation(ABC):
     stratifications: tuple[Stratification, ...] | None = None
     """Optional tuple of the Stratifications this observation should use."""
     priority: int = DEFAULT_EVENT_PRIORITY
-    """The priority of the lifecycle phase this observation will record. Observations 
-        with lower priority levels are recorded first."""
+    """The priority level of the lifecycle phase (see `when`) that this observation will record."""
 
     def observe(
         self,
@@ -144,6 +144,8 @@ class UnstratifiedObservation(Observation):
         Method or function that formats the raw observation results.
     to_observe
         Method or function that determines whether to perform an observation on this Event.
+    priority
+        The priority level of the lifecycle phase (see `when`) that this observation will record.
 
     """
 
@@ -230,6 +232,8 @@ class StratifiedObservation(Observation):
         Method or function that computes the quantity for this observation.
     to_observe
         Method or function that determines whether to perform an observation on this Event.
+    priority
+        The priority level of the lifecycle phase (see `when`) that this observation will record.
 
     """
 
@@ -430,6 +434,8 @@ class AddingObservation(StratifiedObservation):
         Method or function that computes the quantity for this observation.
     to_observe
         Method or function that determines whether to perform an observation on this Event.
+    priority
+        The priority level of the lifecycle phase (see `when`) that this observation will record.
 
     """
 
@@ -517,6 +523,8 @@ class ConcatenatingObservation(UnstratifiedObservation):
         Method or function that formats the raw observation results.
     to_observe
         Method or function that determines whether to perform an observation on this Event.
+    priority
+        The priority level of the lifecycle phase (see `when`) that this observation will record.
 
     """
 

--- a/src/vivarium/framework/results/observation.py
+++ b/src/vivarium/framework/results/observation.py
@@ -86,7 +86,8 @@ class Observation(ABC):
     stratifications: tuple[Stratification, ...] | None = None
     """Optional tuple of the Stratifications this observation should use."""
     priority: int = DEFAULT_EVENT_PRIORITY
-    """The priority level of this observation. Observations with lower priority levels are observed first."""
+    """The priority of the lifecycle phase this observation will record. Observations 
+        with lower priority levels are recorded first."""
 
     def observe(
         self,

--- a/src/vivarium/interface/interactive.py
+++ b/src/vivarium/interface/interactive.py
@@ -263,7 +263,7 @@ class InteractiveContext(SimulationContext):
 
     def get_emitter(
         self, event_name: str
-    ) -> Callable[[pd.Index[int], dict[str, Any] | None], Event]:
+    ) -> Callable[[pd.Index[int], dict[str, Any] | None], None]:
         """Get the callable that emits the given type of events.
 
         Available events can be found by calling

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -645,6 +645,51 @@ def test_get_observations(
 
 
 @pytest.mark.parametrize(
+    ["event_priority", "expected_names"],
+    [
+        (DEFAULT_EVENT_PRIORITY, ["default_obs"]),
+        (2, ["early_obs"]),
+        (9, []),
+    ],
+    ids=["default_priority", "non_default_priority", "unused_priority"],
+)
+def test_get_observations_filters_by_priority(
+    event_priority: int, expected_names: list[str]
+) -> None:
+    ctx = ResultsContext()
+    base_kwargs = {
+        "observation_type": AddingObservation,
+        "population_filter": PopulationFilter(),
+        "requires_attributes": [],
+        "results_formatter": lambda: None,
+        "stratifications": (),
+        "aggregator_sources": None,
+        "aggregator": len,
+    }
+    ctx.register_observation(
+        name="default_obs",
+        when=lifecycle_states.COLLECT_METRICS,
+        **base_kwargs,  # type: ignore[arg-type]
+    )
+    ctx.register_observation(
+        name="early_obs",
+        when=lifecycle_states.COLLECT_METRICS,
+        priority=2,
+        **base_kwargs,  # type: ignore[arg-type]
+    )
+
+    event = Event(
+        name=lifecycle_states.COLLECT_METRICS,
+        index=pd.Index([0]),
+        user_data={},
+        time=0,
+        step_size=1,
+        priority=event_priority,
+    )
+    assert [obs.name for obs in ctx.get_observations(event)] == expected_names
+
+
+@pytest.mark.parametrize(
     "observation_names, stratification_names, expected_resources",
     [
         (["obs1", "obs2"], ["strat1", "strat2"], {"x", "y", "z", "v"}),

--- a/tests/framework/results/test_context.py
+++ b/tests/framework/results/test_context.py
@@ -23,6 +23,7 @@ from tests.framework.results.helpers import (
     sorting_hat_vectorized,
     verify_stratification_added,
 )
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.results import VALUE_COLUMN
@@ -46,6 +47,7 @@ def event() -> Event:
         user_data={},
         time=0,
         step_size=1,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
 
 
@@ -631,7 +633,12 @@ def test_get_observations(
     )
 
     event = Event(
-        name=lifecycle_state, index=pd.Index([0]), user_data={}, time=time, step_size=1
+        name=lifecycle_state,
+        index=pd.Index([0]),
+        user_data={},
+        time=time,
+        step_size=1,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
 
     assert [obs.name for obs in ctx.get_observations(event)] == expected_observations

--- a/tests/framework/results/test_interface.py
+++ b/tests/framework/results/test_interface.py
@@ -12,6 +12,7 @@ from pytest_mock import MockerFixture
 
 from tests.framework.results.helpers import BASE_POPULATION, FAMILIARS
 from tests.framework.results.helpers import HOUSE_CATEGORIES as HOUSES
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.results import ResultsInterface, ResultsManager
@@ -434,6 +435,7 @@ def test_register_adding_observation_when_options(when: str, mocker: MockerFixtu
         user_data={},
         time=0,
         step_size=1,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
     # Run on_post_setup to initialize the raw_results attribute with 0s and set stratifications
     mgr.on_post_setup(event)

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -879,3 +879,43 @@ def _assert_standard_index(df: pd.DataFrame) -> None:
     assert not isinstance(df.index, pd.MultiIndex)
     assert df.index.names == [None]
     assert df.index.dtype == "int64"
+
+
+def test_observation_priority_ordering() -> None:
+    """Test that observations with lower priority fire before those with higher priority."""
+    execution_order: list[str] = []
+
+    class PriorityOrderingObserver(Observer):
+        """Observer that registers two observations at different priorities."""
+
+        def register_observations(self, builder: Builder) -> None:
+            builder.results.register_adding_observation(
+                name="early_counter",
+                when="collect_metrics",
+                priority=2,
+                aggregator=lambda df: self._track("early", df),
+            )
+            builder.results.register_adding_observation(
+                name="default_counter",
+                when="collect_metrics",
+                aggregator=lambda df: self._track("default", df),
+            )
+
+        def _track(self, label: str, df: pd.DataFrame) -> float:
+            execution_order.append(label)
+            return float(len(df))
+
+    components = [
+        Hogwarts(),
+        HogwartsResultsStratifier(),
+        PriorityOrderingObserver(),
+    ]
+    sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
+    sim.step()
+
+    # "early" (priority 2) should have fired before "default" (priority 5)
+    # "early" and "default" are called once per aggregator
+    assert "early" in execution_order and "default" in execution_order
+    last_early = max(i for i, x in enumerate(execution_order) if x == "early")
+    first_default = min(i for i, x in enumerate(execution_order) if x == "default")
+    assert last_early < first_default

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -36,6 +36,7 @@ from tests.framework.results.helpers import (
     sorting_hat_vectorized,
     verify_stratification_added,
 )
+from vivarium.component import DEFAULT_EVENT_PRIORITY
 from vivarium.framework.engine import Builder
 from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
@@ -373,6 +374,7 @@ def test_gather_results_with_no_observations(mocker: pytest_mock.MockerFixture) 
         user_data={},
         time=0,
         step_size=1,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
 
     mgr.gather_results(event)
@@ -395,6 +397,7 @@ def test_gather_results_with_empty_index(mocker: pytest_mock.MockerFixture) -> N
         user_data={},
         time=0,
         step_size=1,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
 
     mgr.gather_results(event)
@@ -570,6 +573,7 @@ def test_prepare_population(
         },
         time=prepare_population_sim._clock.time + prepare_population_sim._clock.step_size,  # type: ignore [operator]
         step_size=prepare_population_sim._clock.step_size,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
 
     population = mgr._prepare_population(event, observations, stratifications)
@@ -620,6 +624,7 @@ def test_prepare_population_all_untracked(
         user_data={},
         time=prepare_population_sim._clock.time + prepare_population_sim._clock.step_size,  # type: ignore [operator]
         step_size=prepare_population_sim._clock.step_size,
+        priority=DEFAULT_EVENT_PRIORITY,
     )
 
     # Add an untracking query

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -42,7 +42,7 @@ from vivarium.framework.event import Event
 from vivarium.framework.lifecycle import lifecycle_states
 from vivarium.framework.results import VALUE_COLUMN
 from vivarium.framework.results.context import ResultsContext
-from vivarium.framework.results.interface import PopulationFilter
+from vivarium.framework.results.interface import PopulationFilter, ResultsInterface
 from vivarium.framework.results.manager import ResultsManager
 from vivarium.framework.results.observation import AddingObservation, Observation
 from vivarium.framework.results.observer import Observer
@@ -924,3 +924,60 @@ def test_observation_priority_ordering() -> None:
     last_early = max(i for i, x in enumerate(execution_order) if x == "early")
     first_default = min(i for i, x in enumerate(execution_order) if x == "default")
     assert last_early < first_default
+
+
+def test_observation_priority_ordering_reverse_registration() -> None:
+    """Ensure ordering is by priority even when registration order is reversed."""
+    execution_order: list[str] = []
+
+    class ReversePriorityObserver(Observer):
+        """Observer that registers the higher-priority observation first."""
+
+        def register_observations(self, builder: Builder) -> None:
+            builder.results.register_adding_observation(
+                name="late_counter",
+                when="collect_metrics",
+                priority=7,
+                aggregator=lambda df: self._track("late", df),
+            )
+            builder.results.register_adding_observation(
+                name="early_counter",
+                when="collect_metrics",
+                priority=2,
+                aggregator=lambda df: self._track("early", df),
+            )
+
+        def _track(self, label: str, df: pd.DataFrame) -> float:
+            execution_order.append(label)
+            return float(len(df))
+
+    components = [
+        Hogwarts(),
+        HogwartsResultsStratifier(),
+        ReversePriorityObserver(),
+    ]
+    sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
+    sim.step()
+
+    assert "early" in execution_order and "late" in execution_order
+    last_early = max(i for i, x in enumerate(execution_order) if x == "early")
+    first_late = min(i for i, x in enumerate(execution_order) if x == "late")
+    assert last_early < first_late
+
+
+@pytest.mark.parametrize("priority", [-1, 10, 100], ids=["negative", "ten", "large"])
+def test_register_observation_invalid_priority_raises(
+    priority: int, mocker: pytest_mock.MockFixture
+) -> None:
+    """Verify that out-of-range priority values raise a ValueError."""
+    mgr = ResultsManager()
+    builder = mocker.MagicMock()
+    builder.configuration.stratification.default = []
+    mgr.setup(builder)
+    interface = ResultsInterface(mgr)
+    with pytest.raises(ValueError, match="Priority must be an integer in range"):
+        interface.register_adding_observation(
+            name="bad_priority",
+            when="collect_metrics",
+            priority=priority,
+        )

--- a/tests/framework/results/test_manager.py
+++ b/tests/framework/results/test_manager.py
@@ -1,4 +1,5 @@
 import re
+from collections.abc import Callable
 
 import numpy as np
 import pandas as pd
@@ -886,83 +887,61 @@ def _assert_standard_index(df: pd.DataFrame) -> None:
     assert df.index.dtype == "int64"
 
 
-def test_observation_priority_ordering() -> None:
-    """Test that observations with lower priority fire before those with higher priority."""
-    execution_order: list[str] = []
+def test_observation_fires_on_correct_priority() -> None:
+    """Test that observations fire on the correct priority of a lifecycle phase.
 
-    class PriorityOrderingObserver(Observer):
-        """Observer that registers two observations at different priorities."""
+    Each observation should only be called when the event priority matches
+    the priority the observation was registered with.
+    """
+    fired_on_priorities: dict[str, list[int]] = {
+        "early": [],
+        "default": [],
+        "late": [],
+    }
+
+    def _make_to_observe(label: str) -> Callable[[Event], bool]:
+        """Create a to_observe callback that records the event priority."""
+
+        def to_observe(event: Event) -> bool:
+            fired_on_priorities[label].append(event.priority)
+            return True
+
+        return to_observe
+
+    class PriorityTrackingObserver(Observer):
+        """Observer that records the event priority at which each observation fires."""
 
         def register_observations(self, builder: Builder) -> None:
             builder.results.register_adding_observation(
                 name="early_counter",
                 when="collect_metrics",
                 priority=2,
-                aggregator=lambda df: self._track("early", df),
+                to_observe=_make_to_observe("early"),
             )
             builder.results.register_adding_observation(
                 name="default_counter",
                 when="collect_metrics",
-                aggregator=lambda df: self._track("default", df),
+                to_observe=_make_to_observe("default"),
             )
-
-        def _track(self, label: str, df: pd.DataFrame) -> float:
-            execution_order.append(label)
-            return float(len(df))
-
-    components = [
-        Hogwarts(),
-        HogwartsResultsStratifier(),
-        PriorityOrderingObserver(),
-    ]
-    sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
-    sim.step()
-
-    # "early" (priority 2) should have fired before "default" (priority 5)
-    # "early" and "default" are called once per aggregator
-    assert "early" in execution_order and "default" in execution_order
-    last_early = max(i for i, x in enumerate(execution_order) if x == "early")
-    first_default = min(i for i, x in enumerate(execution_order) if x == "default")
-    assert last_early < first_default
-
-
-def test_observation_priority_ordering_reverse_registration() -> None:
-    """Ensure ordering is by priority even when registration order is reversed."""
-    execution_order: list[str] = []
-
-    class ReversePriorityObserver(Observer):
-        """Observer that registers the higher-priority observation first."""
-
-        def register_observations(self, builder: Builder) -> None:
             builder.results.register_adding_observation(
                 name="late_counter",
                 when="collect_metrics",
                 priority=7,
-                aggregator=lambda df: self._track("late", df),
+                to_observe=_make_to_observe("late"),
             )
-            builder.results.register_adding_observation(
-                name="early_counter",
-                when="collect_metrics",
-                priority=2,
-                aggregator=lambda df: self._track("early", df),
-            )
-
-        def _track(self, label: str, df: pd.DataFrame) -> float:
-            execution_order.append(label)
-            return float(len(df))
 
     components = [
         Hogwarts(),
         HogwartsResultsStratifier(),
-        ReversePriorityObserver(),
+        PriorityTrackingObserver(),
     ]
     sim = InteractiveContext(configuration=HARRY_POTTER_CONFIG, components=components)
     sim.step()
 
-    assert "early" in execution_order and "late" in execution_order
-    last_early = max(i for i, x in enumerate(execution_order) if x == "early")
-    first_late = min(i for i, x in enumerate(execution_order) if x == "late")
-    assert last_early < first_late
+    # Each observation should have fired exactly once and on its specified priority
+    assert fired_on_priorities["early"] == [2]
+    assert fired_on_priorities["default"] == [DEFAULT_EVENT_PRIORITY]
+    assert fired_on_priorities["late"] == [7]
 
 
 @pytest.mark.parametrize("priority", [-1, 10, 100], ids=["negative", "ten", "large"])

--- a/tests/framework/test_event.py
+++ b/tests/framework/test_event.py
@@ -15,6 +15,7 @@ class EventData(TypedDict):
     user_data: dict[str, str]
     time: pd.Timestamp
     step_size: int
+    priority: int
 
 
 _EVENT_INIT_TYPE = dict[str, EventData]

--- a/tests/framework/test_event.py
+++ b/tests/framework/test_event.py
@@ -29,6 +29,7 @@ def event_init() -> _EVENT_INIT_TYPE:
             "user_data": {"key": "value"},
             "time": pd.Timestamp("1/1/2000"),
             "step_size": 12,
+            "priority": 5,
         },
         "new_val": {
             "name": "test_event",
@@ -36,6 +37,7 @@ def event_init() -> _EVENT_INIT_TYPE:
             "user_data": {"new_key": "new_value"},
             "time": pd.Timestamp.now(),
             "step_size": 30,
+            "priority": 5,
         },
     }
 

--- a/tests/framework/test_lifecycle.py
+++ b/tests/framework/test_lifecycle.py
@@ -408,6 +408,7 @@ def test_lifecycle_manager_add_constraint() -> None:
         user_data={},
         time=0,
         step_size=1,
+        priority=5,
     )
 
     alice.buzz(useless_event)


### PR DESCRIPTION
## Albrja/mic 6867/observer priority

### Allow observations to have specific priority on lifecycle events
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6867

### Changes and notes
-Event and observation now have priority attributes
-ResultsManager registers listener for every lifecycle event priority

## Code-reviewer:
PR Review: Add support for observations to specify priority for lifecycle events
Summary
This PR adds a priority parameter to the observation registration API in the results framework. Observations can now specify an integer priority (0–9, default 5) that controls when they fire relative to other event listeners in the same lifecycle phase. The implementation works by registering the ResultsManager as a listener at every priority level (0–9) for each lifecycle phase, and then filtering observations in get_observations() to only return those whose priority matches the current event's priority. This enables observers to guarantee their observations run before or after other components' event handlers.

Design
Registering 40 listeners (10 × 4 phases) is eager and wasteful in the common case — manager.py:80-100. When all observations use the default priority (the typical case), 36 of 40 gather_results calls per step do nothing — they create an Event, traverse grouped_observations, find zero matches, and return. Consider registering only at the default priority eagerly, then lazily registering additional priority listeners when a non-default-priority observation is actually registered.

get_observations does a full linear scan of all observations per call — context.py:368-375. The grouped_observations dict keys on (lifecycle_state, PopulationFilter, stratifications) but not on priority. Each call iterates every observation for the phase and checks observation.priority == event.priority. A secondary index keyed by (phase, priority) would make this O(1) lookup instead of O(n).

gather_results re-filters observations that get_observations already selected — context.py:318-330. After get_observations returns the priority-filtered list, gather_results iterates grouped_observations again and uses if observation in event_observations (list membership, O(n)) in nested loops. Converting event_observations to a set would improve this, though the re-traversal pattern is pre-existing.

No validation of priority range — manager.py:266-310, interface.py:199. A user can pass priority=15 or priority=-1. The observation registers silently but never fires, since no event is emitted at that priority. This is a silent-failure bug. Add a bounds check in ResultsManager.register_observation() that raises ValueError for priorities outside range(10).

Maintainability
Magic number range(10) couples results manager to event system — manager.py:80. The 10-priority assumption is hardcoded in both ResultsManager.setup() and EventChannel.__init__ (manager.py:96) but is not a named constant. If either drifts, observations at certain priorities silently never fire. Extract a shared constant (e.g., NUM_EVENT_PRIORITIES = 10 in vivarium/component.py alongside DEFAULT_EVENT_PRIORITY).

No comment explaining the 40-listener registration strategy — manager.py:80-100. A developer reading setup() for the first time will find the for priority in range(10) loop surprising. Add a brief comment explaining why the manager registers at every priority level.

DRY
Four identical on_* handler methods — manager.py:110-122. on_time_step_prepare, on_time_step, on_time_step_cleanup, and on_collect_metrics all have the same body: self.gather_results(event). Since the Event already carries its name (lifecycle state) and priority, these four methods are functionally identical. Register self.gather_results directly as the listener to eliminate four trivial wrappers:


for priority in range(10):    for phase in [TIME_STEP_PREPARE, TIME_STEP, TIME_STEP_CLEANUP, COLLECT_METRICS]:        builder.event.register_listener(phase, self.gather_results, priority=priority)
Note: this is a pre-existing pattern, but the PR makes it more visible by expanding the registration from 4 to 40.

PopulationFilter(pop_filter, include_untracked) construction repeated in all 4 interface registration methods — interface.py:258, interface.py:314, interface.py:390, interface.py:459. Pre-existing, but adding priority as another common parameter deepens the repetition.

Tests
test_observation_priority_ordering could pass even if priority filtering is broken — test_manager.py:889-927. The "early" observation (priority 2) is registered before "default" (priority 5). If the priority filter were removed and observations fired in registration order, the test would still pass. Add a variant where the higher-priority observation is registered first to prove ordering is by priority, not registration order.

No unit test for get_observations filtering by priority — test_context.py:600-649. The existing test_get_observations only uses DEFAULT_EVENT_PRIORITY. A test should register observations at different priorities and verify that get_observations returns only those matching the event's priority.

No boundary tests for priority 0 and 9 — If range(10) in setup() were accidentally changed to range(1, 10), no test would catch the off-by-one.

No test for out-of-range priority values — If validation is added (per Design finding #4), it needs a test. If validation is intentionally absent, a test should document the silent-failure behavior.

Existing registration tests don't assert observation.priority — test_interface.py. test_register_stratified_observation and similar tests verify name, when, population_filter, etc., but none checks observation.priority. If priority were silently dropped during registration, no test would fail.

Documentation
register_observation docstring in ResultsContext omits priority — context.py:220-260. The Parameters section lists observation_type, name, population_filter, and when, but not priority, requires_attributes, or **kwargs, despite all being explicit parameters.

Observation.priority docstring doesn't state valid range or default — observation.py:88-89. Reads "The priority level of this observation. Observations with lower priority levels are observed first." Should mention valid values are 0–9 and the default is 5.

Subclass Attributes docstrings omit priority — observation.py. The Attributes sections for UnstratifiedObservation, StratifiedObservation, AddingObservation, and ConcatenatingObservation list all parameters except priority.

CHANGELOG entry is terse — CHANGELOG.rst:3. "Add support for observations to specify priority for lifecycle events" doesn't explain what priority means, the valid range, the default, or which methods gained the parameter.

Functionality
Silent no-op for out-of-range priorities is a correctness risk. A user passing priority=10 gets an observation that registers successfully, appears in self.observations, but is never matched by get_observations because no event is ever emitted at priority 10. The get_results() method would still return the observation's initialized (zero/empty) results, potentially causing confusing output. This is the most critical functional issue in the PR.

Negative priority values exploit Python's negative indexing. Passing priority=-1 to register_adding_observation would not cause an error anywhere in the results framework. In the event system, EventChannel.listeners[-1] would be listeners[9] (Python negative indexing), so the observation would actually fire at priority 9. This is semantically wrong and could mask bugs. The bounds check recommended in Design #4 would fix this.

gather_results called with observations=[] returns early before _prepare_population — manager.py:131-135. This is correct: when no observations match the current priority, the method short-circuits. No correctness issue here.

Event.priority type is int with no constraint — manager.py:61. The Event dataclass is a @dataclass (pre-existing), and priority is typed as int with no validation. This is a pre-existing issue that the PR inherits rather than introduces.

Minor Nits
manager.py:82 — The for priority in range(10) loop body could use a list of (phase, handler) tuples to avoid repeating the builder.event.register_listener call 4 times per iteration.

test_manager.py:897 — The PriorityOrderingObserver inner class could use a class-level execution_order list instead of closing over a mutable from the enclosing scope, which would make the test more robust if parallelized.

Overall
The PR delivers a clean and useful feature — allowing observations to control their firing priority relative to other event listeners. The core mechanism (matching observation.priority == event.priority) is correct and integrates naturally with the existing event system.

The highest-priority improvements are:

Add priority validation to prevent silent failures with out-of-range values (Design #4, Functionality #1-#2)
Add a get_observations unit test that exercises priority filtering (Tests #2) and a reverse-registration-order integration test (Tests #1)
Extract the hardcoded range(10) into a named constant shared with the event system (Maintainability #1)

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

