### PR TITLE
only evaluate multiplication combiners on non-zero values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**4.1.3 - 05/06/26**
+
+- Optimization: Subset to non-zero values before applying multiplication_combiner
+
 **4.1.2 - 05/06/26**
 
 - Make 'vivarium' and extend_path namespace package for monorepo migration

--- a/src/vivarium/framework/values/combiners.py
+++ b/src/vivarium/framework/values/combiners.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from typing import Any, Protocol
 
+import pandas as pd
+
 from vivarium.types import NumberLike
 
 
@@ -74,6 +76,12 @@ def multiplication_combiner(
     This combiner is meant to be used when the pipeline's final value is
     the product of all intermediate values.
 
+    When ``value`` is a ``pd.Series`` and the pipeline is invoked with the
+    :class:`~vivarium.framework.values.pipeline.AttributePipeline` calling
+    convention (a single positional ``pd.Index`` and no kwargs), the mutator
+    is evaluated only on the non-zero entries of ``value``. Entries that are
+    already zero will multiply to zero regardless of the mutator's output.
+
     Parameters
     ----------
     value
@@ -90,6 +98,16 @@ def multiplication_combiner(
     -------
         A modified version of the input value.
     """
+    if (
+        isinstance(value, pd.Series)
+        and len(args) == 1
+        and isinstance(args[0], pd.Index)
+        and not kwargs
+    ):
+        non_zero_index = value[value != 0].index
+        if len(non_zero_index) > 0:
+            value.loc[non_zero_index] = value.loc[non_zero_index] * mutator(non_zero_index)  # type: ignore[assignment]
+        return value
     return value * mutator(*args, **kwargs)
 
 

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -176,23 +176,84 @@ def test_replace_combiner(manager: ValuesManager, mocker: MockFixture) -> None:
     assert value() == 84
 
 
-def test_multiplication_combiner(manager: ValuesManager) -> None:
+@pytest.mark.parametrize(
+    "source, modifiers, expected_value, expected_modifier_indices",
+    [
+        pytest.param(
+            lambda idx: pd.Series(2.0, index=idx),
+            [
+                lambda idx: pd.Series(3.0, index=idx),
+                lambda idx: pd.Series(0.5, index=idx),
+            ],
+            pd.Series(3.0, index=INDEX),
+            [INDEX, INDEX],
+            id="series_no_zeros",
+        ),
+        pytest.param(
+            lambda idx: pd.Series([2.0, 0.0, 2.0, 0.0, 2.0, 0.0], index=idx),
+            [lambda idx: pd.Series(3.0, index=idx)],
+            pd.Series([6.0, 0.0, 6.0, 0.0, 6.0, 0.0], index=INDEX),
+            [INDEX[[0, 2, 4]]],
+            id="series_mixed_zeros",
+        ),
+        pytest.param(
+            lambda idx: pd.Series(0.0, index=idx),
+            [lambda idx: pd.Series(3.0, index=idx)],
+            pd.Series(0.0, index=INDEX),
+            [],
+            id="series_all_zeros",
+        ),
+    ],
+)
+def test_multiplication_combiner(
+    manager: ValuesManager,
+    source: Callable[[pd.Index[int]], pd.Series[float]],
+    modifiers: list[Callable[[pd.Index[int]], pd.Series[float]]],
+    expected_value: pd.Series[float],
+    expected_modifier_indices: list[pd.Index[int]],
+) -> None:
+    """When the value is a Series and the call shape matches the AttributePipeline
+    convention, modifiers are evaluated only on the non-zero entries of the value."""
+    modifier_calls: list[pd.Index[int]] = []
+
+    def spy(
+        modifier: Callable[[pd.Index[int]], pd.Series[float]],
+    ) -> Callable[[pd.Index[int]], pd.Series[float]]:
+        def wrapped(idx: pd.Index[int]) -> pd.Series[float]:
+            modifier_calls.append(idx)
+            return modifier(idx)
+
+        return wrapped
+
     value = manager.register_value_producer(
         "test",
-        source=lambda idx: pd.Series(2.0, index=idx),
+        source=source,
         preferred_combiner=multiplication_combiner,
     )
+    for modifier in modifiers:
+        manager.register_value_modifier("test", modifier=spy(modifier))
 
-    # Source only: should return the source value
-    assert np.all(value(INDEX) == 2.0)
+    pd.testing.assert_series_equal(value(INDEX), expected_value, check_names=False)
 
-    # One modifier: source * modifier = 2.0 * 3.0 = 6.0
-    manager.register_value_modifier("test", modifier=lambda idx: pd.Series(3.0, index=idx))
-    assert np.all(value(INDEX) == 6.0)
+    assert len(modifier_calls) == len(expected_modifier_indices)
+    for actual, expected in zip(modifier_calls, expected_modifier_indices):
+        pd.testing.assert_index_equal(actual, expected)
 
-    # Two modifiers: source * modifier1 * modifier2 = 2.0 * 3.0 * 0.5 = 3.0
-    manager.register_value_modifier("test", modifier=lambda idx: pd.Series(0.5, index=idx))
-    assert np.all(value(INDEX) == 3.0)
+
+def test_multiplication_combiner_scalar(manager: ValuesManager) -> None:
+    """Non-Series values fall back to plain multiplication."""
+    value = manager.register_value_producer(
+        "test",
+        source=lambda: 2.0,
+        preferred_combiner=multiplication_combiner,
+    )
+    assert value() == 2.0
+
+    manager.register_value_modifier("test", modifier=lambda: 3.0)
+    assert value() == 6.0
+
+    manager.register_value_modifier("test", modifier=lambda: 0.5)
+    assert value() == 3.0
 
 
 def test_addition_combiner(manager: ValuesManager) -> None:

--- a/tests/framework/test_values.py
+++ b/tests/framework/test_values.py
@@ -176,84 +176,106 @@ def test_replace_combiner(manager: ValuesManager, mocker: MockFixture) -> None:
     assert value() == 84
 
 
-@pytest.mark.parametrize(
-    "source, modifiers, expected_value, expected_modifier_indices",
-    [
-        pytest.param(
-            lambda idx: pd.Series(2.0, index=idx),
-            [
-                lambda idx: pd.Series(3.0, index=idx),
-                lambda idx: pd.Series(0.5, index=idx),
-            ],
-            pd.Series(3.0, index=INDEX),
-            [INDEX, INDEX],
-            id="series_no_zeros",
-        ),
-        pytest.param(
-            lambda idx: pd.Series([2.0, 0.0, 2.0, 0.0, 2.0, 0.0], index=idx),
-            [lambda idx: pd.Series(3.0, index=idx)],
-            pd.Series([6.0, 0.0, 6.0, 0.0, 6.0, 0.0], index=INDEX),
-            [INDEX[[0, 2, 4]]],
-            id="series_mixed_zeros",
-        ),
-        pytest.param(
-            lambda idx: pd.Series(0.0, index=idx),
-            [lambda idx: pd.Series(3.0, index=idx)],
-            pd.Series(0.0, index=INDEX),
-            [],
-            id="series_all_zeros",
-        ),
-    ],
-)
-def test_multiplication_combiner(
-    manager: ValuesManager,
-    source: Callable[[pd.Index[int]], pd.Series[float]],
-    modifiers: list[Callable[[pd.Index[int]], pd.Series[float]]],
-    expected_value: pd.Series[float],
-    expected_modifier_indices: list[pd.Index[int]],
-) -> None:
-    """When the value is a Series and the call shape matches the AttributePipeline
-    convention, modifiers are evaluated only on the non-zero entries of the value."""
-    modifier_calls: list[pd.Index[int]] = []
+class TestMultiplicationCombiner:
+    """Tests for ``multiplication_combiner``.
 
-    def spy(
+    The combiner branches on whether ``value`` is a ``pd.Series`` invoked with
+    the ``AttributePipeline`` convention (single positional ``pd.Index``, no
+    kwargs). In that branch, modifiers are evaluated only on the non-zero
+    entries of ``value``.
+    """
+
+    @staticmethod
+    def _spy(
         modifier: Callable[[pd.Index[int]], pd.Series[float]],
+        calls: list[pd.Index[int]],
     ) -> Callable[[pd.Index[int]], pd.Series[float]]:
         def wrapped(idx: pd.Index[int]) -> pd.Series[float]:
-            modifier_calls.append(idx)
+            calls.append(idx)
             return modifier(idx)
 
         return wrapped
 
-    value = manager.register_value_producer(
-        "test",
-        source=source,
-        preferred_combiner=multiplication_combiner,
-    )
-    for modifier in modifiers:
-        manager.register_value_modifier("test", modifier=spy(modifier))
+    def test_scalar(self, manager: ValuesManager) -> None:
+        """Non-Series values fall back to plain multiplication."""
+        value = manager.register_value_producer(
+            "test",
+            source=lambda: 2.0,
+            preferred_combiner=multiplication_combiner,
+        )
+        assert value() == 2.0
 
-    pd.testing.assert_series_equal(value(INDEX), expected_value, check_names=False)
+        manager.register_value_modifier("test", modifier=lambda: 3.0)
+        assert value() == 6.0
 
-    assert len(modifier_calls) == len(expected_modifier_indices)
-    for actual, expected in zip(modifier_calls, expected_modifier_indices):
-        pd.testing.assert_index_equal(actual, expected)
+        manager.register_value_modifier("test", modifier=lambda: 0.5)
+        assert value() == 3.0
 
+    def test_series_no_zeros(self, manager: ValuesManager) -> None:
+        """When no entries are zero, modifiers receive the full index."""
+        modifier_calls: list[pd.Index[int]] = []
 
-def test_multiplication_combiner_scalar(manager: ValuesManager) -> None:
-    """Non-Series values fall back to plain multiplication."""
-    value = manager.register_value_producer(
-        "test",
-        source=lambda: 2.0,
-        preferred_combiner=multiplication_combiner,
-    )
-    assert value() == 2.0
+        value = manager.register_value_producer(
+            "test",
+            source=lambda idx: pd.Series(2.0, index=idx),
+            preferred_combiner=multiplication_combiner,
+        )
+        manager.register_value_modifier(
+            "test",
+            modifier=self._spy(lambda idx: pd.Series(3.0, index=idx), modifier_calls),
+        )
+        manager.register_value_modifier(
+            "test",
+            modifier=self._spy(lambda idx: pd.Series(0.5, index=idx), modifier_calls),
+        )
 
-    manager.register_value_modifier("test", modifier=lambda: 3.0)
-    assert value() == 6.0
+        pd.testing.assert_series_equal(
+            value(INDEX), pd.Series(3.0, index=INDEX), check_names=False
+        )
+        assert len(modifier_calls) == 2
+        pd.testing.assert_index_equal(modifier_calls[0], INDEX)
+        pd.testing.assert_index_equal(modifier_calls[1], INDEX)
 
-    manager.register_value_modifier("test", modifier=lambda: 0.5)
-    assert value() == 3.0
+    def test_series_mixed_zeros(self, manager: ValuesManager) -> None:
+        """Modifiers see only the non-zero subset of the index."""
+        modifier_calls: list[pd.Index[int]] = []
+
+        value = manager.register_value_producer(
+            "test",
+            source=lambda idx: pd.Series([2.0, 0.0, 2.0, 0.0, 2.0, 0.0], index=idx),
+            preferred_combiner=multiplication_combiner,
+        )
+        manager.register_value_modifier(
+            "test",
+            modifier=self._spy(lambda idx: pd.Series(3.0, index=idx), modifier_calls),
+        )
+
+        pd.testing.assert_series_equal(
+            value(INDEX),
+            pd.Series([6.0, 0.0, 6.0, 0.0, 6.0, 0.0], index=INDEX),
+            check_names=False,
+        )
+        assert len(modifier_calls) == 1
+        pd.testing.assert_index_equal(modifier_calls[0], INDEX[[0, 2, 4]])
+
+    def test_series_all_zeros(self, manager: ValuesManager) -> None:
+        """Modifiers are never invoked when no entries are non-zero."""
+        modifier_calls: list[pd.Index[int]] = []
+
+        value = manager.register_value_producer(
+            "test",
+            source=lambda idx: pd.Series(0.0, index=idx),
+            preferred_combiner=multiplication_combiner,
+        )
+        manager.register_value_modifier(
+            "test",
+            modifier=self._spy(lambda idx: pd.Series(3.0, index=idx), modifier_calls),
+        )
+
+        pd.testing.assert_series_equal(
+            value(INDEX), pd.Series(0.0, index=INDEX), check_names=False
+        )
+        assert modifier_calls == []
 
 
 def test_addition_combiner(manager: ValuesManager) -> None:


### PR DESCRIPTION
## Only evaluate multiplication combiners on non-zero values
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: optimization
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7081

### Changes and notes
Only evaluate multiplication combiners on non-zero values 

### Testing
Ran make check
Added new tests